### PR TITLE
BUG2025080401 When entering hardware management from the main page, the current hardware will not be used; instead, it will revert to the default hardware

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -311,8 +311,7 @@ class MainWindow(QMainWindow):
         dlg.exec()
 
     def on_hardware_window_init(self):
-        # select the mic and speaker
-        dlg = HardwareWindow()
+        dlg = HardwareWindow(self.speaker, self.mic)
         self.speaker, self.mic = dlg.on_exec()
         self.update_statusbar()
         self.sequence_window.mic = self.mic

--- a/ui/hardware_window.py
+++ b/ui/hardware_window.py
@@ -10,10 +10,10 @@ from consts.running_consts import DEFAULT_DIR
 
 class HardwareWindow(QDialog):
 
-    def __init__(self):
+    def __init__(self, current_speaker=None, current_mic=None):
         super().__init__()
-        self.speaker = None
-        self.mic = None
+        self.speaker = current_speaker
+        self.mic = current_mic
 
         self.init_ui()
         self.refresh_device_display()


### PR DESCRIPTION
change HardwareWindow parameter input mic and speaker