### PR TITLE
FH BUG2025102302 Add database save for streaming audio completion

### DIFF
--- a/ui/sequence/sequence_widget.py
+++ b/ui/sequence/sequence_widget.py
@@ -949,6 +949,14 @@ class SequenceWindow(QWidget):
                 # Save aligned data to final file
                 save_audio_simple(self.recorded_path, aligned_data, sample_rate)
 
+                # Save to database
+                self.recorded_signal_info["sample_rate"] = sample_rate
+                save_code, save_msg = RecordingManager().save_signal_info_to_db(self.recorded_signal_info, self.data_struct.stimulus_info)
+                if save_code == error_code.OK:
+                    self.default_logger.info(f"Database save successful: {save_msg}")
+                else:
+                    self.default_logger.error(f"Database save failed: {save_msg}")
+
                 # Delete temp file AFTER successful save (for data safety)
                 try:
                     if hasattr(self, 'streaming_temp_path') and os.path.exists(self.streaming_temp_path):
@@ -965,6 +973,14 @@ class SequenceWindow(QWidget):
                 if self.streaming_wav_writer:
                     self.streaming_wav_writer.finalize()
                     self.streaming_wav_writer = None
+
+                # Save to database
+                self.recorded_signal_info["sample_rate"] = sample_rate
+                save_code, save_msg = RecordingManager().save_signal_info_to_db(self.recorded_signal_info, None)
+                if save_code == error_code.OK:
+                    self.default_logger.info(f"Database save successful: {save_msg}")
+                else:
+                    self.default_logger.error(f"Database save failed: {save_msg}")
 
             # Handle repeat signal splitting if needed
             if self.streaming_mode == "play_record":


### PR DESCRIPTION
## Summary
Add database persistence functionality for streaming audio recordings to ensure recorded signal metadata is properly saved after streaming audio completion.

## Modified Files
- **ui/sequence/sequence_widget.py**: Enhanced `_on_streaming_complete()` method

## Changes
- **Play+Record mode** (line 952-958): Added `RecordingManager().save_signal_info_to_db()` call with stimulus info after audio file save
- **Record-only mode** (line 977-983): Added `RecordingManager().save_signal_info_to_db()` call without stimulus info after WAV finalization
- **Logging**: Added success/failure logging for database save operations

Fixes #524