### PR TITLE
BUG2026010401 RB and PRB analysis can be selected during recording on…

### DIFF
--- a/ui/operation_sequence.py
+++ b/ui/operation_sequence.py
@@ -821,7 +821,7 @@ class OptionList(QListView):
                 if self.sound_item_type:
                     self.drop_is_accept = False
             elif self.sound_item_type in ["录制音频", "导入音频"]:
-                if text in ["频响 (FR) ", "谐波失真 (HD) "]:
+                if text in ["频响 (FR) ", "谐波失真 (HD) ", "高阶谐波失真 (RB) ", "感知失真 (PRB) "]:
                     self.drop_is_accept = False
             elif not self.sound_item_type:
                 self.drop_is_accept = False
@@ -843,7 +843,7 @@ class OptionList(QListView):
                     QMessageBox.warning(self, "警告", "已选择测试模式")
                 elif not self.config:
                     QMessageBox.warning(self, "警告", "请选择测试模式")
-                elif text in ["频响 (FR) ", "谐波失真 (HD) "]:
+                elif text in ["频响 (FR) ", "谐波失真 (HD) ", "高阶谐波失真 (RB) ", "感知失真 (PRB) "]:
                     QMessageBox.warning(self, "警告", "当前模式不支持此功能")
                 self.drop_is_accept = True
                 return

--- a/ui/signal_analysis_window.py
+++ b/ui/signal_analysis_window.py
@@ -250,8 +250,8 @@ class PerceptualRubAndBuzz(RubAndBuzz):
 
     def __init__(self, title_name):
         super().__init__(title_name)
-        self._prb_curve_label = "Perceived Loudness"
-        self._prb_y_label = "Perceived Loudness (phons)"
+        self._prb_curve_label = "感知失真指数"
+        self._prb_y_label = "感知失真指数 (phon)"
 
     def calculate_thd(self):
         """
@@ -318,11 +318,11 @@ class PerceptualRubAndBuzz(RubAndBuzz):
             self._prb_curve_label = "EHS"
             self._prb_y_label = "EHS"
         elif sc_metric == "totalnl_x_ehs":
-            self._prb_curve_label = "TotalNL×EHS"
-            self._prb_y_label = "TotalNL×EHS"
+            self._prb_curve_label = "感知失真指数"
+            self._prb_y_label = "感知失真指数 (phon)"
         else:
-            self._prb_curve_label = "TotalNL"
-            self._prb_y_label = "TotalNL (phons)"
+            self._prb_curve_label = "感知失真响度"
+            self._prb_y_label = "感知失真响度 (phon)"
         thd_kwargs = {
             'stimulus_metadata': stimulus_metadata,
             'harmonic_orders': self.selected_harmonics,

--- a/ui/ui_analysis_config/perceptual_rb_config_dialog.py
+++ b/ui/ui_analysis_config/perceptual_rb_config_dialog.py
@@ -47,8 +47,8 @@ class PerceptualRbConfigWindow(QDialog):
         self.sc_metric_desc = QLabel("选择输出结果：")
         self.sc_metric_desc.setAlignment(Qt.AlignLeft)
         self.sc_metric_combo = QComboBox()
-        self.sc_metric_combo.addItem("PRB 指数（默认）", "totalnl_x_ehs")
-        self.sc_metric_combo.addItem("PRB 响度", "totalnl")
+        self.sc_metric_combo.addItem("感知失真指数", "totalnl_x_ehs")
+        # self.sc_metric_combo.addItem("感知失真响度", "totalnl")  # 功能尚未完善，暂时禁用
 
         saved_masking = self.load_config.get("masking_config", {})
         if not isinstance(saved_masking, dict):
@@ -57,7 +57,8 @@ class PerceptualRbConfigWindow(QDialog):
         if saved_metric == "totalnl_phons":
             saved_metric = "totalnl"
         # Map old "ehs" option to default
-        if saved_metric not in {"totalnl_x_ehs", "totalnl"}:
+        # 由于"感知失真响度"选项已禁用，强制使用默认选项
+        if saved_metric not in {"totalnl_x_ehs"}:
             saved_metric = "totalnl_x_ehs"
         idx_metric = self.sc_metric_combo.findData(saved_metric)
         if idx_metric >= 0:


### PR DESCRIPTION
1. Disable RB and PRB analysis in record-only and import-audio modes
2. Rename PRB options to "感知失真指数" and "感知失真响度"
3. Update Y-axis labels to use phon unit
4. Temporarily disable "感知失真响度" option (not yet complete)