### PR TITLE
fix: improve fixed mic multi-channel waveform display

### DIFF
--- a/ui/sequence/fixed_mic/runtime_bridge.py
+++ b/ui/sequence/fixed_mic/runtime_bridge.py
@@ -1,6 +1,5 @@
 import time
 
-import pyqtgraph as pg
 from PyQt5.QtWidgets import QMessageBox
 
 from consts import error_code
@@ -27,13 +26,20 @@ def handle_fixed_mic_manual_trigger(window, controller_cls):
             float(window.fixed_mic_controller.window_duration),
         )
         window.fixed_mic_poll_timer.start(50)
-        window.line_graph.clear()
+        window._clear_waveform_display()
         window.fixed_mic_plot_item = None
         window.fixed_mic_last_plot_update_ts = 0.0
         window.fixed_mic_live_y_limit = 0.01
         window.fixed_mic_stream_buffer = []
         window._reset_fixed_mic_session_views()
         window._configure_fixed_mic_live_plot_view()
+        window._render_fixed_mic_waveforms(
+            None,
+            window.fixed_mic_controller.sample_rate,
+            total_channels=window.fixed_mic_controller.channels,
+            reset_page=True,
+            live_mode=True,
+        )
 
     barcode = window.lineedit_s_or_n.text().strip() or None
     create_code, create_msg, session = window.fixed_mic_controller.create_manual_session(barcode)
@@ -60,21 +66,13 @@ def poll_fixed_mic_runtime(window):
     plot_interval_sec = getattr(window, "fixed_mic_plot_interval_sec", 0.12)
     if plot_chunks and current_time - getattr(window, "fixed_mic_last_plot_update_ts", 0.0) >= plot_interval_sec:
         plot_audio = window._get_fixed_mic_stream_plot_audio()
-        if plot_audio.size > 0:
-            time_axis, plot_audio = window.build_live_plot_data(
-                plot_audio,
-                window.fixed_mic_controller.sample_rate,
-                max_points=4000,
-            )
-            if window.fixed_mic_plot_item is None:
-                window.fixed_mic_plot_item = window.line_graph.plot(
-                    time_axis,
-                    plot_audio,
-                    pen=pg.mkPen(color=(30, 30, 30), width=1),
-                )
-            else:
-                window.fixed_mic_plot_item.setData(time_axis, plot_audio)
-            window._update_fixed_mic_live_plot_range(plot_audio)
+        window._render_fixed_mic_waveforms(
+            plot_audio,
+            window.fixed_mic_controller.sample_rate,
+            total_channels=window.fixed_mic_controller.channels,
+            reset_page=False,
+            live_mode=True,
+        )
         window.fixed_mic_last_plot_update_ts = current_time
 
     for session in completed_sessions:
@@ -114,8 +112,6 @@ def stop_fixed_mic_runtime(window):
             pass
         window.fixed_mic_controller.stop_capture()
         window.fixed_mic_controller = None
-    if hasattr(window, "line_graph"):
-        window.line_graph.clear()
     window.fixed_mic_plot_item = None
     window.fixed_mic_last_plot_update_ts = 0.0
     window.fixed_mic_live_y_limit = 0.01

--- a/ui/sequence/fixed_mic/waveform_helpers.py
+++ b/ui/sequence/fixed_mic/waveform_helpers.py
@@ -1,0 +1,58 @@
+import numpy as np
+
+
+def get_fixed_mic_page_channel_indices(total_channels, current_page, page_size=4):
+    normalized_total = max(int(total_channels or 0), 0)
+    normalized_page_size = max(int(page_size or 1), 1)
+    if normalized_total == 0:
+        return []
+
+    max_page = max((normalized_total - 1) // normalized_page_size, 0)
+    normalized_page = min(max(int(current_page or 0), 0), max_page)
+    start = normalized_page * normalized_page_size
+    end = min(start + normalized_page_size, normalized_total)
+    return list(range(start, end))
+
+
+def get_fixed_mic_downsample_step(visible_channel_count):
+    normalized_count = max(int(visible_channel_count or 0), 0)
+    if normalized_count <= 0:
+        return 1
+    if normalized_count <= 2:
+        return 4
+    return 8
+
+
+def build_fixed_mic_plot_data(plot_audio, sample_rate, visible_channel_count):
+    audio_data = np.asarray(plot_audio, dtype=np.float32)
+    if audio_data.size == 0:
+        return np.array([], dtype=np.float32), np.empty((0, 0), dtype=np.float32)
+
+    if audio_data.ndim == 1:
+        audio_data = audio_data.reshape(-1, 1)
+
+    sample_count = audio_data.shape[0]
+    if sample_count == 0:
+        return np.array([], dtype=np.float32), np.empty((0, audio_data.shape[1]), dtype=np.float32)
+
+    step = get_fixed_mic_downsample_step(visible_channel_count)
+    sample_positions = np.arange(0, sample_count, step, dtype=np.int64)
+    if sample_positions.size == 0 or sample_positions[-1] != sample_count - 1:
+        sample_positions = np.append(sample_positions, sample_count - 1)
+
+    display_audio = audio_data[sample_positions]
+    time_axis = sample_positions.astype(np.float32) / float(sample_rate)
+    return time_axis, display_audio
+
+
+def get_fixed_mic_channel_titles(total_channels, channel_config):
+    titles = []
+    normalized_total = max(int(total_channels or 0), 0)
+    channel_list = channel_config if isinstance(channel_config, list) else []
+
+    for index in range(normalized_total):
+        title = ""
+        if index < len(channel_list) and isinstance(channel_list[index], dict):
+            title = str(channel_list[index].get("label", "") or "").strip()
+        titles.append(title or "Mic%d" % (index + 1))
+    return titles

--- a/ui/sequence/sequence_widget.py
+++ b/ui/sequence/sequence_widget.py
@@ -10,8 +10,12 @@ from PyQt5.QtCore import QSize, Qt, QTimer
 from PyQt5.QtGui import QFont, QIcon
 from PyQt5.QtWidgets import (
     QApplication,
+    QGridLayout,
     QHBoxLayout,
+    QLabel,
     QMessageBox,
+    QPushButton,
+    QStackedWidget,
     QVBoxLayout,
     QWidget,
 )
@@ -48,6 +52,11 @@ from ui.sequence.fixed_mic import (
     run_fixed_mic_session_analysis,
     show_fixed_mic_session_analysis_windows,
     show_fixed_mic_session_result_by_id,
+)
+from ui.sequence.fixed_mic.waveform_helpers import (
+    build_fixed_mic_plot_data,
+    get_fixed_mic_channel_titles,
+    get_fixed_mic_page_channel_indices,
 )
 from ui.sequence.fixed_mic.runtime_bridge import (
     handle_fixed_mic_manual_trigger,
@@ -111,6 +120,8 @@ class SequenceWindow(QWidget):
         self.use_streaming = True  # Set to True to use streaming, False for legacy blocking mode
         self.fixed_mic_controller = None
         self.fixed_mic_plot_item = None
+        self.fixed_mic_plot_items = []
+        self.fixed_mic_plot_widgets = []
         self.fixed_mic_analysis_queue = []
         self.fixed_mic_analysis_busy = False
         self.fixed_mic_finalize_pipeline = SessionFinalizePipeline()
@@ -120,12 +131,25 @@ class SequenceWindow(QWidget):
         self.fixed_mic_plot_interval_sec = 0.12
         self.fixed_mic_last_plot_update_ts = 0.0
         self.fixed_mic_live_y_limit = 0.01
+        self.fixed_mic_live_y_limits = []
         self.fixed_mic_stream_buffer = []
         self.fixed_mic_session_rows = {}
         self.fixed_mic_session_store = {}
         self.fixed_mic_detail_panel = None
         self.fixed_mic_session_panel = None
         self.fixed_mic_session_table = None
+        self.fixed_mic_page_size = 4
+        self.fixed_mic_current_page = 0
+        self.fixed_mic_display_total_channels = 0
+        self.fixed_mic_display_audio = None
+        self.fixed_mic_display_sample_rate = 0.0
+        self.fixed_mic_display_live_mode = False
+        self.fixed_mic_waveform_widget = None
+        self.fixed_mic_waveform_grid = None
+        self.fixed_mic_page_label = None
+        self.fixed_mic_prev_page_btn = None
+        self.fixed_mic_next_page_btn = None
+        self.waveform_stack = None
         self._sync_fixed_mic_mode_state()
 
         self.hw_manager = UnifiedHardwareManager()
@@ -279,12 +303,16 @@ class SequenceWindow(QWidget):
         layout = QHBoxLayout()
         self.line_graph = pg.PlotWidget()
         self._configure_main_waveform_plot(self.line_graph)
+        self.fixed_mic_waveform_widget = self._create_fixed_mic_waveform_widget()
+        self.waveform_stack = QStackedWidget()
+        self.waveform_stack.addWidget(self.line_graph)
+        self.waveform_stack.addWidget(self.fixed_mic_waveform_widget)
 
         right_panel = QWidget()
         right_layout = QVBoxLayout()
         right_layout.setContentsMargins(0, 0, 0, 0)
         right_layout.setSpacing(12)
-        right_layout.addWidget(self.line_graph, stretch=7)
+        right_layout.addWidget(self.waveform_stack, stretch=7)
         right_layout.addWidget(self.create_fixed_mic_detail_panel(), stretch=5)
         right_panel.setLayout(right_layout)
 
@@ -309,6 +337,281 @@ class SequenceWindow(QWidget):
         l_axis.setTickFont(font)
         b_axis.setTextPen("black")
         l_axis.setTextPen("black")
+
+    def _configure_fixed_mic_subplot(self, plot_widget):
+        plot_widget.setBackground("white")
+        plot_widget.setLabel("left", "Amplitude(V)", **{"font-size": "11px"})
+        plot_widget.setLabel("bottom", "Time(s)", **{"font-size": "11px"})
+        plot_widget.showGrid(x=True, y=True, alpha=0.2)
+
+        font = QFont()
+        font.setPixelSize(11)
+        b_axis = plot_widget.getAxis("bottom")
+        l_axis = plot_widget.getAxis("left")
+        b_axis.setTickFont(font)
+        l_axis.setTickFont(font)
+        b_axis.setTextPen("black")
+        l_axis.setTextPen("black")
+
+    def _create_fixed_mic_waveform_widget(self):
+        container = QWidget()
+        container_layout = QVBoxLayout()
+        container_layout.setContentsMargins(0, 0, 0, 0)
+        container_layout.setSpacing(8)
+
+        pager_layout = QHBoxLayout()
+        pager_layout.setContentsMargins(0, 0, 0, 0)
+        pager_layout.addStretch()
+        self.fixed_mic_prev_page_btn = QPushButton("上一页")
+        self.fixed_mic_prev_page_btn.clicked.connect(lambda: self._change_fixed_mic_waveform_page(-1))
+        self.fixed_mic_page_label = QLabel("1 / 1")
+        self.fixed_mic_next_page_btn = QPushButton("下一页")
+        self.fixed_mic_next_page_btn.clicked.connect(lambda: self._change_fixed_mic_waveform_page(1))
+        pager_layout.addWidget(self.fixed_mic_prev_page_btn)
+        pager_layout.addWidget(self.fixed_mic_page_label)
+        pager_layout.addWidget(self.fixed_mic_next_page_btn)
+        pager_layout.addStretch()
+        container_layout.addLayout(pager_layout)
+
+        self.fixed_mic_waveform_grid = QGridLayout()
+        self.fixed_mic_waveform_grid.setContentsMargins(0, 0, 0, 0)
+        self.fixed_mic_waveform_grid.setHorizontalSpacing(10)
+        self.fixed_mic_waveform_grid.setVerticalSpacing(10)
+
+        for _ in range(self.fixed_mic_page_size):
+            plot_widget = pg.PlotWidget()
+            self._configure_fixed_mic_subplot(plot_widget)
+            plot_widget.hide()
+            self.fixed_mic_plot_widgets.append(plot_widget)
+            self.fixed_mic_plot_items.append(None)
+            self.fixed_mic_live_y_limits.append(0.01)
+
+        grid_host = QWidget()
+        grid_host.setLayout(self.fixed_mic_waveform_grid)
+        container_layout.addWidget(grid_host, stretch=1)
+        container.setLayout(container_layout)
+        self._refresh_fixed_mic_waveform_paging_controls(0)
+        self._layout_fixed_mic_subplot_widgets(0)
+        return container
+
+    def _show_standard_waveform_view(self):
+        if getattr(self, "waveform_stack", None) is not None:
+            self.waveform_stack.setCurrentWidget(self.line_graph)
+
+    def _show_fixed_mic_waveform_view(self):
+        if getattr(self, "waveform_stack", None) is not None and getattr(self, "fixed_mic_waveform_widget", None) is not None:
+            self.waveform_stack.setCurrentWidget(self.fixed_mic_waveform_widget)
+
+    def _clear_waveform_display(self):
+        if getattr(self, "line_graph", None):
+            self.line_graph.clear()
+        self._clear_fixed_mic_waveform_plots(reset_state=self.is_fixed_mic_mode())
+
+    def _clear_fixed_mic_waveform_plots(self, reset_state=False):
+        for index, plot_widget in enumerate(getattr(self, "fixed_mic_plot_widgets", [])):
+            plot_widget.clear()
+            plot_widget.hide()
+            plot_widget.setTitle("")
+            if index < len(self.fixed_mic_plot_items):
+                self.fixed_mic_plot_items[index] = None
+            if index < len(self.fixed_mic_live_y_limits):
+                self.fixed_mic_live_y_limits[index] = 0.01
+        self._layout_fixed_mic_subplot_widgets(0)
+        if reset_state:
+            self.fixed_mic_current_page = 0
+            self.fixed_mic_display_total_channels = 0
+            self.fixed_mic_display_audio = None
+            self.fixed_mic_display_sample_rate = 0.0
+            self.fixed_mic_display_live_mode = False
+        self._refresh_fixed_mic_waveform_paging_controls(0)
+
+    def _get_fixed_mic_channel_config(self):
+        if not self.is_fixed_mic_mode():
+            return []
+        acq_detail = self.sequence_config[0]["seq1"]["acq"].get("detail", {})
+        channel_config = acq_detail.get("fixed_mic_channels", [])
+        return channel_config if isinstance(channel_config, list) else []
+
+    def _get_fixed_mic_configured_channels(self):
+        if not self.is_fixed_mic_mode():
+            return 0
+        acq_detail = self.sequence_config[0]["seq1"]["acq"].get("detail", {})
+        return max(int(acq_detail.get("channels", 0) or 0), 0)
+
+    def _refresh_fixed_mic_waveform_paging_controls(self, total_channels):
+        total_pages = max((max(int(total_channels or 0), 0) - 1) // self.fixed_mic_page_size + 1, 1)
+        current_page = min(max(int(self.fixed_mic_current_page or 0), 0), total_pages - 1)
+        self.fixed_mic_current_page = current_page
+        show_controls = total_pages > 1
+        if self.fixed_mic_page_label is not None:
+            self.fixed_mic_page_label.setText("%d / %d" % (current_page + 1, total_pages))
+            self.fixed_mic_page_label.setVisible(show_controls)
+        if self.fixed_mic_prev_page_btn is not None:
+            self.fixed_mic_prev_page_btn.setVisible(show_controls)
+            self.fixed_mic_prev_page_btn.setEnabled(show_controls and current_page > 0)
+        if self.fixed_mic_next_page_btn is not None:
+            self.fixed_mic_next_page_btn.setVisible(show_controls)
+            self.fixed_mic_next_page_btn.setEnabled(show_controls and current_page < total_pages - 1)
+
+    def _layout_fixed_mic_subplot_widgets(self, visible_count):
+        if getattr(self, "fixed_mic_waveform_grid", None) is None:
+            return
+
+        while self.fixed_mic_waveform_grid.count():
+            item = self.fixed_mic_waveform_grid.takeAt(0)
+            widget = item.widget()
+            if widget is not None:
+                self.fixed_mic_waveform_grid.removeWidget(widget)
+
+        for row in range(2):
+            self.fixed_mic_waveform_grid.setRowStretch(row, 1)
+            self.fixed_mic_waveform_grid.setColumnStretch(row, 1)
+
+        if visible_count <= 0:
+            return
+
+        if visible_count == 1:
+            self.fixed_mic_waveform_grid.addWidget(self.fixed_mic_plot_widgets[0], 0, 0, 2, 2)
+            return
+
+        if visible_count == 2:
+            self.fixed_mic_waveform_grid.addWidget(self.fixed_mic_plot_widgets[0], 0, 0, 2, 1)
+            self.fixed_mic_waveform_grid.addWidget(self.fixed_mic_plot_widgets[1], 0, 1, 2, 1)
+            return
+
+        positions = [(0, 0), (0, 1), (1, 0), (1, 1)]
+        for index in range(min(visible_count, self.fixed_mic_page_size)):
+            row, column = positions[index]
+            self.fixed_mic_waveform_grid.addWidget(self.fixed_mic_plot_widgets[index], row, column, 1, 1)
+
+    def _change_fixed_mic_waveform_page(self, page_delta):
+        total_channels = max(int(getattr(self, "fixed_mic_display_total_channels", 0) or 0), 0)
+        if total_channels <= self.fixed_mic_page_size:
+            return
+
+        max_page = max((total_channels - 1) // self.fixed_mic_page_size, 0)
+        target_page = min(max(self.fixed_mic_current_page + int(page_delta), 0), max_page)
+        if target_page == self.fixed_mic_current_page:
+            return
+
+        self.fixed_mic_current_page = target_page
+        if self.fixed_mic_display_live_mode:
+            self.fixed_mic_live_y_limits = [0.01] * self.fixed_mic_page_size
+        self._render_fixed_mic_waveforms(
+            self.fixed_mic_display_audio,
+            self.fixed_mic_display_sample_rate or self.data_struct.sample_rate,
+            total_channels=total_channels,
+            reset_page=False,
+            live_mode=self.fixed_mic_display_live_mode,
+        )
+
+    def _update_fixed_mic_subplot_range(self, plot_widget, plot_audio, time_axis, slot_index, live_mode):
+        amplitude = float(np.max(np.abs(plot_audio))) if len(plot_audio) > 0 else 0.0
+        target_limit = max(amplitude * 1.2, 0.01)
+
+        if live_mode:
+            current_limit = float(self.fixed_mic_live_y_limits[slot_index])
+            if target_limit > current_limit:
+                current_limit = current_limit * 0.7 + target_limit * 0.3
+            else:
+                current_limit = current_limit * 0.92 + target_limit * 0.08
+            self.fixed_mic_live_y_limits[slot_index] = max(current_limit, 0.01)
+            plot_widget.enableAutoRange(x=False, y=False)
+            plot_widget.setMouseEnabled(x=False, y=False)
+            plot_widget.setXRange(0.0, float(self.fixed_mic_plot_window_sec), padding=0.0)
+            plot_widget.setYRange(
+                -float(self.fixed_mic_live_y_limits[slot_index]),
+                float(self.fixed_mic_live_y_limits[slot_index]),
+                padding=0.0,
+            )
+            return
+
+        x_end = float(time_axis[-1]) if len(time_axis) > 0 else 1.0
+        plot_widget.enableAutoRange(x=False, y=False)
+        plot_widget.setMouseEnabled(x=True, y=True)
+        plot_widget.setXRange(0.0, x_end, padding=0.0)
+        plot_widget.setYRange(-target_limit, target_limit, padding=0.0)
+
+    def _render_fixed_mic_waveforms(self, audio_data, sample_rate, total_channels=None, reset_page=False, live_mode=False):
+        normalized_audio = None
+        if audio_data is not None:
+            normalized_audio = np.asarray(audio_data, dtype=np.float32)
+            if normalized_audio.ndim == 1:
+                normalized_audio = normalized_audio.reshape(-1, 1)
+
+        if total_channels is None:
+            if normalized_audio is not None and normalized_audio.ndim == 2:
+                total_channels = normalized_audio.shape[1]
+            else:
+                total_channels = self._get_fixed_mic_configured_channels()
+        total_channels = max(int(total_channels or 0), 0)
+        if normalized_audio is not None and normalized_audio.ndim == 2:
+            total_channels = min(total_channels or normalized_audio.shape[1], normalized_audio.shape[1])
+
+        if reset_page:
+            self.fixed_mic_current_page = 0
+            self.fixed_mic_live_y_limits = [0.01] * self.fixed_mic_page_size
+
+        self.fixed_mic_display_audio = normalized_audio
+        self.fixed_mic_display_sample_rate = float(sample_rate or self.data_struct.sample_rate or 1.0)
+        self.fixed_mic_display_total_channels = total_channels
+        self.fixed_mic_display_live_mode = bool(live_mode)
+        self._show_fixed_mic_waveform_view()
+
+        titles = get_fixed_mic_channel_titles(total_channels, self._get_fixed_mic_channel_config())
+        visible_channel_indices = get_fixed_mic_page_channel_indices(
+            total_channels,
+            self.fixed_mic_current_page,
+            self.fixed_mic_page_size,
+        )
+        visible_count = len(visible_channel_indices)
+        self._layout_fixed_mic_subplot_widgets(visible_count)
+        self._refresh_fixed_mic_waveform_paging_controls(total_channels)
+
+        time_axis = np.array([], dtype=np.float32)
+        display_audio = np.empty((0, visible_count), dtype=np.float32)
+        if normalized_audio is not None and normalized_audio.size > 0 and visible_count > 0:
+            visible_audio = normalized_audio[:, visible_channel_indices]
+            time_axis, display_audio = build_fixed_mic_plot_data(
+                visible_audio,
+                self.fixed_mic_display_sample_rate,
+                visible_count,
+            )
+
+        for slot_index, plot_widget in enumerate(self.fixed_mic_plot_widgets):
+            if slot_index >= visible_count:
+                plot_widget.hide()
+                plot_widget.clear()
+                plot_widget.setTitle("")
+                self.fixed_mic_plot_items[slot_index] = None
+                self.fixed_mic_live_y_limits[slot_index] = 0.01
+                continue
+
+            channel_index = visible_channel_indices[slot_index]
+            plot_widget.show()
+            title_text = titles[channel_index] if channel_index < len(titles) else "Mic%d" % (channel_index + 1)
+            plot_widget.setTitle(title_text, color="black", size="12pt")
+
+            channel_audio = (
+                display_audio[:, slot_index]
+                if display_audio.ndim == 2 and display_audio.shape[1] > slot_index
+                else np.array([], dtype=np.float32)
+            )
+            if self.fixed_mic_plot_items[slot_index] is None:
+                self.fixed_mic_plot_items[slot_index] = plot_widget.plot(
+                    time_axis,
+                    channel_audio,
+                    pen=pg.mkPen(color=(30, 30, 30), width=1),
+                )
+            else:
+                self.fixed_mic_plot_items[slot_index].setData(time_axis, channel_audio)
+            self._update_fixed_mic_subplot_range(
+                plot_widget,
+                channel_audio,
+                time_axis,
+                slot_index,
+                bool(live_mode),
+            )
 
     def create_fixed_mic_detail_panel(self):
         self.fixed_mic_detail_panel = QWidget()
@@ -591,7 +894,7 @@ class SequenceWindow(QWidget):
         self.player_status_flag = False
         self.signal_info.clear()
         self.lineedit_s_or_n.clear()
-        self.line_graph.clear()
+        self._clear_waveform_display()
 
         if manual:
             self.replayer_btn.setDisabled(True)
@@ -868,7 +1171,7 @@ class SequenceWindow(QWidget):
         self.data_struct.sample_rate = session.metadata.get("sample_rate", self.data_struct.sample_rate)
         self.data_struct.update_channel_count()
         if update_plot and self.data_struct.store_wave_data is not None:
-            self.plot_line_graph(self.data_struct.store_wave_data, self.line_graph, self.data_struct.sample_rate)
+            self._plot_recorded_signal(self.data_struct.store_wave_data, self.data_struct.sample_rate, reset_page=True)
 
     def _refresh_fixed_mic_review_session_display(self):
         if self.fixed_mic_current_review_session is None:
@@ -940,11 +1243,21 @@ class SequenceWindow(QWidget):
         if getattr(self, "fixed_mic_detail_panel", None) is not None:
             self.fixed_mic_detail_panel.setVisible(self.is_fixed_mic_mode())
         if not self.is_fixed_mic_mode():
+            self._show_standard_waveform_view()
             self.count_board.set_mark_mode_enabled(True)
             self.count_board.set_review_session_text("无")
             self.count_board.set_review_session_visible(False)
             self._update_fixed_mic_toolbar_state()
             return
+
+        if self.fixed_mic_controller is None and self.fixed_mic_current_review_session is None:
+            self._render_fixed_mic_waveforms(
+                None,
+                self.data_struct.sample_rate,
+                total_channels=self._get_fixed_mic_configured_channels(),
+                reset_page=True,
+                live_mode=False,
+            )
 
         if desired_mode == "test" and self.count_board.mode != "test":
             self.count_board.force_test_mode()
@@ -995,7 +1308,8 @@ class SequenceWindow(QWidget):
         if self.checked_work_status_message():
             return
 
-        self.line_graph.clear()
+        self._show_standard_waveform_view()
+        self._clear_waveform_display()
         # CRITICAL: Clean up any existing streaming resources before starting new recording
         # This prevents device conflicts and freezing when replay is clicked multiple times
         self._cleanup_streaming_resources()
@@ -1004,7 +1318,7 @@ class SequenceWindow(QWidget):
 
         # Clear plot and reset streaming state for NEW recording
         if self.player_status_flag:
-            self.line_graph.clear()
+            self._clear_waveform_display()
 
         self.streaming_buffer = []
         self.streaming_time_data = []
@@ -1070,7 +1384,7 @@ class SequenceWindow(QWidget):
                 play_last_stimulus_wave(stimulus_dict, recorded_dict, self.recorded_path, self.recorded_signal_info)
             else:
                 record_without_play(recorded_dict, self.recorded_path, self.recorded_signal_info)
-            self.plot_line_graph(self.data_struct.store_wave_data, self.line_graph, sample_rate)
+            self._plot_recorded_signal(self.data_struct.store_wave_data, sample_rate, reset_page=True)
 
         self.player_status_flag = False  # Recording complete, allow hardware access
         self.data_btn.setEnabled(True)
@@ -1222,10 +1536,9 @@ class SequenceWindow(QWidget):
         plot_chunks = []
         for chunk in chunks:
             audio_chunk = np.asarray(chunk, dtype=np.float32)
-            if audio_chunk.ndim == 2:
-                plot_chunks.append(audio_chunk[:, 0])
-            else:
-                plot_chunks.append(audio_chunk.reshape(-1))
+            if audio_chunk.ndim == 1:
+                audio_chunk = audio_chunk.reshape(-1, 1)
+            plot_chunks.append(audio_chunk)
 
         if not plot_chunks:
             return
@@ -1235,20 +1548,21 @@ class SequenceWindow(QWidget):
             return
 
         max_samples = max(int(float(self.fixed_mic_plot_window_sec) * float(sample_rate)), 1)
-        total_samples = sum(len(chunk) for chunk in self.fixed_mic_stream_buffer)
+        total_samples = sum(chunk.shape[0] for chunk in self.fixed_mic_stream_buffer)
         while total_samples > max_samples and self.fixed_mic_stream_buffer:
             first_chunk = self.fixed_mic_stream_buffer[0]
             overflow = total_samples - max_samples
-            if len(first_chunk) <= overflow:
-                total_samples -= len(first_chunk)
+            if first_chunk.shape[0] <= overflow:
+                total_samples -= first_chunk.shape[0]
                 self.fixed_mic_stream_buffer.pop(0)
             else:
-                self.fixed_mic_stream_buffer[0] = first_chunk[overflow:]
+                self.fixed_mic_stream_buffer[0] = first_chunk[overflow:, :]
                 total_samples -= overflow
 
     def _get_fixed_mic_stream_plot_audio(self):
         if not self.fixed_mic_stream_buffer:
-            return np.array([], dtype=np.float32)
+            channel_count = max(int(self.fixed_mic_display_total_channels or self._get_fixed_mic_configured_channels() or 0), 0)
+            return np.empty((0, channel_count), dtype=np.float32)
         return np.concatenate(self.fixed_mic_stream_buffer, axis=0)
 
     def _reset_fixed_mic_session_views(self):
@@ -1336,35 +1650,16 @@ class SequenceWindow(QWidget):
         return
 
     def _configure_fixed_mic_live_plot_view(self):
-        if not getattr(self, "line_graph", None):
-            return
-        self.line_graph.enableAutoRange(x=False, y=False)
-        self.line_graph.setMouseEnabled(x=False, y=False)
-        self.line_graph.setXRange(0.0, float(self.fixed_mic_plot_window_sec), padding=0.0)
-        self.line_graph.setYRange(-float(self.fixed_mic_live_y_limit), float(self.fixed_mic_live_y_limit), padding=0.0)
+        self.fixed_mic_live_y_limits = [0.01] * self.fixed_mic_page_size
 
     def _update_fixed_mic_live_plot_range(self, plot_audio):
-        if not getattr(self, "line_graph", None):
-            return
-        amplitude = float(np.max(np.abs(plot_audio))) if len(plot_audio) > 0 else 0.0
-        target_limit = max(amplitude * 1.2, 0.01)
-        current_limit = float(getattr(self, "fixed_mic_live_y_limit", 0.01))
-        if target_limit > current_limit:
-            current_limit = current_limit * 0.7 + target_limit * 0.3
-        else:
-            current_limit = current_limit * 0.92 + target_limit * 0.08
-        self.fixed_mic_live_y_limit = max(current_limit, 0.01)
-        self.line_graph.setXRange(0.0, float(self.fixed_mic_plot_window_sec), padding=0.0)
-        self.line_graph.setYRange(
-            -float(self.fixed_mic_live_y_limit),
-            float(self.fixed_mic_live_y_limit),
-            padding=0.0,
-        )
+        return
 
     def _update_fixed_mic_toolbar_state(self):
         if not getattr(self, "toolsbar", None):
             return
         if not self.is_fixed_mic_mode():
+            self._show_standard_waveform_view()
             if getattr(self, "line_graph", None):
                 self.line_graph.enableAutoRange(x=True, y=True)
                 self.line_graph.setMouseEnabled(x=True, y=True)
@@ -1385,6 +1680,22 @@ class SequenceWindow(QWidget):
         self.replayer_btn.setIcon(QIcon(DEFAULT_DIR + "ui/ui_pic/sequence_pic/pause.png"))
         self.replayer_btn.setIconSize(QSize(30, 30))
         self.replayer_btn.setEnabled(is_running)
+
+    def _plot_recorded_signal(self, recorded_signal, sample_rate, reset_page=False):
+        if self.is_fixed_mic_mode() and isinstance(recorded_signal, np.ndarray):
+            if recorded_signal.ndim == 1:
+                recorded_signal = recorded_signal.reshape(-1, 1)
+            self._render_fixed_mic_waveforms(
+                recorded_signal,
+                sample_rate,
+                total_channels=recorded_signal.shape[1],
+                reset_page=reset_page,
+                live_mode=False,
+            )
+            return
+
+        self._show_standard_waveform_view()
+        self.plot_line_graph(recorded_signal, self.line_graph, sample_rate)
 
     @staticmethod
     def plot_line_graph(recorded_signal, line_graph, sample_rate):

--- a/unit_test/ui/test_fixed_mic_idle_stop_behavior.py
+++ b/unit_test/ui/test_fixed_mic_idle_stop_behavior.py
@@ -1,0 +1,204 @@
+import logging
+import os
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+
+if "concurrent_log_handler" not in sys.modules:
+    concurrent_log_handler = types.ModuleType("concurrent_log_handler")
+
+    class _ConcurrentRotatingFileHandler(logging.Handler):
+        def __init__(self, *args, **kwargs):
+            super().__init__()
+
+        def emit(self, record):
+            return
+
+    concurrent_log_handler.ConcurrentRotatingFileHandler = _ConcurrentRotatingFileHandler
+    sys.modules["concurrent_log_handler"] = concurrent_log_handler
+
+if "keyboard" not in sys.modules:
+    keyboard = types.ModuleType("keyboard")
+    keyboard.add_hotkey = lambda *args, **kwargs: None
+    keyboard.unhook_all_hotkeys = lambda *args, **kwargs: None
+    sys.modules["keyboard"] = keyboard
+
+if "pywinusb" not in sys.modules:
+    hid_module = types.ModuleType("hid")
+    hid_module.find_all_hid_devices = lambda: []
+    pywinusb_module = types.ModuleType("pywinusb")
+    pywinusb_module.hid = hid_module
+    sys.modules["pywinusb"] = pywinusb_module
+    sys.modules["pywinusb.hid"] = hid_module
+
+
+from PyQt5.QtWidgets import QApplication, QStackedWidget
+import pyqtgraph as pg
+
+from consts import error_code
+from ui.sequence.fixed_mic.runtime_bridge import handle_fixed_mic_manual_trigger, stop_fixed_mic_runtime
+from ui.sequence.sequence_widget import SequenceWindow
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def build_fixed_mic_window_stub():
+    window = SequenceWindow.__new__(SequenceWindow)
+    window.fixed_mic_plot_items = []
+    window.fixed_mic_plot_widgets = []
+    window.fixed_mic_live_y_limits = []
+    window.fixed_mic_page_size = 4
+    window.fixed_mic_current_page = 0
+    window.fixed_mic_display_total_channels = 0
+    window.fixed_mic_display_audio = None
+    window.fixed_mic_display_sample_rate = 0.0
+    window.fixed_mic_display_live_mode = False
+    window.fixed_mic_plot_window_sec = 15.0
+    window.data_struct = SimpleNamespace(sample_rate=44100)
+    window.sequence_config = [
+        {
+            "seq1": {
+                "acq": {
+                    "mode": "FIXED_MIC_MULTI_SESSION",
+                    "detail": {
+                        "channels": 6,
+                        "fixed_mic_channels": [{"label": f"Mic{i + 1}"} for i in range(6)],
+                    },
+                }
+            }
+        }
+    ]
+    window.line_graph = pg.PlotWidget()
+    window._configure_main_waveform_plot(window.line_graph)
+    window.fixed_mic_waveform_widget = window._create_fixed_mic_waveform_widget()
+    window.waveform_stack = QStackedWidget()
+    window.waveform_stack.addWidget(window.line_graph)
+    window.waveform_stack.addWidget(window.fixed_mic_waveform_widget)
+    return window
+
+
+class DummyController(object):
+    def __init__(self):
+        self.stop_calls = 0
+
+    def process_audio_queue(self):
+        return 0, []
+
+    def stop_capture(self):
+        self.stop_calls += 1
+
+
+class DummyStartController(object):
+    def __init__(self, acq_detail, input_device=None):
+        self.sample_rate = int(acq_detail.get("sample_rate", 44100))
+        self.channels = int(acq_detail.get("channels", 1))
+        self.buffer_duration = float(acq_detail.get("buffer_duration", 15.0))
+        self.window_duration = float(acq_detail.get("window_duration", 3.0))
+        self.is_running = True
+
+    def start_capture(self):
+        return error_code.OK, "ok"
+
+    def create_manual_session(self, barcode):
+        session = SimpleNamespace(session_id="session_01")
+        return error_code.OK, "ok", session
+
+
+class TestFixedMicIdleStopBehavior(object):
+    def test_render_fixed_mic_waveforms_without_audio_shows_empty_subplots(self, qapp):
+        window = build_fixed_mic_window_stub()
+
+        window._render_fixed_mic_waveforms(
+            None,
+            sample_rate=44100,
+            total_channels=6,
+            reset_page=True,
+            live_mode=False,
+        )
+
+        visible_count = sum(not plot_widget.isHidden() for plot_widget in window.fixed_mic_plot_widgets)
+        assert visible_count == 4
+        assert window.fixed_mic_page_label.text() == "1 / 2"
+        assert window.waveform_stack.currentWidget() is window.fixed_mic_waveform_widget
+        assert window.fixed_mic_plot_widgets[0].plotItem.titleLabel.text == "Mic1"
+
+    def test_stop_fixed_mic_runtime_keeps_last_waveform_display(self):
+        clear_calls = []
+        controller = DummyController()
+        window = SimpleNamespace(
+            fixed_mic_poll_timer=SimpleNamespace(isActive=lambda: False, stop=lambda: None),
+            fixed_mic_controller=controller,
+            fixed_mic_analysis_queue=[],
+            fixed_mic_analysis_busy=False,
+            fixed_mic_pending_review_sessions=[],
+            fixed_mic_current_review_session=None,
+            player_status_flag=True,
+            count_board=SimpleNamespace(mode="test", set_review_session_text=lambda *_: None, set_review_session_visible=lambda *_: None),
+            _clear_waveform_display=lambda: clear_calls.append("cleared"),
+            _update_fixed_mic_toolbar_state=lambda: None,
+            _update_fixed_mic_session_status=lambda *args, **kwargs: None,
+            _process_next_fixed_mic_analysis=lambda: None,
+            fixed_mic_plot_item=object(),
+            fixed_mic_last_plot_update_ts=1.0,
+            fixed_mic_live_y_limit=0.5,
+            fixed_mic_stream_buffer=[1],
+        )
+
+        stop_fixed_mic_runtime(window)
+
+        assert clear_calls == []
+        assert controller.stop_calls == 1
+        assert window.fixed_mic_controller is None
+
+    def test_handle_fixed_mic_manual_trigger_resets_to_first_page_empty_layout(self):
+        render_calls = []
+        clear_calls = []
+        timer_calls = []
+        register_calls = []
+        toolbar_calls = []
+        reset_calls = []
+        window = SimpleNamespace(
+            checked_work_status_message=lambda: False,
+            clicked_player_flag=True,
+            fixed_mic_controller=None,
+            sequence_config=[{"seq1": {"acq": {"detail": {"sample_rate": 48000, "channels": 6, "buffer_duration": 15.0, "window_duration": 3.0}}}}],
+            mic={"name": "mic"},
+            fixed_mic_poll_timer=SimpleNamespace(start=lambda interval: timer_calls.append(interval)),
+            _clear_waveform_display=lambda: clear_calls.append("cleared"),
+            _reset_fixed_mic_session_views=lambda: reset_calls.append("reset"),
+            _configure_fixed_mic_live_plot_view=lambda: None,
+            _render_fixed_mic_waveforms=lambda *args, **kwargs: render_calls.append((args, kwargs)),
+            lineedit_s_or_n=SimpleNamespace(text=lambda: ""),
+            data_btn=SimpleNamespace(setEnabled=lambda enabled: None),
+            _update_fixed_mic_toolbar_state=lambda: toolbar_calls.append("updated"),
+            _register_fixed_mic_session=lambda session, status_text="": register_calls.append((session.session_id, status_text)),
+            default_logger=SimpleNamespace(info=lambda *args, **kwargs: None),
+            fixed_mic_plot_item=None,
+            fixed_mic_last_plot_update_ts=0.0,
+            fixed_mic_live_y_limit=0.01,
+            fixed_mic_stream_buffer=[],
+            player_status_flag=False,
+        )
+
+        handle_fixed_mic_manual_trigger(window, DummyStartController)
+
+        assert clear_calls == ["cleared"]
+        assert reset_calls == ["reset"]
+        assert timer_calls == [50]
+        assert render_calls[0][0][0] is None
+        assert render_calls[0][1]["total_channels"] == 6
+        assert render_calls[0][1]["reset_page"] is True
+        assert render_calls[0][1]["live_mode"] is True
+        assert register_calls == [("session_01", "采集中")]

--- a/unit_test/ui/test_fixed_mic_waveform_helpers.py
+++ b/unit_test/ui/test_fixed_mic_waveform_helpers.py
@@ -1,0 +1,66 @@
+import os
+import sys
+
+import numpy as np
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from ui.sequence.fixed_mic.waveform_helpers import (
+    build_fixed_mic_plot_data,
+    get_fixed_mic_channel_titles,
+    get_fixed_mic_downsample_step,
+    get_fixed_mic_page_channel_indices,
+)
+
+
+class TestFixedMicWaveformHelpers(object):
+
+    def test_get_fixed_mic_page_channel_indices_returns_current_page_slice(self):
+        assert get_fixed_mic_page_channel_indices(1, 0) == [0]
+        assert get_fixed_mic_page_channel_indices(6, 0) == [0, 1, 2, 3]
+        assert get_fixed_mic_page_channel_indices(6, 1) == [4, 5]
+        assert get_fixed_mic_page_channel_indices(6, 99) == [4, 5]
+
+    def test_get_fixed_mic_downsample_step_depends_on_visible_channels(self):
+        assert get_fixed_mic_downsample_step(0) == 1
+        assert get_fixed_mic_downsample_step(1) == 4
+        assert get_fixed_mic_downsample_step(2) == 4
+        assert get_fixed_mic_downsample_step(3) == 8
+        assert get_fixed_mic_downsample_step(4) == 8
+
+    def test_build_fixed_mic_plot_data_downsamples_all_channels_with_shared_time_axis(self):
+        audio = np.arange(24, dtype=np.float32).reshape(12, 2)
+
+        time_axis, display_audio = build_fixed_mic_plot_data(
+            audio,
+            sample_rate=12,
+            visible_channel_count=2,
+        )
+
+        assert np.allclose(time_axis, [0.0, 4.0 / 12.0, 8.0 / 12.0, 11.0 / 12.0])
+        assert display_audio.shape == (4, 2)
+        assert list(display_audio[:, 0]) == [0.0, 8.0, 16.0, 22.0]
+        assert list(display_audio[:, 1]) == [1.0, 9.0, 17.0, 23.0]
+
+    def test_build_fixed_mic_plot_data_uses_8x_downsampling_for_three_or_more_visible_channels(self):
+        audio = np.arange(48, dtype=np.float32).reshape(16, 3)
+
+        time_axis, display_audio = build_fixed_mic_plot_data(
+            audio,
+            sample_rate=16,
+            visible_channel_count=3,
+        )
+
+        assert np.allclose(time_axis, [0.0, 8.0 / 16.0, 15.0 / 16.0])
+        assert display_audio.shape == (3, 3)
+        assert list(display_audio[:, 0]) == [0.0, 24.0, 45.0]
+
+    def test_get_fixed_mic_channel_titles_prefers_labels_and_falls_back(self):
+        channel_config = [
+            {"label": "Left"},
+            {"label": ""},
+        ]
+
+        titles = get_fixed_mic_channel_titles(4, channel_config)
+
+        assert titles == ["Left", "Mic2", "Mic3", "Mic4"]


### PR DESCRIPTION
## Summary
- Improve fixed mic concurrent waveform rendering so the main page can show all configured channels with auto layout and pagination.
- Add shared helper logic for per-page downsampling, channel title mapping, and multi-channel live/review waveform updates.
- Keep fixed mic idle/stop behavior usable by showing empty channel panes on entry and preserving the last waveform state on manual stop.

## Test Plan
- [x] `pytest unit_test/ui/test_fixed_mic_waveform_helpers.py unit_test/ui/test_fixed_mic_idle_stop_behavior.py`
- [x] `python -m py_compile ui/sequence/fixed_mic/runtime_bridge.py unit_test/ui/test_fixed_mic_waveform_helpers.py unit_test/ui/test_fixed_mic_idle_stop_behavior.py`
- [x] Checked edited files with lints