### PR TITLE
fix: lazy-load fixed mic session audio

### DIFF
--- a/ui/sequence/fixed_mic/__init__.py
+++ b/ui/sequence/fixed_mic/__init__.py
@@ -9,9 +9,11 @@ from ui.sequence.fixed_mic.analysis_bridge import (
     finalize_and_run_fixed_mic_session,
     finalize_fixed_mic_session_analysis_result,
     get_fixed_mic_ai_result_text,
+    load_fixed_mic_session_audio,
     run_fixed_mic_session_analysis,
     show_fixed_mic_session_analysis_windows,
     show_fixed_mic_session_result_by_id,
+    sync_fixed_mic_session_paths,
 )
 
 __all__ = [
@@ -23,7 +25,9 @@ __all__ = [
     "finalize_and_run_fixed_mic_session",
     "finalize_fixed_mic_session_analysis_result",
     "get_fixed_mic_ai_result_text",
+    "load_fixed_mic_session_audio",
     "run_fixed_mic_session_analysis",
     "show_fixed_mic_session_analysis_windows",
     "show_fixed_mic_session_result_by_id",
+    "sync_fixed_mic_session_paths",
 ]

--- a/ui/sequence/fixed_mic/analysis_bridge.py
+++ b/ui/sequence/fixed_mic/analysis_bridge.py
@@ -1,9 +1,69 @@
+import os
 import re
 
+import numpy as np
 from PyQt5.QtWidgets import QMessageBox
 
+from base.load_audio import load_audio_simple
 from consts import error_code
+from consts.running_consts import DEFAULT_DIR
 from ui.sequence.fixed_mic.session_table_panel import FixedMicSessionTablePanel
+
+
+def sync_fixed_mic_session_paths(window, session):
+    if session is None:
+        return
+
+    recorded_signal_info = getattr(window, "recorded_signal_info", {}) or {}
+    updated_file_path = recorded_signal_info.get("file_path")
+    if not updated_file_path:
+        return
+
+    if os.path.isabs(updated_file_path):
+        updated_recorded_path = updated_file_path
+    else:
+        updated_recorded_path = os.path.join(DEFAULT_DIR, updated_file_path).replace("\\", "/")
+
+    window.recorded_path = updated_recorded_path
+    session.metadata["recorded_path"] = updated_recorded_path
+    session.metadata["recorded_signal_info"] = recorded_signal_info.copy()
+    if getattr(session, "analysis_result", None) is not None:
+        session.analysis_result["recorded_path"] = updated_file_path
+
+
+def load_fixed_mic_session_audio(session):
+    if session is None:
+        return None
+
+    audio_clip = getattr(session, "audio_clip", None)
+    if audio_clip is not None:
+        return np.asarray(audio_clip, dtype=np.float32).copy()
+
+    metadata = getattr(session, "metadata", {}) or {}
+    recorded_path = metadata.get("recorded_path")
+    sample_rate = metadata.get("sample_rate")
+    recorded_signal_info = metadata.get("recorded_signal_info", {}) or {}
+    candidate_paths = [recorded_path, recorded_signal_info.get("file_path")]
+    normalized_paths = []
+    for candidate in candidate_paths:
+        if not candidate:
+            continue
+        normalized_candidate = candidate
+        if not os.path.isabs(normalized_candidate):
+            normalized_candidate = os.path.join(DEFAULT_DIR, normalized_candidate).replace("\\", "/")
+        if normalized_candidate not in normalized_paths:
+            normalized_paths.append(normalized_candidate)
+
+    for candidate_path in normalized_paths:
+        try:
+            loaded_audio, _ = load_audio_simple(candidate_path, sr=sample_rate)
+        except (FileNotFoundError, OSError):
+            continue
+        except Exception:
+            continue
+        if loaded_audio is not None:
+            return np.asarray(loaded_audio, dtype=np.float32).copy()
+    return None
 
 
 def finalize_and_run_fixed_mic_session(window, session, save_recorded_data_to_json_func):
@@ -36,6 +96,7 @@ def finalize_and_run_fixed_mic_session(window, session, save_recorded_data_to_js
     window.data_struct.update_channel_count()
     session.metadata["recorded_path"] = recorded_path
     session.metadata["recorded_signal_info"] = recorded_signal_info.copy()
+    session.audio_clip = None
 
     current_mode = getattr(getattr(window, "count_board", None), "mode", "test")
     if current_mode == "mark":
@@ -91,6 +152,7 @@ def finalize_fixed_mic_session_analysis_result(window, session, use_ai_result_as
 
     if use_ai_result_as_label and result_label in ("OK", "NG"):
         window.update_recorded_signal_info_to_db()
+        sync_fixed_mic_session_paths(window, session)
         sync_fixed_mic_test_statistics(window, result_label)
 
     window.default_logger.info(
@@ -108,7 +170,10 @@ def show_fixed_mic_session_result_by_id(window, session_id):
         session = window.fixed_mic_session_panel.get_session(session_id)
     if session is None:
         return
-    if getattr(session, "audio_clip", None) is None:
+    recorded_signal_info = session.metadata.get("recorded_signal_info", {}) or {}
+    if getattr(session, "audio_clip", None) is None and not (
+        session.metadata.get("recorded_path") or recorded_signal_info.get("file_path")
+    ):
         status_text = session.metadata.get("display_status", "处理中")
         QMessageBox.information(
             window,
@@ -121,7 +186,7 @@ def show_fixed_mic_session_result_by_id(window, session_id):
 
 
 def show_fixed_mic_session_analysis_windows(window, session):
-    if session is None or getattr(session, "audio_clip", None) is None:
+    if session is None:
         return
 
     previous_recorded_path = window.recorded_path
@@ -129,11 +194,15 @@ def show_fixed_mic_session_analysis_windows(window, session):
     previous_wave_data = window.data_struct.store_wave_data
     previous_sample_rate = window.data_struct.sample_rate
     previous_mode = getattr(window.count_board, "mode", "test")
+    session_audio = load_fixed_mic_session_audio(session)
+    if session_audio is None:
+        QMessageBox.information(window, "提示", "当前会话音频文件不可用，无法查看分析结果。")
+        return
 
     try:
         window.recorded_path = session.metadata.get("recorded_path")
         window.recorded_signal_info = session.metadata.get("recorded_signal_info", {}).copy()
-        window.data_struct.store_wave_data = session.audio_clip.copy()
+        window.data_struct.store_wave_data = session_audio
         window.data_struct.sample_rate = session.metadata.get("sample_rate", window.data_struct.sample_rate)
         window.data_struct.update_channel_count()
 

--- a/ui/sequence/sequence_widget.py
+++ b/ui/sequence/sequence_widget.py
@@ -49,9 +49,11 @@ from ui.sequence.fixed_mic import (
     finalize_and_run_fixed_mic_session,
     finalize_fixed_mic_session_analysis_result,
     get_fixed_mic_ai_result_text,
+    load_fixed_mic_session_audio,
     run_fixed_mic_session_analysis,
     show_fixed_mic_session_analysis_windows,
     show_fixed_mic_session_result_by_id,
+    sync_fixed_mic_session_paths,
 )
 from ui.sequence.fixed_mic.waveform_helpers import (
     build_fixed_mic_plot_data,
@@ -1183,7 +1185,7 @@ class SequenceWindow(QWidget):
         recorded_signal_info = session.metadata.get("recorded_signal_info", {}).copy()
         self.recorded_path = session.metadata.get("recorded_path")
         self.recorded_signal_info = recorded_signal_info
-        self.data_struct.store_wave_data = session.audio_clip.copy() if session.audio_clip is not None else None
+        self.data_struct.store_wave_data = load_fixed_mic_session_audio(session)
         self.data_struct.sample_rate = session.metadata.get("sample_rate", self.data_struct.sample_rate)
         self.data_struct.update_channel_count()
         if update_plot and self.data_struct.store_wave_data is not None:
@@ -1224,7 +1226,7 @@ class SequenceWindow(QWidget):
         }
         session.metadata["recorded_signal_info"] = self.recorded_signal_info.copy()
         self.update_recorded_signal_info_to_db()
-        session.metadata["recorded_signal_info"] = self.recorded_signal_info.copy()
+        sync_fixed_mic_session_paths(self, session)
         self._update_fixed_mic_session_status(session, "已标记")
         self._update_fixed_mic_session_result(session, label)
         self.count_board.set_mark_result_file(label)

--- a/unit_test/ui/test_fixed_mic_concurrent.py
+++ b/unit_test/ui/test_fixed_mic_concurrent.py
@@ -1,4 +1,7 @@
+import logging
 import os
+import sys
+import types
 import unittest
 from datetime import datetime
 from types import SimpleNamespace
@@ -7,11 +10,39 @@ from unittest import mock
 import numpy as np
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
+if "concurrent_log_handler" not in sys.modules:
+    concurrent_log_handler = types.ModuleType("concurrent_log_handler")
+
+    class _ConcurrentRotatingFileHandler(logging.Handler):
+        def __init__(self, *args, **kwargs):
+            super().__init__()
+
+        def emit(self, record):
+            return
+
+    concurrent_log_handler.ConcurrentRotatingFileHandler = _ConcurrentRotatingFileHandler
+    sys.modules["concurrent_log_handler"] = concurrent_log_handler
+
+if "keyboard" not in sys.modules:
+    keyboard = types.ModuleType("keyboard")
+    keyboard.add_hotkey = lambda *args, **kwargs: None
+    keyboard.unhook_all_hotkeys = lambda *args, **kwargs: None
+    sys.modules["keyboard"] = keyboard
+
+if "pywinusb" not in sys.modules:
+    hid_module = types.ModuleType("hid")
+    hid_module.find_all_hid_devices = lambda: []
+    pywinusb_module = types.ModuleType("pywinusb")
+    pywinusb_module.hid = hid_module
+    sys.modules["pywinusb"] = pywinusb_module
+    sys.modules["pywinusb.hid"] = hid_module
+
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QApplication, QTableWidget, QTableWidgetItem
 
 from base.fixed_mic_capture import FixedMicCaptureController
 from consts import error_code
+from consts.running_consts import DEFAULT_DIR
 from ui.sequence.fixed_mic import FixedMicSessionTablePanel
 from ui.sequence.sequencement_count_board import SequenceCountBoard
 from ui.sequence.sequence_widget import SequenceWindow
@@ -319,6 +350,49 @@ class TestFixedMicConcurrent(unittest.TestCase):
         self.assertEqual(fake_window.fixed_mic_pending_review_sessions, [remaining_session])
         fake_window._update_fixed_mic_session_status.assert_called_once_with(selected_session, "已标记")
 
+    def test_handle_fixed_mic_mark_result_syncs_session_paths_after_label_move(self):
+        ok_button = object()
+        selected_session = SimpleNamespace(
+            session_id="fixed_mic_session_001",
+            metadata={"recorded_path": DEFAULT_DIR + "audio_data/stored_data/not_labeled/test.wav"},
+            analysis_result=None,
+        )
+        fake_window = SimpleNamespace(
+            fixed_mic_current_review_session=selected_session,
+            fixed_mic_pending_review_sessions=[selected_session],
+            count_board=SimpleNamespace(
+                ok_btn=ok_button,
+                ng_btn=object(),
+                set_mark_result_file=mock.Mock(),
+                set_mark_text=mock.Mock(),
+            ),
+            recorded_signal_info={"file_path": "audio_data/stored_data/not_labeled/test.wav"},
+            sender=lambda: ok_button,
+            _load_fixed_mic_review_session_context=mock.Mock(),
+            update_recorded_signal_info_to_db=mock.Mock(
+                side_effect=lambda: fake_window.recorded_signal_info.update(
+                    {"file_path": "audio_data/stored_data/OK/test.wav"}
+                )
+            ),
+            _update_fixed_mic_session_status=mock.Mock(),
+            _update_fixed_mic_session_result=mock.Mock(),
+            _emit_display_update=mock.Mock(),
+            _refresh_fixed_mic_review_session_display=mock.Mock(),
+            default_logger=SimpleNamespace(info=lambda *args, **kwargs: None),
+        )
+
+        SequenceWindow._handle_fixed_mic_mark_result(fake_window)
+
+        self.assertTrue(selected_session.metadata["recorded_path"].endswith("audio_data/stored_data/OK/test.wav"))
+        self.assertEqual(
+            selected_session.metadata["recorded_signal_info"]["file_path"],
+            "audio_data/stored_data/OK/test.wav",
+        )
+        self.assertEqual(
+            selected_session.analysis_result["recorded_path"],
+            "audio_data/stored_data/OK/test.wav",
+        )
+
     def test_selection_changed_marks_selected_pending_session_as_reviewing(self):
         session_a = SimpleNamespace(session_id="fixed_mic_session_001", metadata={})
         session_b = SimpleNamespace(session_id="fixed_mic_session_002", metadata={})
@@ -402,6 +476,49 @@ class TestFixedMicConcurrent(unittest.TestCase):
         self.assertEqual(fake_window.recorded_signal_info, {"file_path": "test.wav"})
         fake_window.data_struct.update_channel_count.assert_called_once()
         fake_window.plot_line_graph.assert_not_called()
+
+    def test_load_fixed_mic_review_session_context_reads_saved_audio_when_clip_is_released(self):
+        fake_session = SimpleNamespace(
+            metadata={"recorded_path": "test.wav", "recorded_signal_info": {"file_path": "test.wav"}, "sample_rate": 10},
+            audio_clip=None,
+        )
+        loaded_audio = np.array([[0.1], [0.2]], dtype=np.float32)
+        fake_window = SimpleNamespace(
+            recorded_path=None,
+            recorded_signal_info={},
+            data_struct=SimpleNamespace(store_wave_data=None, sample_rate=1, update_channel_count=mock.Mock()),
+            _plot_recorded_signal=mock.Mock(),
+        )
+
+        with mock.patch("ui.sequence.sequence_widget.load_fixed_mic_session_audio", return_value=loaded_audio):
+            SequenceWindow._load_fixed_mic_review_session_context(fake_window, fake_session, update_plot=True)
+
+        self.assertTrue(np.array_equal(fake_window.data_struct.store_wave_data, loaded_audio))
+        fake_window._plot_recorded_signal.assert_called_once_with(loaded_audio, 10, reset_page=True)
+
+    def test_load_fixed_mic_session_audio_falls_back_to_updated_file_path_when_recorded_path_is_stale(self):
+        from ui.sequence.fixed_mic.analysis_bridge import load_fixed_mic_session_audio
+
+        fake_session = SimpleNamespace(
+            audio_clip=None,
+            metadata={
+                "recorded_path": DEFAULT_DIR + "audio_data/stored_data/not_labeled/test.wav",
+                "recorded_signal_info": {"file_path": "audio_data/stored_data/OK/test.wav"},
+                "sample_rate": 10,
+            },
+        )
+        loaded_audio = np.array([[0.1], [0.2]], dtype=np.float32)
+
+        with mock.patch(
+            "ui.sequence.fixed_mic.analysis_bridge.load_audio_simple",
+            side_effect=[FileNotFoundError("old path missing"), (loaded_audio, np.array([0.0, 0.1]))],
+        ) as load_mock:
+            result = load_fixed_mic_session_audio(fake_session)
+
+        self.assertTrue(np.array_equal(result, loaded_audio))
+        self.assertEqual(load_mock.call_count, 2)
+        self.assertEqual(load_mock.call_args_list[0].kwargs["sr"], 10)
+        self.assertTrue(load_mock.call_args_list[1].args[0].endswith("audio_data/stored_data/OK/test.wav"))
 
     def test_handle_fixed_mic_manual_trigger_starts_capture_and_creates_session(self):
         class FakeTimer(object):
@@ -708,6 +825,25 @@ class TestFixedMicConcurrent(unittest.TestCase):
         fake_window._select_fixed_mic_session_row.assert_called_once_with("fixed_mic_session_001")
         fake_window._show_fixed_mic_session_analysis_windows.assert_called_once_with(fake_session)
 
+    def test_show_fixed_mic_session_result_by_id_allows_saved_session_without_memory_clip(self):
+        fake_session = SimpleNamespace(
+            session_id="fixed_mic_session_001",
+            audio_clip=None,
+            metadata={"recorded_path": "test.wav", "display_status": "待审核"},
+        )
+        fake_window = SimpleNamespace(
+            fixed_mic_session_panel=SimpleNamespace(get_session=mock.Mock(return_value=fake_session)),
+            _select_fixed_mic_session_row=mock.Mock(),
+            _show_fixed_mic_session_analysis_windows=mock.Mock(),
+        )
+
+        with mock.patch("ui.sequence.fixed_mic.analysis_bridge.QMessageBox.information") as info_mock:
+            SequenceWindow._show_fixed_mic_session_result_by_id(fake_window, "fixed_mic_session_001")
+
+        info_mock.assert_not_called()
+        fake_window._select_fixed_mic_session_row.assert_called_once_with("fixed_mic_session_001")
+        fake_window._show_fixed_mic_session_analysis_windows.assert_called_once_with(fake_session)
+
     def test_update_fixed_mic_live_plot_range_locks_x_axis_and_smooths_y_axis(self):
         fake_line_graph = SimpleNamespace(
             setXRange=mock.Mock(),
@@ -843,6 +979,7 @@ class TestFixedMicConcurrent(unittest.TestCase):
         fake_window._select_fixed_mic_session_row.assert_not_called()
         fake_window._enqueue_fixed_mic_review_session.assert_called_once_with(fake_session)
         fake_window._run_fixed_mic_session_analysis.assert_not_called()
+        self.assertIsNone(fake_session.audio_clip)
 
     def test_finalize_fixed_mic_analysis_result_uses_ai_result_without_default_ai(self):
         fake_session = SimpleNamespace(
@@ -877,6 +1014,45 @@ class TestFixedMicConcurrent(unittest.TestCase):
         fake_window.update_recorded_signal_info_to_db.assert_called_once()
         fake_window.count_board.set_test_result_file.assert_called_once_with("OK", "demo_model")
         fake_window.count_board.set_test_text.assert_called_once()
+
+    def test_finalize_fixed_mic_analysis_result_syncs_paths_after_auto_label_move(self):
+        fake_session = SimpleNamespace(
+            session_id="fixed_mic_session_001",
+            metadata={},
+            analysis_result=None,
+        )
+        fake_ai = SimpleNamespace(
+            result="OK",
+            calculate_ai_scores=mock.Mock(),
+            ai_analyse_score_textedit=SimpleNamespace(toPlainText=lambda: "评分结果: OK"),
+        )
+        fake_window = SimpleNamespace(
+            recorded_path=DEFAULT_DIR + "audio_data/stored_data/not_labeled/test.wav",
+            recorded_signal_info={"labels": "not_labeled", "file_path": "audio_data/stored_data/not_labeled/test.wav"},
+            default_ai=None,
+            analysis_window=[fake_ai],
+            analysis_config={"default_ai": None, "display_sequence": []},
+            count_board=SimpleNamespace(mode="test", set_test_result_file=mock.Mock(), set_test_text=mock.Mock()),
+            update_recorded_signal_info_to_db=mock.Mock(
+                side_effect=lambda: fake_window.recorded_signal_info.update(
+                    {"file_path": "audio_data/stored_data/OK/test.wav"}
+                )
+            ),
+            default_logger=SimpleNamespace(info=lambda *args, **kwargs: None),
+        )
+
+        SequenceWindow._finalize_fixed_mic_session_analysis_result(fake_window, fake_session, use_ai_result_as_label=True)
+
+        self.assertTrue(fake_window.recorded_path.endswith("audio_data/stored_data/OK/test.wav"))
+        self.assertTrue(fake_session.metadata["recorded_path"].endswith("audio_data/stored_data/OK/test.wav"))
+        self.assertEqual(
+            fake_session.metadata["recorded_signal_info"]["file_path"],
+            "audio_data/stored_data/OK/test.wav",
+        )
+        self.assertEqual(
+            fake_session.analysis_result["recorded_path"],
+            "audio_data/stored_data/OK/test.wav",
+        )
 
     def test_run_fixed_mic_session_analysis_only_runs_ai_for_auto_label(self):
         fake_session = SimpleNamespace(


### PR DESCRIPTION
## Summary
- release saved fixed-mic session clips from memory and reload them from disk for review and analysis views
- keep session metadata in sync after manual and AI label moves so saved sessions remain viewable after files move from not_labeled to OK/NG
- add focused regression tests for lazy loading, path fallback, and label-move path synchronization

## Test plan
- [x] Focused pytest run for fixed mic lazy loading, label moves, review loading, and analysis result flows
- [x] Manual fixed-mic memory regression check during 30-session capture
- [x] Manual verification that saved sessions remain viewable after marking to OK/NG