### PR TITLE
feat: add playback controls for recorded session lists

### DIFF
--- a/base/playback_controller.py
+++ b/base/playback_controller.py
@@ -1,0 +1,216 @@
+import os
+import threading
+import time
+
+import numpy as np
+
+from base.sound_device_manager import sd
+from consts import error_code
+
+
+class PlaybackController(object):
+    def __init__(self, monitor_interval_sec: float = 0.08):
+        self._playback_lock = threading.RLock()
+        self._playback_current_file = None
+        self._playback_is_running = False
+        self._playback_session_id = 0
+        self._playback_stream = None
+        self._monitor_interval_sec = float(monitor_interval_sec)
+
+    @staticmethod
+    def _close_stream_safely(stream):
+        if stream is None:
+            return
+        try:
+            if not getattr(stream, "closed", True):
+                stream.close(ignore_errors=True)
+        except Exception:
+            pass
+
+    @staticmethod
+    def _normalize_output_device(device=None):
+        if isinstance(device, dict):
+            return device.get("index")
+        return device
+
+    @staticmethod
+    def _load_playback_audio(file_path):
+        try:
+            import soundfile as sf
+
+            audio_data, sample_rate = sf.read(file_path, dtype="float32", always_2d=True)
+            return np.asarray(audio_data, dtype=np.float32), int(sample_rate)
+        except Exception:
+            import librosa
+
+            audio_data, sample_rate = librosa.load(file_path, sr=None, mono=False)
+            audio_data = np.asarray(audio_data, dtype=np.float32)
+            if audio_data.ndim == 1:
+                audio_data = audio_data.reshape(-1, 1)
+            elif audio_data.ndim == 2:
+                audio_data = audio_data.T
+            else:
+                raise RuntimeError("Unsupported audio shape")
+            return audio_data, int(sample_rate)
+
+    @staticmethod
+    def _get_output_device_info(device=None):
+        normalized_device = PlaybackController._normalize_output_device(device)
+        if normalized_device is None:
+            return sd.query_devices(kind="output")
+        return sd.query_devices(device=normalized_device)
+
+    @staticmethod
+    def _adapt_audio_to_output_channels(audio_data, max_output_channels):
+        audio_data = np.asarray(audio_data, dtype=np.float32)
+        if audio_data.ndim == 1:
+            audio_data = audio_data.reshape(-1, 1)
+
+        if max_output_channels is None or max_output_channels <= 0:
+            raise RuntimeError("Output device has no available playback channels.")
+
+        input_channels = audio_data.shape[1]
+        if input_channels <= max_output_channels:
+            return audio_data
+
+        if max_output_channels == 1:
+            return audio_data.mean(axis=1, keepdims=True, dtype=np.float32)
+
+        if max_output_channels == 2:
+            return audio_data[:, :2]
+
+        return audio_data[:, :max_output_channels]
+
+    def _reset_playback_state_if_session(self, session_id):
+        with self._playback_lock:
+            if session_id != self._playback_session_id:
+                return
+            stream = self._playback_stream
+            self._playback_current_file = None
+            self._playback_is_running = False
+            self._playback_stream = None
+
+        self._close_stream_safely(stream)
+
+    def _monitor_playback_done(self, session_id, stream):
+        while True:
+            with self._playback_lock:
+                if session_id != self._playback_session_id:
+                    return
+                if self._playback_stream is not stream:
+                    return
+
+            try:
+                stream_active = (not getattr(stream, "closed", True)) and bool(stream.active)
+            except Exception:
+                stream_active = False
+
+            if not stream_active:
+                self._reset_playback_state_if_session(session_id)
+                return
+
+            time.sleep(self._monitor_interval_sec)
+
+    def start_audio_playback(self, file_path: str, device=None):
+        if not file_path:
+            return error_code.INVALID_PATH, "Missing audio file path."
+
+        abs_path = os.path.abspath(file_path)
+        if not os.path.isfile(abs_path):
+            return error_code.INVALID_PATH, f"Audio file does not exist: {abs_path}"
+
+        try:
+            audio_data, sample_rate = self._load_playback_audio(abs_path)
+        except Exception as e:
+            return error_code.INVALID_FILE, f"Failed to decode audio: {str(e)[:80]}"
+
+        if audio_data.size == 0:
+            return error_code.INVALID_FILE, "Audio file is empty."
+
+        try:
+            normalized_device = self._normalize_output_device(device)
+            device_info = self._get_output_device_info(device)
+            max_output_channels = int(device_info.get("max_output_channels", 0))
+            audio_data = self._adapt_audio_to_output_channels(audio_data, max_output_channels)
+        except Exception as e:
+            return error_code.INVALID_PLAY, f"Failed to adapt playback channels: {str(e)[:80]}"
+
+        with self._playback_lock:
+            self._playback_session_id += 1
+            session_id = self._playback_session_id
+            self._playback_current_file = abs_path
+            self._playback_is_running = True
+            self._playback_stream = None
+
+        stream = None
+        try:
+            sd.play(audio_data, samplerate=sample_rate, device=normalized_device, blocking=False)
+            stream = sd.get_stream()
+        except Exception as e:
+            self._reset_playback_state_if_session(session_id)
+            return error_code.INVALID_PLAY, f"Failed to start playback: {str(e)[:80]}"
+
+        with self._playback_lock:
+            if session_id != self._playback_session_id:
+                self._close_stream_safely(stream)
+                return error_code.INVALID_PLAY, "Playback session was replaced."
+            self._playback_stream = stream
+
+        threading.Thread(target=self._monitor_playback_done, args=(session_id, stream), daemon=True).start()
+        return error_code.OK, "Audio playback started."
+
+    def stop_audio_playback(self):
+        with self._playback_lock:
+            self._playback_session_id += 1
+            was_running = bool(self._playback_is_running)
+            stream = self._playback_stream
+            self._playback_current_file = None
+            self._playback_is_running = False
+            self._playback_stream = None
+
+        stop_error = None
+        if stream is not None:
+            try:
+                if not getattr(stream, "closed", True) and bool(stream.active):
+                    stream.stop(ignore_errors=True)
+            except Exception as e:
+                stop_error = e
+
+            try:
+                if not getattr(stream, "closed", True):
+                    stream.close(ignore_errors=True)
+            except Exception as e:
+                if stop_error is None:
+                    stop_error = e
+
+        if stop_error is not None and was_running:
+            return error_code.INVALID_PLAY, f"Failed to stop playback: {str(stop_error)[:80]}"
+        if was_running:
+            return error_code.OK, "Audio playback stopped."
+        return error_code.INVALID_PLAY, "No active audio playback."
+
+    def is_audio_playing(self):
+        with self._playback_lock:
+            running = bool(self._playback_is_running)
+            stream = self._playback_stream
+            session_id = self._playback_session_id
+
+        if not running:
+            return False
+
+        if stream is None:
+            return True
+
+        try:
+            active = (not getattr(stream, "closed", True)) and bool(stream.active)
+        except Exception:
+            active = False
+
+        if not active:
+            self._reset_playback_state_if_session(session_id)
+            return False
+        return True
+
+    def get_current_playing_file(self):
+        with self._playback_lock:
+            return self._playback_current_file

--- a/ui/archive_audio_data_dialog.py
+++ b/ui/archive_audio_data_dialog.py
@@ -2,11 +2,13 @@ import os
 import sys
 from datetime import datetime
 
-from PyQt5.QtCore import Qt
+from PyQt5.QtCore import Qt, QTimer
+from PyQt5.QtGui import QStandardItem
 from PyQt5.QtWidgets import QPushButton, QProgressDialog, QMessageBox, QFileDialog, QApplication
 
 from base.file_ops import FileOps
 from base.log_manager import LogManager
+from base.playback_controller import PlaybackController
 from consts import error_code, model_consts
 from consts.running_consts import DEFAULT_DIR
 from ui.custom_ui_widget.audio_data_manage_dialog import audioDataManageDialog
@@ -15,15 +17,62 @@ from ui.custom_ui_widget.audio_data_manage_dialog import audioDataManageDialog
 class ArchiveAudioDataDialog(audioDataManageDialog):
 
     def __init__(self, logger: LogManager):
+        self._play_col = 6
+        self._play_text = "播放"
+        self._stop_text = "停止"
+        self._current_playing_row = None
+        self._current_playing_file = None
+        self.playback_controller = PlaybackController()
+        self._playback_poll_timer = None
         super(ArchiveAudioDataDialog, self).__init__(logger)
+        self._playback_poll_timer = QTimer(self)
+        self._playback_poll_timer.setInterval(150)
+        self._playback_poll_timer.timeout.connect(self._on_playback_poll_timeout)
+        self.data_view.clicked.connect(self._on_data_view_clicked)
         self.package_btn = QPushButton(" 打  包 ")
         self.delete_btn = QPushButton(" 删  除 ")
         self.init_ui()
+
+    def get_table_column_count(self):
+        return 8
+
+    def get_header_labels(self):
+        return ["", "文件名称", "产品型号", "音频标签", "采样率", "录音时间", "播放", "激励信号"]
 
     def init_ui(self):
         self.setWindowTitle("音频数据管理")
 
         self.set_bottom_layout()
+
+    def load_audio_data_to_view(self):
+        self._stop_playback_if_needed()
+        super().load_audio_data_to_view()
+        self._rebuild_play_cells()
+
+    def show_all_wave(self):
+        self._stop_playback_if_needed()
+        super().show_all_wave()
+        self._rebuild_play_cells()
+
+    def load_audio_data_to_model(self, audio_data, stimulus_name):
+        self.setRowCount(0)
+        if not audio_data:
+            return set(), set()
+
+        product_model_set = set()
+        record_date_set = set()
+        for item in audio_data:
+            product_model_set.add(item[2])
+            record_date_set.add(item[4])
+
+            file_name = item[1].split("/")[-1]
+            row_stimulus_name = stimulus_name.get(item[7], "无激励信号")
+            row_data_list = [None, file_name, item[2], item[5], item[3], item[4], self._play_text, row_stimulus_name]
+            self.add_row_data(row_data_list)
+
+        self.resizeColumnsToContents()
+        self.resizeRowsToContents()
+        return product_model_set, record_date_set
 
     def set_bottom_layout(self):
         all_show_btn = QPushButton("全部显示")
@@ -37,7 +86,106 @@ class ArchiveAudioDataDialog(audioDataManageDialog):
         self.bottom_layout.addWidget(self.package_btn)
         self.bottom_layout.addWidget(self.delete_btn)
 
+    def _resolve_row_file_path(self, row):
+        audio_data = self.filter_audio_data if self.is_filter_flag else self.all_audio_data
+        if row < 0 or row >= len(audio_data):
+            return None
+
+        raw_path = audio_data[row][1]
+        if not raw_path:
+            return None
+        if os.path.isabs(raw_path):
+            return os.path.abspath(raw_path)
+        return os.path.abspath(os.path.join(DEFAULT_DIR, raw_path))
+
+    def _rebuild_play_cells(self):
+        model = self.model()
+        if model is None or model.columnCount() <= self._play_col:
+            return
+
+        for row in range(model.rowCount()):
+            item = model.item(row, self._play_col)
+            if item is None:
+                item = QStandardItem()
+                model.setItem(row, self._play_col, item)
+            item.setEditable(False)
+            item.setTextAlignment(Qt.AlignCenter)
+        self._refresh_play_cell_states()
+
+    def _refresh_play_cell_states(self):
+        model = self.model()
+        if model is None or model.columnCount() <= self._play_col:
+            return
+
+        is_playing = self.playback_controller.is_audio_playing()
+        for row in range(model.rowCount()):
+            item = model.item(row, self._play_col)
+            if item is None:
+                item = QStandardItem()
+                model.setItem(row, self._play_col, item)
+            item.setText(self._stop_text if is_playing and row == self._current_playing_row else self._play_text)
+            item.setTextAlignment(Qt.AlignCenter)
+
+    def _clear_playing_state(self):
+        self._current_playing_row = None
+        self._current_playing_file = None
+        if self._playback_poll_timer is not None:
+            self._playback_poll_timer.stop()
+        self._refresh_play_cell_states()
+
+    def _stop_playback_if_needed(self):
+        if self.playback_controller.is_audio_playing() or self._current_playing_row is not None:
+            self.playback_controller.stop_audio_playback()
+        self._clear_playing_state()
+
+    def _on_data_view_clicked(self, index):
+        if not index.isValid() or index.column() != self._play_col:
+            return
+        self._toggle_row_playback(index.row())
+
+    def _toggle_row_playback(self, row):
+        row_path = self._resolve_row_file_path(row)
+        if not row_path:
+            QMessageBox.warning(self, "提示", "未找到该行对应音频文件路径")
+            self._clear_playing_state()
+            return
+
+        if self.playback_controller.is_audio_playing() and row == self._current_playing_row:
+            self.playback_controller.stop_audio_playback()
+            self._clear_playing_state()
+            return
+
+        if self.playback_controller.is_audio_playing():
+            self.playback_controller.stop_audio_playback()
+            self._clear_playing_state()
+
+        code, msg = self.playback_controller.start_audio_playback(row_path)
+        if code != error_code.OK:
+            QMessageBox.warning(self, "提示", msg)
+            self._clear_playing_state()
+            return
+
+        self._current_playing_row = row
+        self._current_playing_file = row_path
+        self._refresh_play_cell_states()
+        if self._playback_poll_timer is not None and not self._playback_poll_timer.isActive():
+            self._playback_poll_timer.start()
+
+    def _on_playback_poll_timeout(self):
+        if not self.playback_controller.is_audio_playing():
+            self._clear_playing_state()
+            return
+
+        playing_file = self.playback_controller.get_current_playing_file()
+        if not playing_file or not self._current_playing_file:
+            self._clear_playing_state()
+            return
+
+        if os.path.abspath(playing_file) != os.path.abspath(self._current_playing_file):
+            self._clear_playing_state()
+
     def on_clicked_package_btn(self):
+        self._stop_playback_if_needed()
         if not self.select_wave_data:
             msg_box = QMessageBox(self)
             msg_box.setWindowTitle("提示")
@@ -78,10 +226,18 @@ class ArchiveAudioDataDialog(audioDataManageDialog):
         self.packaging_progress = None
 
     def on_clicked_delete_btn(self):
+        current_file = self.playback_controller.get_current_playing_file()
+        if current_file and self.select_wave_data:
+            self._stop_playback_if_needed()
+
         is_delete_item_list = list()
         will_delete_in_db_list = list()
         for key, value in self.select_wave_data.items():
-            file_path = DEFAULT_DIR + value[1]
+            raw_path = value[1]
+            if os.path.isabs(raw_path):
+                file_path = os.path.abspath(raw_path)
+            else:
+                file_path = os.path.abspath(os.path.join(DEFAULT_DIR, raw_path))
             if os.path.isfile(file_path):
                 try:
                     os.remove(file_path)
@@ -102,6 +258,15 @@ class ArchiveAudioDataDialog(audioDataManageDialog):
         self.delete_audio_data_with_id(will_delete_in_db_list)
         self.set_select_wave_num_text(0)
         self.update_filter_sets_after_deletion()
+        self._rebuild_play_cells()
+
+    def closeEvent(self, event):
+        self._stop_playback_if_needed()
+        super().closeEvent(event)
+
+    def reject(self):
+        self._stop_playback_if_needed()
+        super().reject()
 
 
 if __name__ == "__main__":

--- a/ui/custom_ui_widget/audio_data_manage_dialog.py
+++ b/ui/custom_ui_widget/audio_data_manage_dialog.py
@@ -63,7 +63,7 @@ class audioDataManageDialog(DataManageDialog):
 
         self.all_selected_checkbox = QCheckBox("全选")
 
-        self.init_ui_layout(0, 7, [])
+        self.init_ui_layout(0, self.get_table_column_count(), [])
 
         self.set_view_checked_changed(self.on_row_checkbox_toggled)
 
@@ -71,7 +71,7 @@ class audioDataManageDialog(DataManageDialog):
 
     def init_base_ui(self):
         self.set_checkable_of_column([0])
-        self.set_h_header(["", "文件名称", "产品型号", "音频标签", "采样率", "录音时间", "激励信号"])
+        self.set_h_header(self.get_header_labels())
         self.verticalHeader().setVisible(False)
 
         self.set_top_layout()
@@ -79,6 +79,12 @@ class audioDataManageDialog(DataManageDialog):
         self.load_all_audio_data()
         self.load_audio_data_to_view()
         self.set_select_wave_num_text(0)
+
+    def get_table_column_count(self):
+        return 7
+
+    def get_header_labels(self):
+        return ["", "文件名称", "产品型号", "音频标签", "采样率", "录音时间", "激励信号"]
 
     def set_top_layout(self):
         filter_btn = QPushButton(" 筛  选 ")
@@ -251,6 +257,7 @@ class FilterAudioDialog(QDialog):
         self.filter_sample_rate_num = 0
         self.filter_label_num = 0
         self.sample_rate_filter_layout = QHBoxLayout()
+        self.sample_rate_layout_adjusted = False
 
         self.is_clicked_ok = False
 
@@ -361,9 +368,12 @@ class FilterAudioDialog(QDialog):
         if is_hide:
             self.select_not_label_check_box.hide()
             self.select_not_label_check_box.setChecked(False)
-        else:
+        elif not self.sample_rate_layout_adjusted:
             self.sample_rate_filter_layout.addSpacing(10)
             self.sample_rate_filter_layout.addStretch(1)
+            self.sample_rate_layout_adjusted = True
+            self.select_not_label_check_box.show()
+        else:
             self.select_not_label_check_box.show()
 
     def create_product_model_filter_groupbox(self):

--- a/ui/sequence/fixed_mic/session_table_panel.py
+++ b/ui/sequence/fixed_mic/session_table_panel.py
@@ -1,6 +1,7 @@
+import os
 from datetime import timedelta
 
-from PyQt5.QtCore import QSize, Qt
+from PyQt5.QtCore import QSize, Qt, QTimer
 from PyQt5.QtGui import QColor, QFont, QIcon, QPainter, QPen, QPixmap
 from PyQt5.QtWidgets import (
     QAbstractItemView,
@@ -12,7 +13,12 @@ from PyQt5.QtWidgets import (
     QToolButton,
     QVBoxLayout,
     QWidget,
+    QMessageBox,
 )
+
+from base.playback_controller import PlaybackController
+from consts import error_code
+from consts.running_consts import DEFAULT_DIR
 
 
 class FixedMicSessionTablePanel(QWidget):
@@ -22,15 +28,21 @@ class FixedMicSessionTablePanel(QWidget):
         self.session_rows = {}
         self.session_store = {}
         self.session_table = None
+        self.playback_controller = PlaybackController()
+        self._playback_poll_timer = QTimer(self)
+        self._playback_poll_timer.setInterval(150)
+        self._playback_poll_timer.timeout.connect(self._on_playback_poll_timeout)
+        self._current_playing_session_id = None
+        self._current_playing_file = None
         self.init_ui()
 
     def init_ui(self):
         group_box = QGroupBox("会话列表")
         group_layout = QVBoxLayout()
 
-        self.session_table = QTableWidget(0, 8)
+        self.session_table = QTableWidget(0, 9)
         self.session_table.setHorizontalHeaderLabels(
-            ["会话", "触发时间", "截止时间", "音频时长", "条码", "进度", "结果", "分析"]
+            ["会话", "触发时间", "截止时间", "音频时长", "条码", "进度", "结果", "播放", "分析"]
         )
         self.session_table.verticalHeader().setVisible(False)
         self.session_table.verticalHeader().setDefaultSectionSize(34)
@@ -59,11 +71,13 @@ class FixedMicSessionTablePanel(QWidget):
         header.setSectionResizeMode(5, QHeaderView.Stretch)
         header.setSectionResizeMode(6, QHeaderView.Stretch)
         header.setSectionResizeMode(7, QHeaderView.Fixed)
+        header.setSectionResizeMode(8, QHeaderView.Fixed)
         self.session_table.setColumnWidth(0, 56)
         self.session_table.setColumnWidth(1, 92)
         self.session_table.setColumnWidth(2, 92)
         self.session_table.setColumnWidth(3, 86)
-        self.session_table.setColumnWidth(7, 84)
+        self.session_table.setColumnWidth(7, 72)
+        self.session_table.setColumnWidth(8, 84)
 
         group_layout.addWidget(self.session_table)
         group_box.setLayout(group_layout)
@@ -75,6 +89,7 @@ class FixedMicSessionTablePanel(QWidget):
         self.setLayout(layout)
 
     def reset_sessions(self):
+        self._stop_playback_if_needed()
         self.session_rows = {}
         self.session_store = {}
         if self.session_table is not None:
@@ -110,7 +125,9 @@ class FixedMicSessionTablePanel(QWidget):
             if col == 4:
                 item.setToolTip(str(value))
             self.session_table.setItem(row, col, item)
-        self.session_table.setCellWidget(row, 7, self.create_view_cell(session.session_id))
+        self.session_table.setCellWidget(row, 7, self.create_play_cell(session.session_id))
+        self.session_table.setCellWidget(row, 8, self.create_view_cell(session.session_id))
+        self._refresh_play_button_for_session(session.session_id)
         self.session_table.scrollToBottom()
 
     def update_session_status(self, session, status_text):
@@ -129,6 +146,7 @@ class FixedMicSessionTablePanel(QWidget):
             self.session_table.setItem(row, 5, item)
         else:
             item.setText(status_text)
+        self._refresh_play_button_for_session(session.session_id)
 
     def update_session_result(self, session, result_label):
         if session is None:
@@ -149,6 +167,7 @@ class FixedMicSessionTablePanel(QWidget):
             self.session_table.setItem(row, 6, item)
         else:
             item.setText(normalized_label)
+        self._refresh_play_button_for_session(session.session_id)
 
     def refresh_session_timing(self, row, session):
         if session is None or row is None:
@@ -184,6 +203,35 @@ class FixedMicSessionTablePanel(QWidget):
 
     def get_session(self, session_id):
         return self.session_store.get(session_id)
+
+    def create_play_button(self, session_id):
+        play_btn = QToolButton()
+        play_btn.setText("播放")
+        play_btn.setFixedSize(46, 24)
+        play_btn.setAutoRaise(False)
+        play_btn.setStyleSheet(
+            """
+            QToolButton {
+                border: 1px solid rgba(120, 120, 120, 0.25);
+                background-color: rgba(120, 120, 120, 0.04);
+                border-radius: 3px;
+                padding: 0px 6px;
+            }
+            QToolButton:hover:enabled {
+                background-color: rgba(120, 120, 120, 0.08);
+            }
+            QToolButton:pressed:enabled {
+                background-color: rgba(120, 120, 120, 0.12);
+            }
+            QToolButton:disabled {
+                color: rgb(160, 160, 160);
+                border-color: rgba(160, 160, 160, 0.2);
+                background-color: rgba(120, 120, 120, 0.02);
+            }
+            """
+        )
+        play_btn.clicked.connect(lambda: self._on_play_button_clicked(session_id))
+        return play_btn
 
     def create_view_button(self, session_id):
         view_btn = QToolButton()
@@ -227,6 +275,120 @@ class FixedMicSessionTablePanel(QWidget):
         cell_layout.addStretch()
         cell_widget.setLayout(cell_layout)
         return cell_widget
+
+    def create_play_cell(self, session_id):
+        cell_widget = QWidget()
+        cell_layout = QHBoxLayout()
+        cell_layout.setContentsMargins(0, 0, 0, 0)
+        cell_layout.setSpacing(0)
+        cell_layout.addStretch()
+        cell_layout.addWidget(self.create_play_button(session_id), alignment=Qt.AlignCenter)
+        cell_layout.addStretch()
+        cell_widget.setLayout(cell_layout)
+        return cell_widget
+
+    def _resolve_session_playback_path(self, session):
+        if session is None:
+            return None
+        metadata = getattr(session, "metadata", {}) or {}
+        candidate_paths = [metadata.get("recorded_path"), (metadata.get("recorded_signal_info", {}) or {}).get("file_path")]
+        for candidate in candidate_paths:
+            if not candidate:
+                continue
+            normalized_candidate = candidate
+            if not os.path.isabs(normalized_candidate):
+                normalized_candidate = os.path.join(DEFAULT_DIR, normalized_candidate).replace("\\", "/")
+            normalized_candidate = os.path.abspath(normalized_candidate)
+            if os.path.isfile(normalized_candidate):
+                return normalized_candidate
+        return None
+
+    @staticmethod
+    def _get_cell_center_widget(table, row, column):
+        cell_widget = table.cellWidget(row, column)
+        if cell_widget is None or cell_widget.layout() is None or cell_widget.layout().count() < 2:
+            return None
+        item = cell_widget.layout().itemAt(1)
+        return item.widget() if item is not None else None
+
+    def _refresh_play_button_for_session(self, session_id):
+        row = self.session_rows.get(session_id)
+        if row is None or self.session_table is None:
+            return
+        play_btn = self._get_cell_center_widget(self.session_table, row, 7)
+        if play_btn is None:
+            return
+
+        session = self.get_session(session_id)
+        playback_path = self._resolve_session_playback_path(session)
+        is_current = session_id == self._current_playing_session_id and self.playback_controller.is_audio_playing()
+
+        play_btn.setEnabled(playback_path is not None)
+        play_btn.setText("停止" if is_current else "播放")
+        if playback_path is None:
+            play_btn.setToolTip("当前会话尚未保存音频，暂不可播放")
+        else:
+            play_btn.setToolTip(playback_path)
+
+    def _refresh_all_play_buttons(self):
+        for session_id in list(self.session_rows.keys()):
+            self._refresh_play_button_for_session(session_id)
+
+    def _clear_playing_state(self):
+        self._current_playing_session_id = None
+        self._current_playing_file = None
+        self._playback_poll_timer.stop()
+        self._refresh_all_play_buttons()
+
+    def _stop_playback_if_needed(self):
+        if self.playback_controller.is_audio_playing() or self._current_playing_session_id is not None:
+            self.playback_controller.stop_audio_playback()
+        self._clear_playing_state()
+
+    def _on_play_button_clicked(self, session_id):
+        session = self.get_session(session_id)
+        playback_path = self._resolve_session_playback_path(session)
+        if not playback_path:
+            self._refresh_play_button_for_session(session_id)
+            return
+
+        if self.playback_controller.is_audio_playing() and session_id == self._current_playing_session_id:
+            self.playback_controller.stop_audio_playback()
+            self._clear_playing_state()
+            return
+
+        if self.playback_controller.is_audio_playing():
+            self.playback_controller.stop_audio_playback()
+            self._clear_playing_state()
+
+        code, msg = self.playback_controller.start_audio_playback(playback_path)
+        if code != error_code.OK:
+            QMessageBox.warning(self, "提示", msg)
+            self._clear_playing_state()
+            return
+
+        self._current_playing_session_id = session_id
+        self._current_playing_file = playback_path
+        self._refresh_all_play_buttons()
+        if not self._playback_poll_timer.isActive():
+            self._playback_poll_timer.start()
+
+    def _on_playback_poll_timeout(self):
+        if not self.playback_controller.is_audio_playing():
+            self._clear_playing_state()
+            return
+
+        playing_file = self.playback_controller.get_current_playing_file()
+        if not playing_file or not self._current_playing_file:
+            self._clear_playing_state()
+            return
+
+        if os.path.abspath(playing_file) != os.path.abspath(self._current_playing_file):
+            self._clear_playing_state()
+
+    def closeEvent(self, event):
+        self._stop_playback_if_needed()
+        super(FixedMicSessionTablePanel, self).closeEvent(event)
 
     @staticmethod
     def make_table_item(text, session_id=None):

--- a/unit_test/base/test_playback_controller.py
+++ b/unit_test/base/test_playback_controller.py
@@ -1,0 +1,152 @@
+import mock
+import numpy as np
+
+from consts import error_code
+
+
+class FakeStream(object):
+    def __init__(self, active=True, closed=False):
+        self.active = active
+        self.closed = closed
+        self.stop_called = False
+        self.close_called = False
+
+    def stop(self, ignore_errors=True):
+        self.stop_called = True
+        self.active = False
+
+    def close(self, ignore_errors=True):
+        self.close_called = True
+        self.closed = True
+
+
+class TestPlaybackController(object):
+    @mock.patch("base.playback_controller.os.path.isfile")
+    def test_start_audio_playback_returns_invalid_path_when_file_missing(self, mock_isfile):
+        from base.playback_controller import PlaybackController
+
+        mock_isfile.return_value = False
+
+        result = PlaybackController().start_audio_playback("missing.wav")
+
+        assert result[0] == error_code.INVALID_PATH
+
+    @mock.patch("base.playback_controller.threading.Thread")
+    @mock.patch("base.playback_controller.sd.get_stream")
+    @mock.patch("base.playback_controller.sd.play")
+    @mock.patch("base.playback_controller.sd.query_devices")
+    @mock.patch("base.playback_controller.os.path.isfile")
+    def test_start_audio_playback_sets_playback_state(
+        self,
+        mock_isfile,
+        mock_query_devices,
+        mock_play,
+        mock_get_stream,
+        mock_thread,
+    ):
+        from base.playback_controller import PlaybackController
+
+        mock_isfile.return_value = True
+        mock_query_devices.return_value = {"max_output_channels": 2}
+        fake_stream = FakeStream(active=True, closed=False)
+        mock_get_stream.return_value = fake_stream
+        mock_thread.return_value = mock.Mock()
+        controller = PlaybackController()
+        controller._load_playback_audio = mock.Mock(return_value=(np.ones((4, 1), dtype=np.float32), 44100))
+
+        result = controller.start_audio_playback("exists.wav")
+
+        assert result == (error_code.OK, "Audio playback started.")
+        assert controller.is_audio_playing() is True
+        assert controller.get_current_playing_file().endswith("exists.wav")
+        mock_play.assert_called_once()
+
+    @mock.patch("base.playback_controller.threading.Thread")
+    @mock.patch("base.playback_controller.sd.get_stream")
+    @mock.patch("base.playback_controller.sd.play")
+    @mock.patch("base.playback_controller.sd.query_devices")
+    @mock.patch("base.playback_controller.os.path.isfile")
+    def test_start_audio_playback_downmixes_multichannel_audio_for_stereo_output(
+        self,
+        mock_isfile,
+        mock_query_devices,
+        mock_play,
+        mock_get_stream,
+        mock_thread,
+    ):
+        from base.playback_controller import PlaybackController
+
+        mock_isfile.return_value = True
+        mock_query_devices.return_value = {"max_output_channels": 2}
+        mock_get_stream.return_value = FakeStream(active=True, closed=False)
+        mock_thread.return_value = mock.Mock()
+        controller = PlaybackController()
+        controller._load_playback_audio = mock.Mock(
+            return_value=(np.arange(24, dtype=np.float32).reshape(6, 4), 44100)
+        )
+
+        result = controller.start_audio_playback("exists.wav")
+
+        assert result == (error_code.OK, "Audio playback started.")
+        play_data = mock_play.call_args[0][0]
+        assert play_data.shape == (6, 2)
+
+    @mock.patch("base.playback_controller.threading.Thread")
+    @mock.patch("base.playback_controller.sd.get_stream")
+    @mock.patch("base.playback_controller.sd.play")
+    @mock.patch("base.playback_controller.sd.query_devices")
+    @mock.patch("base.playback_controller.os.path.isfile")
+    def test_start_audio_playback_downmixes_to_mono_for_single_channel_output(
+        self,
+        mock_isfile,
+        mock_query_devices,
+        mock_play,
+        mock_get_stream,
+        mock_thread,
+    ):
+        from base.playback_controller import PlaybackController
+
+        mock_isfile.return_value = True
+        mock_query_devices.return_value = {"max_output_channels": 1}
+        mock_get_stream.return_value = FakeStream(active=True, closed=False)
+        mock_thread.return_value = mock.Mock()
+        controller = PlaybackController()
+        controller._load_playback_audio = mock.Mock(
+            return_value=(np.arange(24, dtype=np.float32).reshape(6, 4), 44100)
+        )
+
+        result = controller.start_audio_playback("exists.wav")
+
+        assert result == (error_code.OK, "Audio playback started.")
+        play_data = mock_play.call_args[0][0]
+        assert play_data.shape == (6, 1)
+
+    @mock.patch("base.playback_controller.os.path.isfile")
+    def test_stop_audio_playback_stops_stream_and_clears_state(self, mock_isfile):
+        from base.playback_controller import PlaybackController
+
+        mock_isfile.return_value = True
+        controller = PlaybackController()
+        controller._load_playback_audio = mock.Mock(return_value=(np.ones((4, 1), dtype=np.float32), 44100))
+        controller._playback_is_running = True
+        controller._playback_current_file = "exists.wav"
+        controller._playback_stream = FakeStream(active=True, closed=False)
+
+        result = controller.stop_audio_playback()
+
+        assert result == (error_code.OK, "Audio playback stopped.")
+        assert controller.is_audio_playing() is False
+        assert controller.get_current_playing_file() is None
+
+    def test_is_audio_playing_resets_state_when_stream_inactive(self):
+        from base.playback_controller import PlaybackController
+
+        controller = PlaybackController()
+        controller._playback_is_running = True
+        controller._playback_current_file = "exists.wav"
+        controller._playback_stream = FakeStream(active=False, closed=False)
+
+        result = controller.is_audio_playing()
+
+        assert result is False
+        assert controller.get_current_playing_file() is None

--- a/unit_test/ui/test_fixed_mic_concurrent.py
+++ b/unit_test/ui/test_fixed_mic_concurrent.py
@@ -773,7 +773,7 @@ class TestFixedMicConcurrent(unittest.TestCase):
             trigger_time=datetime(2026, 3, 19, 10, 55, 58),
             vehicle_barcode="BARCODE_001",
             window_duration=3.0,
-            metadata={},
+            metadata={"recorded_path": "test.wav"},
         )
         panel = FixedMicSessionTablePanel(on_view_session=lambda _session_id: None)
         fake_window = SimpleNamespace(
@@ -787,7 +787,69 @@ class TestFixedMicConcurrent(unittest.TestCase):
         self.assertEqual(panel.session_table.item(0, 3).text(), "3.00s")
         self.assertEqual(panel.session_table.item(0, 5).text(), "采集中")
         self.assertEqual(panel.session_table.item(0, 6).text(), "not_labeled")
+        self.assertEqual(panel.session_table.columnCount(), 9)
+        self.assertEqual(panel.session_table.horizontalHeaderItem(7).text(), "播放")
+        self.assertEqual(panel.session_table.horizontalHeaderItem(8).text(), "分析")
         self.assertIsNotNone(panel.session_table.cellWidget(0, 7))
+        self.assertIsNotNone(panel.session_table.cellWidget(0, 8))
+
+    def test_register_fixed_mic_session_disables_play_button_when_session_has_no_saved_audio(self):
+        fake_session = SimpleNamespace(
+            session_id="fixed_mic_session_001",
+            trigger_time=datetime(2026, 3, 19, 10, 55, 58),
+            vehicle_barcode="BARCODE_001",
+            window_duration=3.0,
+            metadata={},
+        )
+        panel = FixedMicSessionTablePanel(on_view_session=lambda _session_id: None)
+
+        panel.register_session(fake_session, status_text="采集中")
+
+        play_cell = panel.session_table.cellWidget(0, 7)
+        play_button = play_cell.layout().itemAt(1).widget()
+        self.assertFalse(play_button.isEnabled())
+
+    def test_fixed_mic_play_button_switches_playback_between_saved_sessions(self):
+        panel = FixedMicSessionTablePanel(on_view_session=lambda _session_id: None)
+        session_a = SimpleNamespace(
+            session_id="fixed_mic_session_001",
+            trigger_time=datetime(2026, 3, 19, 10, 55, 58),
+            vehicle_barcode="BARCODE_001",
+            window_duration=3.0,
+            metadata={"recorded_path": "a.wav"},
+        )
+        session_b = SimpleNamespace(
+            session_id="fixed_mic_session_002",
+            trigger_time=datetime(2026, 3, 19, 10, 56, 10),
+            vehicle_barcode="BARCODE_002",
+            window_duration=3.0,
+            metadata={"recorded_path": "b.wav"},
+        )
+        panel.register_session(session_a, status_text="已保存")
+        panel.register_session(session_b, status_text="已保存")
+        playback_state = {"playing": False}
+
+        def _start_audio_playback(_path):
+            playback_state["playing"] = True
+            return error_code.OK, "Audio playback started."
+
+        def _stop_audio_playback():
+            playback_state["playing"] = False
+            return error_code.OK, "Audio playback stopped."
+
+        panel.playback_controller = SimpleNamespace(
+            is_audio_playing=mock.Mock(side_effect=lambda: playback_state["playing"]),
+            start_audio_playback=mock.Mock(side_effect=_start_audio_playback),
+            stop_audio_playback=mock.Mock(side_effect=_stop_audio_playback),
+            get_current_playing_file=mock.Mock(return_value=None),
+        )
+
+        with mock.patch("ui.sequence.fixed_mic.session_table_panel.os.path.isfile", return_value=True):
+            panel._on_play_button_clicked(session_a.session_id)
+            panel._on_play_button_clicked(session_b.session_id)
+
+        self.assertEqual(panel.playback_controller.start_audio_playback.call_count, 2)
+        panel.playback_controller.stop_audio_playback.assert_called_once()
 
     def test_update_fixed_mic_session_result_updates_result_column(self):
         fake_session = SimpleNamespace(


### PR DESCRIPTION
## Summary
- add reusable playback control for archived audio rows and fixed-mic session rows
- support stereo-safe playback by adapting multi-channel recordings to the active output device
- cover the new playback controller and fixed-mic table behavior with targeted tests

## Test plan
- [x] python -m pytest "unit_test/base/test_playback_controller.py" -q
- [x] python -m pytest "unit_test/ui/test_fixed_mic_concurrent.py::TestFixedMicConcurrent::test_register_fixed_mic_session_populates_result_column_and_view_button" "unit_test/ui/test_fixed_mic_concurrent.py::TestFixedMicConcurrent::test_register_fixed_mic_session_disables_play_button_when_session_has_no_saved_audio" "unit_test/ui/test_fixed_mic_concurrent.py::TestFixedMicConcurrent::test_fixed_mic_play_button_switches_playback_between_saved_sessions" -q
- [x] python -m py_compile "base/playback_controller.py" "ui/archive_audio_data_dialog.py" "ui/custom_ui_widget/audio_data_manage_dialog.py" "ui/sequence/fixed_mic/session_table_panel.py" "unit_test/base/test_playback_controller.py" "unit_test/ui/test_fixed_mic_concurrent.py"
- [ ] manual UI verification on saved audio rows and fixed-mic session rows

Made with [Cursor](https://cursor.com)