### PR TITLE
fix(fixed-mic): stabilize channel-routed session workflow

### DIFF
--- a/base/fixed_mic_capture.py
+++ b/base/fixed_mic_capture.py
@@ -101,6 +101,14 @@ class FixedMicCaptureController(object):
                 break
 
     def create_manual_session(self, vehicle_barcode=None):
+        trigger_payload = self.trigger_adapter.build_manual_trigger_payload(vehicle_barcode)
+        return self._create_session(trigger_payload)
+
+    def create_hotkey_session(self, channel_index, vehicle_barcode=None):
+        trigger_payload = self.trigger_adapter.build_hotkey_trigger_payload(channel_index, vehicle_barcode)
+        return self._create_session(trigger_payload)
+
+    def _create_session(self, trigger_payload):
         if not self.is_running:
             return error_code.INVALID_RECORD, "Fixed mic capture is not running.", None
 
@@ -108,7 +116,10 @@ class FixedMicCaptureController(object):
             if len(self._active_sessions) >= self.max_sessions:
                 return error_code.INVALID_ADD, "Maximum active fixed mic sessions reached.", None
 
-            trigger_payload = self.trigger_adapter.build_manual_trigger_payload(vehicle_barcode)
+            selected_channel = trigger_payload.get("selected_channel")
+            if selected_channel is not None and not 1 <= int(selected_channel) <= self.channels:
+                return error_code.INVALID_ADD, "Selected fixed mic channel is out of range.", None
+
             trigger_sample_index = self._total_callback_samples
             self._session_counter += 1
             session_id = "fixed_mic_session_%03d" % self._session_counter
@@ -126,7 +137,11 @@ class FixedMicCaptureController(object):
                 metadata={
                     "sample_rate": self.sample_rate,
                     "channels": self.channels,
+                    "selected_channel": selected_channel,
                 },
+                selected_channel=selected_channel,
+                source_channel_count=self.channels,
+                effective_channel_count=self.channels,
             )
             session.mark_capturing()
             self._active_sessions[session_id] = session
@@ -215,6 +230,15 @@ class FixedMicCaptureController(object):
             )
             return
 
+        audio_clip = self._select_session_audio_clip(audio_clip, session)
+        if audio_clip is None:
+            session.cancel("selected fixed mic channel is invalid")
+            self._cancelled_sessions.append(session)
+            self.default_logger.warning(
+                "Fixed mic session selected channel is invalid: %s", session.to_summary()
+            )
+            return
+
         session.freeze_audio_clip(audio_clip)
         self._captured_sessions.append(session)
         self.default_logger.info(
@@ -222,6 +246,20 @@ class FixedMicCaptureController(object):
             session.session_id,
             session.metadata.get("audio_clip_shape"),
         )
+
+    def _select_session_audio_clip(self, audio_clip, session):
+        selected_channel = getattr(session, "selected_channel", None)
+        if selected_channel is None:
+            return audio_clip
+
+        normalized_audio = np.asarray(audio_clip, dtype=np.float32)
+        if normalized_audio.ndim == 1:
+            normalized_audio = normalized_audio.reshape(-1, 1)
+
+        channel_index = int(selected_channel) - 1
+        if channel_index < 0 or channel_index >= normalized_audio.shape[1]:
+            return None
+        return normalized_audio[:, channel_index : channel_index + 1].copy()
 
     def _audio_callback(self, indata, frames, time_info, status):
         if status:

--- a/base/fixed_mic_capture_runtime.py
+++ b/base/fixed_mic_capture_runtime.py
@@ -24,6 +24,9 @@ class FixedMicSession(object):
         capture_end_sample,
         window_duration,
         metadata=None,
+        selected_channel=None,
+        source_channel_count=None,
+        effective_channel_count=None,
     ):
         self.session_id = session_id
         self.vehicle_barcode = vehicle_barcode
@@ -37,6 +40,9 @@ class FixedMicSession(object):
         self.audio_clip = None
         self.analysis_result = None
         self.metadata = metadata if metadata is not None else {}
+        self.selected_channel = selected_channel
+        self.source_channel_count = source_channel_count
+        self.effective_channel_count = effective_channel_count
         self.created_at = datetime.now()
         self.completed_at = None
 
@@ -52,9 +58,16 @@ class FixedMicSession(object):
             self.audio_clip = None
             return
         self.audio_clip = np.asarray(audio_clip, dtype=np.float32).copy()
+        if self.audio_clip.ndim == 1:
+            self.effective_channel_count = 1
+        else:
+            self.effective_channel_count = int(self.audio_clip.shape[1])
         self.status = FixedMicSessionStatus.FROZEN
         self.completed_at = datetime.now()
         self.metadata["audio_clip_shape"] = tuple(self.audio_clip.shape)
+        self.metadata["selected_channel"] = self.selected_channel
+        self.metadata["source_channel_count"] = self.source_channel_count
+        self.metadata["effective_channel_count"] = self.effective_channel_count
         if self.audio_clip.ndim == 1:
             self.metadata["audio_clip_samples"] = int(len(self.audio_clip))
         else:
@@ -79,6 +92,8 @@ class FixedMicSession(object):
             "capture_start_sample": self.capture_start_sample,
             "capture_end_sample": self.capture_end_sample,
             "has_audio_clip": self.audio_clip is not None,
+            "selected_channel": self.selected_channel,
+            "effective_channel_count": self.effective_channel_count,
         }
 
 
@@ -183,6 +198,14 @@ class FixedMicTriggerAdapter(object):
             "trigger_mode": "manual_click",
             "vehicle_barcode": vehicle_barcode,
             "trigger_time": datetime.now(),
+        }
+
+    def build_hotkey_trigger_payload(self, channel_index, vehicle_barcode=None):
+        return {
+            "trigger_mode": "hotkey_channel",
+            "vehicle_barcode": vehicle_barcode,
+            "trigger_time": datetime.now(),
+            "selected_channel": int(channel_index),
         }
 
     def on_grating_trigger(self, event):

--- a/base/load_config.py
+++ b/base/load_config.py
@@ -219,6 +219,15 @@ class LoadUiConfig(object):
                 }
             )
 
+        fixed_mic_hotkeys = []
+        for index in range(channel_count):
+            fixed_mic_hotkeys.append(
+                {
+                    "shortcut": f"Ctrl+{index + 1}",
+                    "channel_index": index + 1,
+                }
+            )
+
         return {
             "capture_mode": "fixed_mic_multi_session",
             "fixed_mic_mode_version": "basic_concurrent",
@@ -232,6 +241,7 @@ class LoadUiConfig(object):
             "save_all_channels": True,
             "grating_adapter_enabled": False,
             "fixed_mic_channels": fixed_mic_channels,
+            "fixed_mic_hotkeys": fixed_mic_hotkeys,
         }
 
     @staticmethod
@@ -241,8 +251,15 @@ class LoadUiConfig(object):
         if code == error_code.OK and isinstance(data, dict):
             merged_config = LoadUiConfig.get_default_fixed_mic_concurrent_config()
             merged_config.update(data)
+            needs_backfill = False
             if "fixed_mic_channels" in data:
                 merged_config["fixed_mic_channels"] = data["fixed_mic_channels"]
+            if "fixed_mic_hotkeys" in data:
+                merged_config["fixed_mic_hotkeys"] = data["fixed_mic_hotkeys"]
+            else:
+                needs_backfill = True
+            if needs_backfill:
+                LoadUiConfig.save_fixed_mic_concurrent_config(merged_config)
             return error_code.OK, merged_config
 
         default_config = LoadUiConfig.get_default_fixed_mic_concurrent_config()

--- a/base/model_config.py
+++ b/base/model_config.py
@@ -1,10 +1,14 @@
 import numpy as np
 
 from base.load_config import load_config
+from base.log_manager import LogManager
 from base.pre_processing.preprocessing_manager import PreprocessingManager
 from base.split_data_dir import copy_from_restored_audio_database
 from consts import error_code, model_consts
 from machine_learning import MODEL_MAPPING
+
+
+default_logger = LogManager.set_log_handler("core")
 
 def load_data_from_database():
     try:
@@ -47,5 +51,19 @@ def preprocess_raw_signals(raw_signals, fs, preprocess_config):
     processed_data = []
     pm = PreprocessingManager()
     for i in range(len(raw_signals)):
-        processed_data.append(pm.process(raw_signals[i], fs[i], **preprocess_config))
+        signal = np.asarray(raw_signals[i], dtype=np.float32)
+        original_shape = tuple(signal.shape)
+        squeezed_signal = np.squeeze(signal)
+        if squeezed_signal.ndim == 0:
+            signal = squeezed_signal.reshape(1)
+        elif squeezed_signal.ndim == 1:
+            signal = squeezed_signal
+        if tuple(signal.shape) != original_shape:
+            default_logger.info(
+                "预处理输入归一化: index=%s, original_shape=%s, normalized_shape=%s",
+                i,
+                original_shape,
+                tuple(signal.shape),
+            )
+        processed_data.append(pm.process(signal, fs[i], **preprocess_config))
     return np.array(processed_data)

--- a/base/session_finalize_pipeline.py
+++ b/base/session_finalize_pipeline.py
@@ -1,3 +1,5 @@
+import os
+
 from base.log_manager import LogManager
 from base.play_and_record import get_recorded_info
 from base.recording_management import RecordingManager
@@ -8,6 +10,20 @@ from consts import error_code
 class SessionFinalizePipeline(object):
     def __init__(self):
         self.default_logger = LogManager.set_log_handler("core")
+
+    @staticmethod
+    def apply_fixed_mic_channel_suffix(recorded_path, recorded_signal_info, session):
+        selected_channel = getattr(session, "selected_channel", None)
+        if not selected_channel:
+            return recorded_path, recorded_signal_info
+
+        base_path, ext = os.path.splitext(recorded_path)
+        suffixed_path = "%s_ch%s%s" % (base_path, selected_channel, ext or "")
+        updated_signal_info = recorded_signal_info.copy()
+        updated_signal_info["file_path"] = suffixed_path
+        updated_signal_info["selected_channel"] = selected_channel
+        updated_signal_info["effective_channel_count"] = getattr(session, "effective_channel_count", None)
+        return suffixed_path, updated_signal_info
 
     def save_fixed_mic_session(self, session, product_model, recorded_count):
         if session is None:
@@ -20,6 +36,11 @@ class SessionFinalizePipeline(object):
             recorded_count,
             session.vehicle_barcode,
             "not_labeled",
+        )
+        recorded_path, recorded_signal_info = self.apply_fixed_mic_channel_suffix(
+            recorded_path,
+            recorded_signal_info,
+            session,
         )
         sample_rate = session.metadata.get("sample_rate", 44100)
 

--- a/main_window.py
+++ b/main_window.py
@@ -19,11 +19,11 @@ from ui.display_window import DisplayWindow, save_display_config
 from ui.hardware_window import HardwareWindow
 from ui.login_window import AddAccountWindow, ChangePwdWindow, LoginWindow
 from ui.operation_sequence import AnalysisModelSelect
+from ui.sequence.fixed_mic.hotkey_bridge import handle_fixed_mic_native_hotkey
 from ui.sequence.sequence_widget import SequenceWindow
 
 
 class MainWindow(QMainWindow):
-
     def __init__(self):
         super().__init__()
         # set up statusbar object data
@@ -364,6 +364,13 @@ class MainWindow(QMainWindow):
             SequenceWindow.tcp_server = None
         self._close_display_window()
         event.accept()
+
+    def nativeEvent(self, eventType, message):
+        sequence_window = getattr(self, "sequence_window", None)
+        if sys.platform == "win32" and sequence_window is not None:
+            if handle_fixed_mic_native_hotkey(sequence_window, eventType, message):
+                return True, 1
+        return super().nativeEvent(eventType, message)
 
     def mousepressevent(self, event):
         # If the mouse is pressed, recoed mouse move data, start the window resizing

--- a/ui/acquisition_config_window.py
+++ b/ui/acquisition_config_window.py
@@ -404,6 +404,9 @@ class FixedMicConcurrentConfigWindow(BaseConfigWindow):
 
     def on_click_ok_btn(self):
         channel_rows = self.build_channel_rows_for_save(self.channels_spin.value())
+        preserved_hotkeys = self.input_data.get("fixed_mic_hotkeys")
+        if not isinstance(preserved_hotkeys, list) or not preserved_hotkeys:
+            preserved_hotkeys = LoadUiConfig.get_default_fixed_mic_concurrent_config().get("fixed_mic_hotkeys", [])
         config_data = {
             "capture_mode": "fixed_mic_multi_session",
             "fixed_mic_mode_version": "basic_concurrent",
@@ -417,6 +420,7 @@ class FixedMicConcurrentConfigWindow(BaseConfigWindow):
             "save_all_channels": self.save_all_channels_box.isChecked(),
             "grating_adapter_enabled": False,
             "fixed_mic_channels": channel_rows,
+            "fixed_mic_hotkeys": preserved_hotkeys,
         }
         LoadUiConfig.save_fixed_mic_concurrent_config(config_data)
         self.final_data = config_data

--- a/ui/sequence/fixed_mic/__init__.py
+++ b/ui/sequence/fixed_mic/__init__.py
@@ -1,9 +1,18 @@
 from ui.sequence.fixed_mic.session_table_panel import FixedMicSessionTablePanel
 from ui.sequence.fixed_mic.runtime_bridge import (
+    handle_fixed_mic_hotkey_trigger,
     handle_fixed_mic_manual_trigger,
     poll_fixed_mic_runtime,
     process_next_fixed_mic_analysis,
     stop_fixed_mic_runtime,
+)
+from ui.sequence.fixed_mic.hotkey_bridge import (
+    build_fixed_mic_hotkey_map,
+    handle_fixed_mic_windows_hotkey,
+    handle_fixed_mic_hotkey_trigger as dispatch_fixed_mic_hotkey_trigger,
+    install_fixed_mic_hotkeys,
+    set_fixed_mic_hotkeys_enabled,
+    uninstall_fixed_mic_hotkeys,
 )
 from ui.sequence.fixed_mic.analysis_bridge import (
     finalize_and_run_fixed_mic_session,
@@ -18,10 +27,17 @@ from ui.sequence.fixed_mic.analysis_bridge import (
 
 __all__ = [
     "FixedMicSessionTablePanel",
+    "build_fixed_mic_hotkey_map",
+    "handle_fixed_mic_windows_hotkey",
+    "dispatch_fixed_mic_hotkey_trigger",
+    "handle_fixed_mic_hotkey_trigger",
     "handle_fixed_mic_manual_trigger",
+    "install_fixed_mic_hotkeys",
     "poll_fixed_mic_runtime",
     "process_next_fixed_mic_analysis",
+    "set_fixed_mic_hotkeys_enabled",
     "stop_fixed_mic_runtime",
+    "uninstall_fixed_mic_hotkeys",
     "finalize_and_run_fixed_mic_session",
     "finalize_fixed_mic_session_analysis_result",
     "get_fixed_mic_ai_result_text",

--- a/ui/sequence/fixed_mic/analysis_bridge.py
+++ b/ui/sequence/fixed_mic/analysis_bridge.py
@@ -66,6 +66,59 @@ def load_fixed_mic_session_audio(session):
     return None
 
 
+def get_fixed_mic_session_channel_text(session):
+    if session is None:
+        return ""
+
+    selected_channel = getattr(session, "selected_channel", None)
+    if selected_channel:
+        return "CH%s" % int(selected_channel)
+    return "全通道"
+
+
+def apply_fixed_mic_analysis_window_titles(window, session):
+    channel_text = get_fixed_mic_session_channel_text(session)
+    if not channel_text:
+        return
+
+    analysis_instances = list(getattr(window, "analysis_window", []) or [])
+    default_ai = getattr(window, "default_ai", None)
+    if default_ai is not None and default_ai not in analysis_instances:
+        analysis_instances.append(default_ai)
+
+    for instance in analysis_instances:
+        base_title = getattr(instance, "fixed_mic_base_title", None) or instance.windowTitle()
+        instance.fixed_mic_base_title = base_title
+        instance.setWindowTitle("%s - %s" % (base_title, channel_text))
+
+
+def get_fixed_mic_ai_model_routing(window):
+    try:
+        acq_detail = window.sequence_config[0]["seq1"]["acq"].get("detail", {})
+    except Exception:
+        return {}
+
+    routing_config = acq_detail.get("fixed_mic_ai_model_routing", {})
+    if not isinstance(routing_config, dict):
+        return {}
+    return routing_config.copy()
+
+
+def apply_fixed_mic_ai_model_routing(window):
+    routing_config = get_fixed_mic_ai_model_routing(window)
+    if not routing_config:
+        return
+
+    for instance in getattr(window, "analysis_window", []) or []:
+        if not hasattr(instance, "calculate_ai_scores"):
+            continue
+        merged_config = dict(getattr(instance, "analysis_config", {}) or {})
+        if isinstance(merged_config.get("channel_model_switch"), dict):
+            continue
+        merged_config["_fixed_mic_ai_model_routing"] = routing_config.copy()
+        instance.analysis_config = merged_config
+
+
 def finalize_and_run_fixed_mic_session(window, session, save_recorded_data_to_json_func):
     if session is None or session.audio_clip is None:
         return
@@ -122,6 +175,7 @@ def finalize_and_run_fixed_mic_session(window, session, save_recorded_data_to_js
 
 def run_fixed_mic_session_analysis(window, session, use_ai_result_as_label=False):
     window._prepare_analysis_instances()
+    apply_fixed_mic_ai_model_routing(window)
     if use_ai_result_as_label:
         run_fixed_mic_ai_only_analysis(window)
     else:
@@ -208,6 +262,8 @@ def show_fixed_mic_session_analysis_windows(window, session):
 
         window._close_analysis_windows()
         window._prepare_analysis_instances()
+        apply_fixed_mic_ai_model_routing(window)
+        apply_fixed_mic_analysis_window_titles(window, session)
         width, height = window._get_analysis_window_position()
         window.count_board.mode = "view"
         window._execute_analysis_windows(width, height, show_windows=True)
@@ -278,8 +334,10 @@ def sync_fixed_mic_test_statistics(window, result_label):
     analyse_model_name = ""
     ai_instance = get_fixed_mic_ai_instance(window)
     if ai_instance is not None:
-        ai_config = getattr(ai_instance, "analysis_config", None) or {}
-        analyse_model_name = ai_config.get("analyse_model_name", "")
+        analyse_model_name = str(getattr(ai_instance, "resolved_model_name", "") or "").strip()
+        if not analyse_model_name:
+            ai_config = getattr(ai_instance, "analysis_config", None) or {}
+            analyse_model_name = ai_config.get("analyse_model_name", "")
     if not analyse_model_name:
         for key in analysis_config.get("display_sequence", []):
             key_config = analysis_config.get(key)

--- a/ui/sequence/fixed_mic/hotkey_bridge.py
+++ b/ui/sequence/fixed_mic/hotkey_bridge.py
@@ -1,0 +1,350 @@
+import ctypes
+from ctypes import wintypes
+
+from PyQt5.QtCore import QObject, QEvent, Qt
+from PyQt5.QtGui import QKeySequence
+from PyQt5.QtWidgets import QApplication, QShortcut
+
+WINDOWS_MESSAGE_KEYDOWN = 0x0100
+WINDOWS_MESSAGE_SYSKEYDOWN = 0x0104
+WINDOWS_VK_CONTROL = 0x11
+WINDOWS_VK_MENU = 0x12
+SUPPORTED_QT_MODIFIER_MASK = int(Qt.ControlModifier | Qt.AltModifier | Qt.ShiftModifier | Qt.MetaModifier)
+
+DEFAULT_FIXED_MIC_HOTKEY_CONFIG = [
+    {"shortcut": "Ctrl+1", "channel_index": 1},
+    {"shortcut": "Ctrl+2", "channel_index": 2},
+    {"shortcut": "Ctrl+3", "channel_index": 3},
+    {"shortcut": "Ctrl+4", "channel_index": 4},
+]
+
+SHORTCUT_MODIFIER_TOKEN_MAP = {
+    "CTRL": int(Qt.ControlModifier),
+    "CONTROL": int(Qt.ControlModifier),
+    "ALT": int(Qt.AltModifier),
+    "SHIFT": int(Qt.ShiftModifier),
+    "META": int(Qt.MetaModifier),
+    "WIN": int(Qt.MetaModifier),
+    "WINDOWS": int(Qt.MetaModifier),
+}
+
+
+class FixedMicHotkeyEventFilter(QObject):
+    def __init__(self, window):
+        super(FixedMicHotkeyEventFilter, self).__init__(window)
+        self.window = window
+
+    def eventFilter(self, watched, event):
+        if event.type() != QEvent.KeyPress:
+            return False
+        if getattr(event, "isAutoRepeat", lambda: False)():
+            return False
+
+        channel_index = resolve_fixed_mic_hotkey_channel_from_qt_event(event, self.window)
+        if channel_index is None:
+            return False
+
+        if not getattr(self.window, "isVisible", lambda: False)():
+            return False
+        if not hasattr(self.window, "is_fixed_mic_mode") or not self.window.is_fixed_mic_mode():
+            return False
+
+        active_window = QApplication.activeWindow()
+        if active_window is not None and self.window.window() is not active_window:
+            return False
+
+        dispatch_fixed_mic_hotkey(window=self.window, channel_index=channel_index)
+        event.accept()
+        return True
+
+
+def get_default_fixed_mic_hotkey_config():
+    return [dict(item) for item in DEFAULT_FIXED_MIC_HOTKEY_CONFIG]
+
+
+def get_configured_fixed_mic_hotkey_items(window=None):
+    default_items = get_default_fixed_mic_hotkey_config()
+    if window is None:
+        return default_items
+
+    try:
+        acq_detail = window.sequence_config[0]["seq1"]["acq"].get("detail", {})
+    except Exception:
+        return default_items
+
+    configured_items = acq_detail.get("fixed_mic_hotkeys")
+    if isinstance(configured_items, list) and configured_items:
+        return configured_items
+    return default_items
+
+
+def resolve_fixed_mic_key_token_spec(key_token):
+    normalized_key = str(key_token or "").strip().upper()
+    if not normalized_key:
+        return None
+
+    if len(normalized_key) == 1 and "0" <= normalized_key <= "9":
+        digit_value = ord(normalized_key) - ord("0")
+        return {
+            "qt_key": int(Qt.Key_0) + digit_value,
+            "windows_vk": 0x30 + digit_value,
+        }
+
+    if len(normalized_key) == 1 and "A" <= normalized_key <= "Z":
+        return {
+            "qt_key": int(getattr(Qt, "Key_%s" % normalized_key)),
+            "windows_vk": ord(normalized_key),
+        }
+
+    if normalized_key.startswith("F") and normalized_key[1:].isdigit():
+        function_index = int(normalized_key[1:])
+        if 1 <= function_index <= 12:
+            return {
+                "qt_key": int(Qt.Key_F1) + function_index - 1,
+                "windows_vk": 0x70 + function_index - 1,
+            }
+    return None
+
+
+def parse_fixed_mic_shortcut_spec(shortcut_text, channel_index):
+    shortcut = str(shortcut_text or "").strip()
+    if not shortcut:
+        return None
+
+    try:
+        normalized_channel = int(channel_index)
+    except (TypeError, ValueError):
+        return None
+    if normalized_channel <= 0:
+        return None
+
+    shortcut_tokens = [token.strip() for token in shortcut.split("+") if token.strip()]
+    if len(shortcut_tokens) < 2:
+        return None
+
+    modifier_tokens = shortcut_tokens[:-1]
+    key_token = shortcut_tokens[-1]
+    qt_modifiers = 0
+    windows_modifier_state = {"control": False, "alt": False}
+    normalized_tokens = []
+    seen_modifier_tokens = set()
+    for token in modifier_tokens:
+        normalized_token = str(token).strip().upper()
+        qt_modifier = SHORTCUT_MODIFIER_TOKEN_MAP.get(normalized_token)
+        if qt_modifier is None or normalized_token in seen_modifier_tokens:
+            return None
+        seen_modifier_tokens.add(normalized_token)
+        qt_modifiers |= int(qt_modifier)
+        normalized_tokens.append("Ctrl" if normalized_token in ("CTRL", "CONTROL") else normalized_token.title())
+        if normalized_token in ("CTRL", "CONTROL"):
+            windows_modifier_state["control"] = True
+        elif normalized_token == "ALT":
+            windows_modifier_state["alt"] = True
+
+    key_spec = resolve_fixed_mic_key_token_spec(key_token)
+    if key_spec is None:
+        return None
+
+    normalized_shortcut = "+".join(normalized_tokens + [str(key_token).strip().upper()])
+    windows_messages = (
+        (WINDOWS_MESSAGE_SYSKEYDOWN,) if windows_modifier_state["alt"] else (WINDOWS_MESSAGE_KEYDOWN,)
+    )
+    return {
+        "shortcut": normalized_shortcut,
+        "channel_index": normalized_channel,
+        "qt_key": int(key_spec["qt_key"]),
+        "qt_modifiers": int(qt_modifiers),
+        "windows_vk": int(key_spec["windows_vk"]),
+        "windows_messages": windows_messages,
+        "windows_modifier_state": windows_modifier_state,
+    }
+
+
+def build_fixed_mic_hotkey_specs(window=None):
+    hotkey_items = get_configured_fixed_mic_hotkey_items(window)
+    parsed_specs = []
+    for item in hotkey_items:
+        if not isinstance(item, dict):
+            continue
+        parsed_spec = parse_fixed_mic_shortcut_spec(
+            item.get("shortcut"),
+            item.get("channel_index"),
+        )
+        if parsed_spec is None:
+            continue
+        parsed_specs.append(parsed_spec)
+
+    if parsed_specs:
+        return parsed_specs
+
+    default_specs = []
+    for item in get_default_fixed_mic_hotkey_config():
+        parsed_spec = parse_fixed_mic_shortcut_spec(item.get("shortcut"), item.get("channel_index"))
+        if parsed_spec is not None:
+            default_specs.append(parsed_spec)
+    return default_specs
+
+
+def build_fixed_mic_hotkey_map(window=None):
+    return {spec["shortcut"]: spec["channel_index"] for spec in build_fixed_mic_hotkey_specs(window)}
+
+
+def resolve_fixed_mic_hotkey_channel_from_qt_key(key, window=None):
+    for spec in build_fixed_mic_hotkey_specs(window):
+        if spec["qt_key"] == key:
+            return spec["channel_index"]
+    return None
+
+
+def resolve_fixed_mic_hotkey_channel_from_qt_event(event, window=None):
+    normalized_modifiers = int(event.modifiers()) & SUPPORTED_QT_MODIFIER_MASK
+    for spec in build_fixed_mic_hotkey_specs(window):
+        if spec["qt_key"] != event.key():
+            continue
+        if normalized_modifiers != int(spec.get("qt_modifiers", 0)):
+            continue
+        return spec["channel_index"]
+    return None
+
+
+def resolve_fixed_mic_hotkey_channel_from_windows_vk(virtual_key, window=None):
+    for spec in build_fixed_mic_hotkey_specs(window):
+        if int(spec["windows_vk"]) == int(virtual_key):
+            return spec["channel_index"]
+    return None
+
+
+def resolve_fixed_mic_hotkey_channel_from_windows_message(message_id, virtual_key, modifier_state=None, window=None):
+    normalized_modifier_state = normalize_fixed_mic_windows_modifier_state(modifier_state)
+    for spec in build_fixed_mic_hotkey_specs(window):
+        if int(spec["windows_vk"]) != int(virtual_key):
+            continue
+        if int(message_id or 0) not in tuple(spec.get("windows_messages", ())):
+            continue
+        if normalized_modifier_state != normalize_fixed_mic_windows_modifier_state(
+            spec.get("windows_modifier_state", {})
+        ):
+            continue
+        return spec["channel_index"]
+    return None
+
+
+def normalize_fixed_mic_windows_modifier_state(modifier_state=None):
+    state = modifier_state if isinstance(modifier_state, dict) else {}
+    return {
+        "control": bool(state.get("control", False)),
+        "alt": bool(state.get("alt", False)),
+    }
+
+
+def get_fixed_mic_windows_key_pressed(virtual_key):
+    user32 = getattr(getattr(ctypes, "windll", None), "user32", None)
+    if user32 is None:
+        return False
+    return bool(user32.GetKeyState(int(virtual_key)) & 0x8000)
+
+
+def get_fixed_mic_windows_modifier_state():
+    return {
+        "control": get_fixed_mic_windows_key_pressed(WINDOWS_VK_CONTROL),
+        "alt": get_fixed_mic_windows_key_pressed(WINDOWS_VK_MENU),
+    }
+
+
+def parse_fixed_mic_windows_msg(message):
+    try:
+        return wintypes.MSG.from_address(int(message))
+    except (TypeError, ValueError):
+        return None
+
+
+def handle_fixed_mic_native_hotkey(window, event_type, message):
+    if event_type != "windows_generic_MSG":
+        return False
+
+    msg = parse_fixed_mic_windows_msg(message)
+    if msg is None:
+        return False
+
+    return handle_fixed_mic_windows_hotkey(
+        window,
+        msg.message,
+        msg.wParam,
+        modifier_state=get_fixed_mic_windows_modifier_state(),
+    )
+
+
+def dispatch_fixed_mic_hotkey(window, channel_index):
+    if channel_index is None:
+        return False
+    if hasattr(window, "_handle_fixed_mic_hotkey_trigger"):
+        window._handle_fixed_mic_hotkey_trigger(channel_index)
+        return True
+    return False
+
+
+def handle_fixed_mic_windows_hotkey(window, message_id, virtual_key, modifier_state=None):
+    channel_index = resolve_fixed_mic_hotkey_channel_from_windows_message(
+        message_id,
+        virtual_key,
+        modifier_state=modifier_state,
+        window=window,
+    )
+    if channel_index is None:
+        return False
+    if not getattr(window, "isVisible", lambda: False)():
+        return False
+    if not hasattr(window, "is_fixed_mic_mode") or not window.is_fixed_mic_mode():
+        return False
+    return dispatch_fixed_mic_hotkey(window, channel_index)
+
+
+def install_fixed_mic_hotkeys(window):
+    uninstall_fixed_mic_hotkeys(window)
+    shortcuts = []
+    for hotkey_text, channel_index in build_fixed_mic_hotkey_map(window).items():
+        shortcut = QShortcut(QKeySequence(hotkey_text), window)
+        # Use application-wide shortcut context so the trigger still works
+        # when focus is inside nested child widgets on the sequence page.
+        shortcut.setContext(Qt.ApplicationShortcut)
+        shortcut.setEnabled(False)
+        shortcut.activated.connect(
+            lambda selected_channel=channel_index: handle_fixed_mic_hotkey_trigger(window, selected_channel)
+        )
+        shortcuts.append(shortcut)
+    window.fixed_mic_hotkey_shortcuts = shortcuts
+
+    app = QApplication.instance()
+    if app is not None:
+        event_filter = FixedMicHotkeyEventFilter(window)
+        app.installEventFilter(event_filter)
+        window.fixed_mic_hotkey_event_filter = event_filter
+    else:
+        window.fixed_mic_hotkey_event_filter = None
+
+
+def set_fixed_mic_hotkeys_enabled(window, enabled):
+    for shortcut in getattr(window, "fixed_mic_hotkey_shortcuts", []) or []:
+        shortcut.setEnabled(bool(enabled))
+
+
+def uninstall_fixed_mic_hotkeys(window):
+    app = QApplication.instance()
+    event_filter = getattr(window, "fixed_mic_hotkey_event_filter", None)
+    if app is not None and event_filter is not None:
+        try:
+            app.removeEventFilter(event_filter)
+        except Exception:
+            pass
+    window.fixed_mic_hotkey_event_filter = None
+    for shortcut in getattr(window, "fixed_mic_hotkey_shortcuts", []) or []:
+        try:
+            shortcut.setEnabled(False)
+            shortcut.deleteLater()
+        except Exception:
+            pass
+    window.fixed_mic_hotkey_shortcuts = []
+
+
+def handle_fixed_mic_hotkey_trigger(window, channel_index):
+    dispatch_fixed_mic_hotkey(window, channel_index)

--- a/ui/sequence/fixed_mic/runtime_bridge.py
+++ b/ui/sequence/fixed_mic/runtime_bridge.py
@@ -5,6 +5,54 @@ from PyQt5.QtWidgets import QMessageBox
 from consts import error_code
 
 
+def ensure_fixed_mic_capture_started(window, controller_cls):
+    if window.fixed_mic_controller is not None:
+        return error_code.OK, "Fixed mic capture already running."
+
+    acq_detail = window.sequence_config[0]["seq1"]["acq"]["detail"]
+    window.fixed_mic_controller = controller_cls(acq_detail, input_device=window.mic)
+    start_code, start_msg = window.fixed_mic_controller.start_capture()
+    if start_code != error_code.OK:
+        window.fixed_mic_controller = None
+        return start_code, start_msg
+
+    window.fixed_mic_plot_window_sec = max(
+        min(float(window.fixed_mic_controller.buffer_duration), 15.0),
+        float(window.fixed_mic_controller.window_duration),
+    )
+    window.fixed_mic_poll_timer.start(50)
+    window._clear_waveform_display()
+    window.fixed_mic_plot_item = None
+    window.fixed_mic_last_plot_update_ts = 0.0
+    window.fixed_mic_live_y_limit = 0.01
+    window.fixed_mic_stream_buffer = []
+    if hasattr(window, "_set_fixed_mic_display_channel_context"):
+        window._set_fixed_mic_display_channel_context(None)
+    window._reset_fixed_mic_session_views()
+    window._configure_fixed_mic_live_plot_view()
+    window._render_fixed_mic_waveforms(
+        None,
+        window.fixed_mic_controller.sample_rate,
+        total_channels=window.fixed_mic_controller.channels,
+        reset_page=True,
+        live_mode=True,
+    )
+    return error_code.OK, "Fixed mic capture started."
+
+
+def finalize_fixed_mic_session_created(window, session):
+    window.player_status_flag = window.fixed_mic_controller.is_running
+    window.data_btn.setEnabled(False)
+    window._update_fixed_mic_toolbar_state()
+    window._register_fixed_mic_session(session, status_text="采集中")
+    window.default_logger.info(
+        "固定麦阶段2已创建会话: %s, trigger_source=%s, selected_channel=%s",
+        session.session_id,
+        getattr(session, "trigger_source", None),
+        getattr(session, "selected_channel", None),
+    )
+
+
 def handle_fixed_mic_manual_trigger(window, controller_cls):
     if window.checked_work_status_message():
         return
@@ -13,33 +61,10 @@ def handle_fixed_mic_manual_trigger(window, controller_cls):
         window.default_logger.info("固定麦并发模式阶段2仅接收手动点击触发。")
         return
 
-    if window.fixed_mic_controller is None:
-        acq_detail = window.sequence_config[0]["seq1"]["acq"]["detail"]
-        window.fixed_mic_controller = controller_cls(acq_detail, input_device=window.mic)
-        start_code, start_msg = window.fixed_mic_controller.start_capture()
-        if start_code != error_code.OK:
-            QMessageBox.warning(window, "提示", "固定麦持续采集启动失败: %s" % start_msg)
-            window.fixed_mic_controller = None
-            return
-        window.fixed_mic_plot_window_sec = max(
-            min(float(window.fixed_mic_controller.buffer_duration), 15.0),
-            float(window.fixed_mic_controller.window_duration),
-        )
-        window.fixed_mic_poll_timer.start(50)
-        window._clear_waveform_display()
-        window.fixed_mic_plot_item = None
-        window.fixed_mic_last_plot_update_ts = 0.0
-        window.fixed_mic_live_y_limit = 0.01
-        window.fixed_mic_stream_buffer = []
-        window._reset_fixed_mic_session_views()
-        window._configure_fixed_mic_live_plot_view()
-        window._render_fixed_mic_waveforms(
-            None,
-            window.fixed_mic_controller.sample_rate,
-            total_channels=window.fixed_mic_controller.channels,
-            reset_page=True,
-            live_mode=True,
-        )
+    start_code, start_msg = ensure_fixed_mic_capture_started(window, controller_cls)
+    if start_code != error_code.OK:
+        QMessageBox.warning(window, "提示", "固定麦持续采集启动失败: %s" % start_msg)
+        return
 
     barcode = window.lineedit_s_or_n.text().strip() or None
     create_code, create_msg, session = window.fixed_mic_controller.create_manual_session(barcode)
@@ -47,11 +72,27 @@ def handle_fixed_mic_manual_trigger(window, controller_cls):
         QMessageBox.warning(window, "提示", create_msg)
         return
 
-    window.player_status_flag = window.fixed_mic_controller.is_running
-    window.data_btn.setEnabled(False)
-    window._update_fixed_mic_toolbar_state()
-    window._register_fixed_mic_session(session, status_text="采集中")
-    window.default_logger.info("固定麦阶段2已创建会话: %s" % session.session_id)
+    finalize_fixed_mic_session_created(window, session)
+
+
+def handle_fixed_mic_hotkey_trigger(window, controller_cls, channel_index):
+    if window.checked_work_status_message():
+        return
+    if not window.is_fixed_mic_mode():
+        return
+
+    start_code, start_msg = ensure_fixed_mic_capture_started(window, controller_cls)
+    if start_code != error_code.OK:
+        QMessageBox.warning(window, "提示", "固定麦持续采集启动失败: %s" % start_msg)
+        return
+
+    barcode = window.lineedit_s_or_n.text().strip() or None
+    create_code, create_msg, session = window.fixed_mic_controller.create_hotkey_session(channel_index, barcode)
+    if create_code != error_code.OK:
+        QMessageBox.warning(window, "提示", create_msg)
+        return
+
+    finalize_fixed_mic_session_created(window, session)
 
 
 def poll_fixed_mic_runtime(window):
@@ -116,6 +157,8 @@ def stop_fixed_mic_runtime(window):
     window.fixed_mic_last_plot_update_ts = 0.0
     window.fixed_mic_live_y_limit = 0.01
     window.fixed_mic_stream_buffer = []
+    if hasattr(window, "_set_fixed_mic_display_channel_context") and not preserve_review_state:
+        window._set_fixed_mic_display_channel_context(None)
     if preserve_review_state:
         if window.fixed_mic_analysis_queue and not window.fixed_mic_analysis_busy:
             try:

--- a/ui/sequence/fixed_mic/session_table_panel.py
+++ b/ui/sequence/fixed_mic/session_table_panel.py
@@ -40,9 +40,9 @@ class FixedMicSessionTablePanel(QWidget):
         group_box = QGroupBox("会话列表")
         group_layout = QVBoxLayout()
 
-        self.session_table = QTableWidget(0, 9)
+        self.session_table = QTableWidget(0, 10)
         self.session_table.setHorizontalHeaderLabels(
-            ["会话", "触发时间", "截止时间", "音频时长", "条码", "进度", "结果", "播放", "分析"]
+            ["会话", "触发时间", "截止时间", "音频时长", "通道", "条码", "进度", "结果", "播放", "分析"]
         )
         self.session_table.verticalHeader().setVisible(False)
         self.session_table.verticalHeader().setDefaultSectionSize(34)
@@ -54,7 +54,7 @@ class FixedMicSessionTablePanel(QWidget):
         self.session_table.setTextElideMode(Qt.ElideMiddle)
         self.session_table.setHorizontalScrollMode(QAbstractItemView.ScrollPerPixel)
         self.session_table.setMinimumWidth(0)
-        self.session_table.setMinimumHeight(240)
+        self.session_table.setMinimumHeight(160)
 
         header = self.session_table.horizontalHeader()
         header_font = header.font()
@@ -67,17 +67,19 @@ class FixedMicSessionTablePanel(QWidget):
         header.setSectionResizeMode(1, QHeaderView.Fixed)
         header.setSectionResizeMode(2, QHeaderView.Fixed)
         header.setSectionResizeMode(3, QHeaderView.Fixed)
-        header.setSectionResizeMode(4, QHeaderView.Stretch)
+        header.setSectionResizeMode(4, QHeaderView.Fixed)
         header.setSectionResizeMode(5, QHeaderView.Stretch)
         header.setSectionResizeMode(6, QHeaderView.Stretch)
-        header.setSectionResizeMode(7, QHeaderView.Fixed)
+        header.setSectionResizeMode(7, QHeaderView.Stretch)
         header.setSectionResizeMode(8, QHeaderView.Fixed)
+        header.setSectionResizeMode(9, QHeaderView.Fixed)
         self.session_table.setColumnWidth(0, 56)
         self.session_table.setColumnWidth(1, 92)
         self.session_table.setColumnWidth(2, 92)
         self.session_table.setColumnWidth(3, 86)
-        self.session_table.setColumnWidth(7, 72)
-        self.session_table.setColumnWidth(8, 84)
+        self.session_table.setColumnWidth(4, 76)
+        self.session_table.setColumnWidth(8, 72)
+        self.session_table.setColumnWidth(9, 84)
 
         group_layout.addWidget(self.session_table)
         group_box.setLayout(group_layout)
@@ -116,17 +118,18 @@ class FixedMicSessionTablePanel(QWidget):
         trigger_time = session.trigger_time.strftime("%H:%M:%S") if getattr(session, "trigger_time", None) else "-"
         deadline_time = self.get_deadline_text(session)
         duration_text = self.get_duration_text(session)
+        channel_text = self.get_channel_text(session)
         barcode = session.vehicle_barcode or "-"
         result_label = self.get_result_label(session)
-        values = [session_no, trigger_time, deadline_time, duration_text, barcode, status_text, result_label]
+        values = [session_no, trigger_time, deadline_time, duration_text, channel_text, barcode, status_text, result_label]
         for col, value in enumerate(values):
             session_id = session.session_id if col == 0 else None
             item = self.make_table_item(str(value), session_id=session_id)
-            if col == 4:
+            if col == 5:
                 item.setToolTip(str(value))
             self.session_table.setItem(row, col, item)
-        self.session_table.setCellWidget(row, 7, self.create_play_cell(session.session_id))
-        self.session_table.setCellWidget(row, 8, self.create_view_cell(session.session_id))
+        self.session_table.setCellWidget(row, 8, self.create_play_cell(session.session_id))
+        self.session_table.setCellWidget(row, 9, self.create_view_cell(session.session_id))
         self._refresh_play_button_for_session(session.session_id)
         self.session_table.scrollToBottom()
 
@@ -140,10 +143,17 @@ class FixedMicSessionTablePanel(QWidget):
             self.register_session(session, status_text=status_text)
             return
         self.refresh_session_timing(row, session)
-        item = self.session_table.item(row, 5)
+        channel_item = self.session_table.item(row, 4)
+        channel_text = self.get_channel_text(session)
+        if channel_item is None:
+            channel_item = self.make_table_item(channel_text)
+            self.session_table.setItem(row, 4, channel_item)
+        else:
+            channel_item.setText(channel_text)
+        item = self.session_table.item(row, 6)
         if item is None:
             item = self.make_table_item(status_text)
-            self.session_table.setItem(row, 5, item)
+            self.session_table.setItem(row, 6, item)
         else:
             item.setText(status_text)
         self._refresh_play_button_for_session(session.session_id)
@@ -161,10 +171,10 @@ class FixedMicSessionTablePanel(QWidget):
         if row is None:
             return
         self.refresh_session_timing(row, session)
-        item = self.session_table.item(row, 6)
+        item = self.session_table.item(row, 7)
         if item is None:
             item = self.make_table_item(normalized_label)
-            self.session_table.setItem(row, 6, item)
+            self.session_table.setItem(row, 7, item)
         else:
             item.setText(normalized_label)
         self._refresh_play_button_for_session(session.session_id)
@@ -315,7 +325,7 @@ class FixedMicSessionTablePanel(QWidget):
         row = self.session_rows.get(session_id)
         if row is None or self.session_table is None:
             return
-        play_btn = self._get_cell_center_widget(self.session_table, row, 7)
+        play_btn = self._get_cell_center_widget(self.session_table, row, 8)
         if play_btn is None:
             return
 
@@ -430,6 +440,15 @@ class FixedMicSessionTablePanel(QWidget):
             return "not_labeled"
         metadata = getattr(session, "metadata", {})
         return metadata.get("result_label", "not_labeled")
+
+    @staticmethod
+    def get_channel_text(session):
+        if session is None:
+            return "-"
+        selected_channel = getattr(session, "selected_channel", None)
+        if selected_channel:
+            return "CH%s" % selected_channel
+        return "全通道"
 
     @staticmethod
     def get_deadline_text(session):

--- a/ui/sequence/sequence_widget.py
+++ b/ui/sequence/sequence_widget.py
@@ -15,6 +15,7 @@ from PyQt5.QtWidgets import (
     QLabel,
     QMessageBox,
     QPushButton,
+    QSplitter,
     QStackedWidget,
     QVBoxLayout,
     QWidget,
@@ -61,10 +62,16 @@ from ui.sequence.fixed_mic.waveform_helpers import (
     get_fixed_mic_page_channel_indices,
 )
 from ui.sequence.fixed_mic.runtime_bridge import (
+    handle_fixed_mic_hotkey_trigger,
     handle_fixed_mic_manual_trigger,
     poll_fixed_mic_runtime,
     process_next_fixed_mic_analysis,
     stop_fixed_mic_runtime,
+)
+from ui.sequence.fixed_mic.hotkey_bridge import (
+    install_fixed_mic_hotkeys,
+    set_fixed_mic_hotkeys_enabled,
+    uninstall_fixed_mic_hotkeys,
 )
 from ui.sequence.sequence_tools_bar import SequenceToolsBar
 from ui.signal_analysis_window import get_class_mapping
@@ -146,12 +153,18 @@ class SequenceWindow(QWidget):
         self.fixed_mic_display_audio = None
         self.fixed_mic_display_sample_rate = 0.0
         self.fixed_mic_display_live_mode = False
+        self.fixed_mic_display_channel_indices_override = None
+        self.fixed_mic_display_channel_text = ""
+        self.fixed_mic_display_session_text = ""
         self.fixed_mic_waveform_widget = None
         self.fixed_mic_waveform_grid = None
+        self.fixed_mic_waveform_context_label = None
         self.fixed_mic_page_label = None
         self.fixed_mic_prev_page_btn = None
         self.fixed_mic_next_page_btn = None
         self.waveform_stack = None
+        self.fixed_mic_vertical_splitter = None
+        self.fixed_mic_hotkey_shortcuts = []
         self._sync_fixed_mic_mode_state()
 
         self.hw_manager = UnifiedHardwareManager()
@@ -165,6 +178,8 @@ class SequenceWindow(QWidget):
         self.bind_hw_signals()
         self.init_lineedit_text()
         self.init_ui()
+        install_fixed_mic_hotkeys(self)
+        set_fixed_mic_hotkeys_enabled(self, self.is_fixed_mic_mode())
 
     def init_ui(self):
         """
@@ -313,9 +328,16 @@ class SequenceWindow(QWidget):
         right_panel = QWidget()
         right_layout = QVBoxLayout()
         right_layout.setContentsMargins(0, 0, 0, 0)
-        right_layout.setSpacing(12)
-        right_layout.addWidget(self.waveform_stack, stretch=7)
-        right_layout.addWidget(self.create_fixed_mic_detail_panel(), stretch=5)
+        right_layout.setSpacing(0)
+        self.fixed_mic_vertical_splitter = QSplitter(Qt.Vertical)
+        self.fixed_mic_vertical_splitter.setChildrenCollapsible(False)
+        self.fixed_mic_vertical_splitter.setHandleWidth(8)
+        self.fixed_mic_vertical_splitter.addWidget(self.waveform_stack)
+        self.fixed_mic_vertical_splitter.addWidget(self.create_fixed_mic_detail_panel())
+        self.fixed_mic_vertical_splitter.setStretchFactor(0, 7)
+        self.fixed_mic_vertical_splitter.setStretchFactor(1, 4)
+        self.fixed_mic_vertical_splitter.setSizes([520, 260])
+        right_layout.addWidget(self.fixed_mic_vertical_splitter)
         right_panel.setLayout(right_layout)
 
         layout.addWidget(self.count_board, stretch=1)
@@ -360,6 +382,18 @@ class SequenceWindow(QWidget):
         container_layout = QVBoxLayout()
         container_layout.setContentsMargins(0, 0, 0, 0)
         container_layout.setSpacing(8)
+
+        self.fixed_mic_waveform_context_label = QLabel("固定麦波形 | 等待触发")
+        self.fixed_mic_waveform_context_label.setStyleSheet(
+            """
+            QLabel {
+                color: #5f6368;
+                font-size: 13px;
+                padding: 2px 2px 0px 2px;
+            }
+            """
+        )
+        container_layout.addWidget(self.fixed_mic_waveform_context_label)
 
         pager_layout = QHBoxLayout()
         pager_layout.setContentsMargins(0, 0, 0, 0)
@@ -425,7 +459,13 @@ class SequenceWindow(QWidget):
             self.fixed_mic_display_audio = None
             self.fixed_mic_display_sample_rate = 0.0
             self.fixed_mic_display_live_mode = False
+            self.fixed_mic_display_channel_indices_override = None
+            self.fixed_mic_display_channel_text = ""
+            self.fixed_mic_display_session_text = ""
         self._refresh_fixed_mic_waveform_paging_controls(0)
+        refresh_context = getattr(self, "_refresh_fixed_mic_waveform_context_label", None)
+        if callable(refresh_context):
+            refresh_context()
 
     def _get_fixed_mic_channel_config(self):
         if not self.is_fixed_mic_mode():
@@ -433,6 +473,55 @@ class SequenceWindow(QWidget):
         acq_detail = self.sequence_config[0]["seq1"]["acq"].get("detail", {})
         channel_config = acq_detail.get("fixed_mic_channels", [])
         return channel_config if isinstance(channel_config, list) else []
+
+    def _set_fixed_mic_display_channel_context(self, session=None):
+        if session is None:
+            self.fixed_mic_display_channel_indices_override = None
+            self.fixed_mic_display_channel_text = ""
+            self.fixed_mic_display_session_text = ""
+            refresh_context = getattr(self, "_refresh_fixed_mic_waveform_context_label", None)
+            if callable(refresh_context):
+                refresh_context()
+            return
+
+        session_id = str(getattr(session, "session_id", "") or "")
+        session_no = session_id.split("_")[-1] if session_id else ""
+        self.fixed_mic_display_session_text = "会话 %s" % session_no if session_no else "会话回看"
+
+        selected_channel = getattr(session, "selected_channel", None)
+        if selected_channel:
+            normalized_channel = max(int(selected_channel), 1)
+            self.fixed_mic_display_channel_indices_override = [normalized_channel - 1]
+            self.fixed_mic_display_channel_text = "CH%s" % normalized_channel
+            refresh_context = getattr(self, "_refresh_fixed_mic_waveform_context_label", None)
+            if callable(refresh_context):
+                refresh_context()
+            return
+
+        self.fixed_mic_display_channel_indices_override = None
+        self.fixed_mic_display_channel_text = "全通道"
+        refresh_context = getattr(self, "_refresh_fixed_mic_waveform_context_label", None)
+        if callable(refresh_context):
+            refresh_context()
+
+    def _build_fixed_mic_waveform_context_text(self):
+        channel_text = str(getattr(self, "fixed_mic_display_channel_text", "") or "").strip()
+        session_text = str(getattr(self, "fixed_mic_display_session_text", "") or "").strip()
+        if bool(getattr(self, "fixed_mic_display_live_mode", False)):
+            return "实时采集中 | %s" % (channel_text or "全通道")
+        if session_text:
+            if channel_text:
+                return "%s 回看 | %s" % (session_text, channel_text)
+            return "%s 回看" % session_text
+        if getattr(self, "fixed_mic_display_audio", None) is not None:
+            return "固定麦波形 | %s" % (channel_text or "全通道")
+        return "固定麦波形 | 等待触发"
+
+    def _refresh_fixed_mic_waveform_context_label(self):
+        label = getattr(self, "fixed_mic_waveform_context_label", None)
+        if label is None:
+            return
+        label.setText(self._build_fixed_mic_waveform_context_text())
 
     def _get_fixed_mic_configured_channels(self):
         if not self.is_fixed_mic_mode():
@@ -556,24 +645,42 @@ class SequenceWindow(QWidget):
 
         self.fixed_mic_display_audio = normalized_audio
         self.fixed_mic_display_sample_rate = float(sample_rate or self.data_struct.sample_rate or 1.0)
-        self.fixed_mic_display_total_channels = total_channels
+        override_indices = list(getattr(self, "fixed_mic_display_channel_indices_override", None) or [])
+        display_total_channels = len(override_indices) if override_indices else total_channels
+        self.fixed_mic_display_total_channels = display_total_channels
         self.fixed_mic_display_live_mode = bool(live_mode)
         self._show_fixed_mic_waveform_view()
+        refresh_context = getattr(self, "_refresh_fixed_mic_waveform_context_label", None)
+        if callable(refresh_context):
+            refresh_context()
 
-        titles = get_fixed_mic_channel_titles(total_channels, self._get_fixed_mic_channel_config())
-        visible_channel_indices = get_fixed_mic_page_channel_indices(
-            total_channels,
-            self.fixed_mic_current_page,
-            self.fixed_mic_page_size,
-        )
+        title_total_channels = total_channels
+        if override_indices:
+            title_total_channels = max(
+                int(total_channels or 0),
+                int(self._get_fixed_mic_configured_channels() or 0),
+                max(override_indices) + 1,
+            )
+        titles = get_fixed_mic_channel_titles(title_total_channels, self._get_fixed_mic_channel_config())
+        if override_indices:
+            visible_channel_indices = override_indices
+        else:
+            visible_channel_indices = get_fixed_mic_page_channel_indices(
+                total_channels,
+                self.fixed_mic_current_page,
+                self.fixed_mic_page_size,
+            )
         visible_count = len(visible_channel_indices)
         self._layout_fixed_mic_subplot_widgets(visible_count)
-        self._refresh_fixed_mic_waveform_paging_controls(total_channels)
+        self._refresh_fixed_mic_waveform_paging_controls(display_total_channels)
 
         time_axis = np.array([], dtype=np.float32)
         display_audio = np.empty((0, visible_count), dtype=np.float32)
         if normalized_audio is not None and normalized_audio.size > 0 and visible_count > 0:
-            visible_audio = normalized_audio[:, visible_channel_indices]
+            if override_indices and normalized_audio.shape[1] == visible_count:
+                visible_audio = normalized_audio
+            else:
+                visible_audio = normalized_audio[:, visible_channel_indices]
             time_axis, display_audio = build_fixed_mic_plot_data(
                 visible_audio,
                 self.fixed_mic_display_sample_rate,
@@ -592,6 +699,8 @@ class SequenceWindow(QWidget):
             channel_index = visible_channel_indices[slot_index]
             plot_widget.show()
             title_text = titles[channel_index] if channel_index < len(titles) else "Mic%d" % (channel_index + 1)
+            if override_indices:
+                title_text = "%s (CH%d)" % (title_text, channel_index + 1)
             plot_widget.setTitle(title_text, color="black", size="12pt")
 
             channel_audio = (
@@ -732,6 +841,7 @@ class SequenceWindow(QWidget):
         if hasattr(self, 'hw_manager'):
             self.hw_manager.stop()
         self._stop_fixed_mic_runtime()
+        uninstall_fixed_mic_hotkeys(self)
         super().closeEvent(event)
 
     def reset_test_reord(self):
@@ -1025,6 +1135,9 @@ class SequenceWindow(QWidget):
     def _handle_fixed_mic_manual_trigger(self):
         handle_fixed_mic_manual_trigger(self, FixedMicCaptureController)
 
+    def _handle_fixed_mic_hotkey_trigger(self, channel_index):
+        handle_fixed_mic_hotkey_trigger(self, FixedMicCaptureController, channel_index)
+
     def _poll_fixed_mic_runtime(self):
         poll_fixed_mic_runtime(self)
 
@@ -1188,6 +1301,7 @@ class SequenceWindow(QWidget):
         self.data_struct.store_wave_data = load_fixed_mic_session_audio(session)
         self.data_struct.sample_rate = session.metadata.get("sample_rate", self.data_struct.sample_rate)
         self.data_struct.update_channel_count()
+        self._set_fixed_mic_display_channel_context(session)
         if update_plot and self.data_struct.store_wave_data is not None:
             self._plot_recorded_signal(self.data_struct.store_wave_data, self.data_struct.sample_rate, reset_page=True)
 
@@ -1256,6 +1370,7 @@ class SequenceWindow(QWidget):
     def _sync_fixed_mic_mode_state(self, desired_mode=None):
         if getattr(self, "count_board", None) is None:
             return
+        set_fixed_mic_hotkeys_enabled(self, self.is_fixed_mic_mode())
         if getattr(self, "fixed_mic_detail_panel", None) is not None:
             self.fixed_mic_detail_panel.setVisible(self.is_fixed_mic_mode())
         if not self.is_fixed_mic_mode():
@@ -1430,6 +1545,7 @@ class SequenceWindow(QWidget):
             cls_map = class_mapping.get(type)
             if cls_map:
                 class_instance = cls_map(key)
+                class_instance.fixed_mic_base_title = key
                 if self.analysis_config["default_ai"] == key:
                     self.default_ai = class_instance
                 class_instance.deviation_value = self.deviation_value

--- a/ui/signal_analysis_window.py
+++ b/ui/signal_analysis_window.py
@@ -48,6 +48,33 @@ def get_class_mapping():
     return class_mapping
 
 
+def resolve_ai_model_name_for_runtime(analysis_item_config, actual_channels):
+    if not isinstance(analysis_item_config, dict):
+        return ""
+
+    default_model_name = str(analysis_item_config.get("analyse_model_name", "") or "").strip()
+    routing_config = analysis_item_config.get("channel_model_switch")
+    if not isinstance(routing_config, dict):
+        routing_config = analysis_item_config.get("_fixed_mic_ai_model_routing")
+    if not isinstance(routing_config, dict) or not routing_config.get("enabled", False):
+        return default_model_name
+
+    normalized_channels = max(int(actual_channels or 1), 1)
+    if normalized_channels <= 1:
+        return str(routing_config.get("single_channel_model_name", "") or "").strip() or default_model_name
+    return str(routing_config.get("multi_channel_model_name", "") or "").strip() or default_model_name
+
+
+def prepare_single_channel_waveform_for_prediction(raw_data):
+    normalized_data = np.asarray(raw_data, dtype=np.float32)
+    squeezed_data = np.squeeze(normalized_data)
+    if squeezed_data.ndim == 0:
+        return squeezed_data.reshape(1)
+    if squeezed_data.ndim == 1:
+        return squeezed_data
+    return normalized_data
+
+
 class AnalysisGraphWidget(QWidget):
 
     def __init__(self):
@@ -191,6 +218,7 @@ class AI(QWidget):
         self.data_struct = DataDealStruct()
         self.analysis_config = None
         self.result = None
+        self.resolved_model_name = ""
         self.default_logger = LogManager.set_log_handler("core")
         self.init_ui()
         self.setWindowTitle(title_name)
@@ -233,7 +261,17 @@ class AI(QWidget):
             first_match.mergeCharFormat(format)
 
     def calculate_ai_scores(self, mode, analysis_config):
-        model_name = self.analysis_config["analyse_model_name"]
+        model_name = resolve_ai_model_name_for_runtime(
+            self.analysis_config,
+            getattr(self.data_struct, "num_channels", 1),
+        )
+        self.resolved_model_name = model_name
+        self.default_logger.info(
+            "AI评分开始: mode=%s, resolved_model=%s, data_channels=%s",
+            mode,
+            model_name,
+            getattr(self.data_struct, "num_channels", 1),
+        )
         code, result = self.get_model_info(model_name, self.default_logger)
         if code != error_code.OK or not os.path.exists(result[0]):
             self.ai_analyse_score_textedit.setPlainText("模型不存在，请重新选择！")
@@ -243,7 +281,7 @@ class AI(QWidget):
             result_text = self.model_predict(model_path, model_name, **kwargs)
             default_ai_model = analysis_config["default_ai"]
             if mode == "test" and default_ai_model:
-                analyse_model_name = analysis_config.get(default_ai_model, None).get("analyse_model_name", None)
+                analyse_model_name = model_name
                 match_object = re.search(r"评分结果:\s*(\S+)", result_text)
                 if match_object:
                     match_result = match_object.group(1)
@@ -264,11 +302,19 @@ class AI(QWidget):
         full_config_path = config_path
         data_load_config = load_config(config_path=full_config_path, module_name="data_load")
         multichannel_config = data_load_config.get("multichannel", {})
+        original_wave_data = np.array(self.data_struct.store_wave_data, dtype=np.float32)
         if multichannel_config.get("enabled"):
             # 多通道预测
-            raw_data = np.array(self.data_struct.store_wave_data, dtype=np.float32)
+            raw_data = original_wave_data
             if raw_data.ndim == 2 and raw_data.shape[0] > raw_data.shape[1]:
                 raw_data = raw_data.T
+            self.default_logger.info(
+                "AI预测输入(多通道): model=%s, original_shape=%s, normalized_shape=%s, sample_rate=%s",
+                model_name,
+                tuple(original_wave_data.shape),
+                tuple(raw_data.shape),
+                self.data_struct.sample_rate,
+            )
             ret_str = predict_multichannel_from_audio(
                 multichannel_signal=np.array(raw_data, dtype=np.float32),
                 file_name="modelpredict.wav",
@@ -277,8 +323,16 @@ class AI(QWidget):
                 **kwargs,
             )
         else:
+            raw_data = prepare_single_channel_waveform_for_prediction(self.data_struct.store_wave_data)
+            self.default_logger.info(
+                "AI预测输入(单通道): model=%s, original_shape=%s, normalized_shape=%s, sample_rate=%s",
+                model_name,
+                tuple(original_wave_data.shape),
+                tuple(raw_data.shape),
+                self.data_struct.sample_rate,
+            )
             ret_str = predict_from_audio(
-                signals=[np.array(self.data_struct.store_wave_data, dtype=np.float32)],
+                signals=[raw_data],
                 file_names=["modelpredict.wav"],
                 fs=[self.data_struct.sample_rate],
                 load_model_path=model_path,

--- a/ui/ui_analysis_config/ai_config_dialog.py
+++ b/ui/ui_analysis_config/ai_config_dialog.py
@@ -1,7 +1,7 @@
-from PyQt5.QtCore import Qt, QTimer
+from PyQt5.QtCore import Qt, QTimer, QPropertyAnimation, QEasingCurve
 from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import QDialog, QGroupBox, QHBoxLayout, QVBoxLayout, QPushButton
-from PyQt5.QtWidgets import QLabel, QMessageBox, QComboBox, QSizePolicy
+from PyQt5.QtWidgets import QLabel, QMessageBox, QComboBox, QSizePolicy, QCheckBox, QWidget
 
 from base.training_model_management import TrainingModelManagement
 from consts import ui_style_const, error_code
@@ -23,11 +23,15 @@ class AIConfigWindow(QDialog):
         self.setWindowFlag(Qt.WindowContextHelpButtonHint, False)
         self.setWindowIcon(QIcon(DEFAULT_DIR + "ui/ui_pic/logo_pic/ting.ico"))
         self.setMinimumSize(350, 350)
-        self.resize(350, 350)
+        self.resize(420, 360)
         layout = QVBoxLayout()
+        layout.setContentsMargins(12, 12, 12, 12)
+        layout.setSpacing(12)
         model_box = self.create_model_layout()
+        advanced_box = self.create_advanced_settings_box()
         btn_layout = self.create_btn()
         layout.addWidget(model_box)
+        layout.addWidget(advanced_box)
         layout.addStretch()
         layout.addLayout(btn_layout)
         self.setLayout(layout)
@@ -36,6 +40,18 @@ class AIConfigWindow(QDialog):
             + ui_style_const.qpushbutton_style
             + ui_style_const.qlabel_style
             + ui_style_const.qcombobox_style
+            + ui_style_const.qcheckbox_style
+            + """
+            QGroupBox#aiModelBox, QGroupBox#aiAdvancedBox {
+                margin-top: 8px;
+            }
+            QGroupBox#aiModelBox::title, QGroupBox#aiAdvancedBox::title {
+                subcontrol-origin: margin;
+                subcontrol-position: top left;
+                left: 0px;
+                padding: 0px 2px 0px 0px;
+            }
+            """
         )
 
     def cheack_model_list(self):
@@ -44,7 +60,8 @@ class AIConfigWindow(QDialog):
 
     def create_model_layout(self):
         model_box = QGroupBox("模型")
-        model_box.setMinimumSize(150, 150)
+        model_box.setObjectName("aiModelBox")
+        model_box.setMinimumHeight(118)
         analyse_model_label = QLabel("分析模型:")
         self.analyse_model_combo_box = QComboBox(self)
         self.analyse_model_combo_box.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)
@@ -55,11 +72,111 @@ class AIConfigWindow(QDialog):
         self.analyse_model_combo_box.currentTextChanged.connect(self.get_default_config)
         QTimer.singleShot(5, self.cheack_model_list)
         analyse_model_combo_layout = QHBoxLayout()
+        analyse_model_combo_layout.setContentsMargins(12, 18, 12, 12)
         analyse_model_combo_layout.addWidget(analyse_model_label)
         analyse_model_combo_layout.addWidget(self.analyse_model_combo_box)
         analyse_model_combo_layout.setSpacing(10)
         model_box.setLayout(analyse_model_combo_layout)
         return model_box
+
+    def create_advanced_settings_box(self):
+        advanced_box = QGroupBox("高级设置")
+        advanced_box.setObjectName("aiAdvancedBox")
+        box_layout = QVBoxLayout()
+        box_layout.setContentsMargins(12, 18, 12, 12)
+        box_layout.setSpacing(10)
+
+        self.channel_model_switch_box = QCheckBox("按通道数切换模型")
+        channel_switch_config = self.get_channel_model_switch_config()
+        self.channel_model_switch_box.setChecked(bool(channel_switch_config.get("enabled", False)))
+        self.channel_model_switch_box.toggled.connect(self.update_channel_model_switch_state)
+        box_layout.addWidget(self.channel_model_switch_box)
+
+        self.channel_model_detail_widget = QWidget(self)
+        self.channel_model_detail_widget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        detail_layout = QVBoxLayout()
+        detail_layout.setContentsMargins(0, 0, 0, 0)
+        detail_layout.setSpacing(10)
+
+        single_layout = QHBoxLayout()
+        single_label = QLabel("单通道模型:")
+        self.single_channel_model_combo_box = QComboBox(self)
+        self.single_channel_model_combo_box.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)
+        self.single_channel_model_combo_box.setFixedHeight(30)
+        self.populate_optional_model_combo(
+            self.single_channel_model_combo_box,
+            channel_switch_config.get("single_channel_model_name", ""),
+        )
+        single_layout.addWidget(single_label)
+        single_layout.addWidget(self.single_channel_model_combo_box)
+        detail_layout.addLayout(single_layout)
+
+        multi_layout = QHBoxLayout()
+        multi_label = QLabel("多通道模型:")
+        self.multi_channel_model_combo_box = QComboBox(self)
+        self.multi_channel_model_combo_box.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)
+        self.multi_channel_model_combo_box.setFixedHeight(30)
+        self.populate_optional_model_combo(
+            self.multi_channel_model_combo_box,
+            channel_switch_config.get("multi_channel_model_name", ""),
+        )
+        multi_layout.addWidget(multi_label)
+        multi_layout.addWidget(self.multi_channel_model_combo_box)
+        detail_layout.addLayout(multi_layout)
+
+        self.channel_model_detail_widget.setLayout(detail_layout)
+        box_layout.addWidget(self.channel_model_detail_widget)
+        self.channel_model_detail_animation = QPropertyAnimation(self.channel_model_detail_widget, b"maximumHeight", self)
+        self.channel_model_detail_animation.setDuration(140)
+        self.channel_model_detail_animation.setEasingCurve(QEasingCurve.InOutCubic)
+        self.channel_model_detail_animation.finished.connect(self.on_channel_model_detail_animation_finished)
+
+        advanced_box.setLayout(box_layout)
+        self.sync_channel_model_detail_visibility(self.channel_model_switch_box.isChecked(), animate=False)
+        return advanced_box
+
+    def get_channel_model_switch_config(self):
+        channel_switch_config = self.load_config.get("channel_model_switch", {})
+        return channel_switch_config if isinstance(channel_switch_config, dict) else {}
+
+    def populate_optional_model_combo(self, combo_box, selected_model_name):
+        if hasattr(combo_box, "setPlaceholderText"):
+            combo_box.setPlaceholderText("选择模型")
+        for model_name in self.model_list:
+            combo_box.addItem(model_name, model_name)
+        target_model_name = str(selected_model_name or "").strip()
+        target_index = combo_box.findData(target_model_name)
+        combo_box.setCurrentIndex(target_index if target_index >= 0 else -1)
+
+    def update_channel_model_switch_state(self, enabled):
+        is_enabled = bool(enabled)
+        self.single_channel_model_combo_box.setEnabled(is_enabled)
+        self.multi_channel_model_combo_box.setEnabled(is_enabled)
+        self.sync_channel_model_detail_visibility(is_enabled, animate=True)
+
+    def sync_channel_model_detail_visibility(self, is_visible, animate):
+        detail_height = self.channel_model_detail_widget.sizeHint().height()
+        self.channel_model_detail_animation.stop()
+
+        if not animate:
+            self.channel_model_detail_widget.setVisible(bool(is_visible))
+            self.channel_model_detail_widget.setMaximumHeight(detail_height if is_visible else 0)
+            return
+
+        if is_visible:
+            self.channel_model_detail_widget.setVisible(True)
+            start_height = max(self.channel_model_detail_widget.maximumHeight(), 0)
+            self.channel_model_detail_animation.setStartValue(start_height)
+            self.channel_model_detail_animation.setEndValue(detail_height)
+        else:
+            start_height = self.channel_model_detail_widget.height() or detail_height
+            self.channel_model_detail_animation.setStartValue(start_height)
+            self.channel_model_detail_animation.setEndValue(0)
+        self.channel_model_detail_animation.start()
+
+    def on_channel_model_detail_animation_finished(self):
+        if not self.channel_model_switch_box.isChecked():
+            self.channel_model_detail_widget.setVisible(False)
 
     def load_model_name_from_db(self):
         model_list = []
@@ -87,7 +204,14 @@ class AIConfigWindow(QDialog):
         return btn_layout
 
     def get_default_config(self):
-        default_config = {"analyse_model_name": self.analyse_model_combo_box.currentText()}
+        default_config = {
+            "analyse_model_name": self.analyse_model_combo_box.currentText(),
+            "channel_model_switch": {
+                "enabled": self.channel_model_switch_box.isChecked(),
+                "single_channel_model_name": self.single_channel_model_combo_box.currentData() or "",
+                "multi_channel_model_name": self.multi_channel_model_combo_box.currentData() or "",
+            },
+        }
         return default_config
 
     def on_default_btn_clicked(self):


### PR DESCRIPTION
## Summary
- Add channel-routed fixed mic hotkeys, session finalization, and AI model selection through the AI item advanced settings.
- Fix single-channel fixed mic AI prediction input normalization and keep the fixed mic analysis/session UI consistent with channel context and resizable session list layout.
- Merge the latest develop_ninebot session playback changes into the fixed mic session table while preserving the local channel/result workflow.

## Test plan
- [x] Run `python -m unittest unit_test.ui.test_fixed_mic_concurrent`
- [x] Run `python -m unittest unit_test.ui.test_fixed_mic_concurrent unit_test.base.test_playback_controller`
- [x] Manual verification of fixed mic test mode, mark mode, and session list resize/playback interactions

Made with [Cursor](https://cursor.com)