### PR TITLE
增加近期测试历史面板并支持回看结果

### DIFF
--- a/ui/sequence/recent_session_panel.py
+++ b/ui/sequence/recent_session_panel.py
@@ -1,0 +1,352 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Callable
+
+from PyQt5.QtCore import QSize, Qt, QTimer
+from PyQt5.QtGui import QColor
+from PyQt5.QtWidgets import (
+    QAbstractItemView,
+    QGroupBox,
+    QHBoxLayout,
+    QHeaderView,
+    QMessageBox,
+    QTableWidget,
+    QTableWidgetItem,
+    QToolButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from base.playback_controller import PlaybackController
+from consts import error_code
+from consts.running_consts import DEFAULT_DIR
+
+
+class RecentSessionPanel(QWidget):
+    def __init__(
+        self,
+        on_play_session: Callable[[str], Any] | None = None,
+        on_view_session: Callable[[str], None] | None = None,
+        parent=None,
+    ):
+        super().__init__(parent)
+        self.on_play_session = on_play_session
+        self.on_view_session = on_view_session
+        self.row_by_session_id = {}
+        self.playback_controller = PlaybackController()
+        self._playback_poll_timer = QTimer(self)
+        self._playback_poll_timer.setInterval(150)
+        self._playback_poll_timer.timeout.connect(self._on_playback_poll_timeout)
+        self._current_playing_session_id = None
+        self._current_playing_file = None
+        self.session_table = None
+        self.init_ui()
+
+    def init_ui(self):
+        group_box = QGroupBox("近期测试历史")
+        group_layout = QVBoxLayout()
+
+        self.session_table = QTableWidget(0, 7)
+        self.session_table.setHorizontalHeaderLabels(["时间", "条码", "型号", "模式", "结果", "播放", "查看结果"])
+        self.session_table.verticalHeader().setVisible(False)
+        self.session_table.verticalHeader().setDefaultSectionSize(34)
+        self.session_table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.session_table.setSelectionMode(QAbstractItemView.SingleSelection)
+        self.session_table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self.session_table.setAlternatingRowColors(True)
+        self.session_table.setWordWrap(False)
+        self.session_table.setTextElideMode(Qt.ElideMiddle)
+        self.session_table.setHorizontalScrollMode(QAbstractItemView.ScrollPerPixel)
+        self.session_table.setMinimumHeight(190)
+
+        header = self.session_table.horizontalHeader()
+        header_font = header.font()
+        header_font.setPixelSize(14)
+        header.setFont(header_font)
+        header.setMinimumHeight(34)
+        header.setDefaultAlignment(Qt.AlignCenter)
+        header.setStretchLastSection(False)
+        header.setSectionResizeMode(0, QHeaderView.Fixed)
+        header.setSectionResizeMode(1, QHeaderView.Stretch)
+        header.setSectionResizeMode(2, QHeaderView.Fixed)
+        header.setSectionResizeMode(3, QHeaderView.Fixed)
+        header.setSectionResizeMode(4, QHeaderView.Fixed)
+        header.setSectionResizeMode(5, QHeaderView.Fixed)
+        header.setSectionResizeMode(6, QHeaderView.Fixed)
+        self.session_table.setColumnWidth(0, 110)
+        self.session_table.setColumnWidth(2, 120)
+        self.session_table.setColumnWidth(3, 62)
+        self.session_table.setColumnWidth(4, 110)
+        self.session_table.setColumnWidth(5, 72)
+        self.session_table.setColumnWidth(6, 92)
+
+        group_layout.addWidget(self.session_table)
+        group_box.setLayout(group_layout)
+
+        layout = QVBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+        layout.addWidget(group_box)
+        self.setLayout(layout)
+
+    def reset_sessions(self):
+        self._stop_playback_if_needed()
+        self.row_by_session_id = {}
+        if self.session_table is not None:
+            self.session_table.setRowCount(0)
+            self.session_table.clearSelection()
+
+    def upsert_session(self, session_record: dict[str, Any]):
+        if not isinstance(session_record, dict):
+            return
+        session_id = str(session_record.get("session_id") or "").strip()
+        if not session_id or self.session_table is None:
+            return
+        row = self.row_by_session_id.get(session_id)
+        if row is None:
+            self._insert_session_row(session_record)
+            return
+        self._populate_row(row, session_record)
+        self._refresh_play_button_for_session(session_id)
+
+    def remove_session(self, session_id: str):
+        if not session_id or self.session_table is None:
+            return
+        row = self.row_by_session_id.get(session_id)
+        if row is None:
+            return
+        if session_id == self._current_playing_session_id:
+            self._stop_playback_if_needed()
+        self.session_table.removeRow(row)
+        self.row_by_session_id.pop(session_id, None)
+        for key, value in list(self.row_by_session_id.items()):
+            if value > row:
+                self.row_by_session_id[key] = value - 1
+
+    def _insert_session_row(self, session_record: dict[str, Any]):
+        self.session_table.insertRow(0)
+        for key in list(self.row_by_session_id.keys()):
+            self.row_by_session_id[key] = int(self.row_by_session_id[key]) + 1
+        session_id = str(session_record.get("session_id") or "")
+        self.row_by_session_id[session_id] = 0
+        self._populate_row(0, session_record)
+        self._refresh_play_button_for_session(session_id)
+
+    def _populate_row(self, row: int, session_record: dict[str, Any]):
+        values = [
+            session_record.get("time_text") or "-",
+            session_record.get("barcode") or "-",
+            session_record.get("product_model") or "-",
+            session_record.get("mode_text", ""),
+            session_record.get("result_label") or "-",
+        ]
+        for col, value in enumerate(values):
+            item = self.make_table_item(str(value))
+            if col in (1, 2):
+                item.setToolTip(str(value))
+            elif col == 4:
+                self._apply_result_item_style(item, str(value))
+            self.session_table.setItem(row, col, item)
+        session_id = str(session_record.get("session_id") or "")
+        self.session_table.setCellWidget(row, 5, self.create_play_cell(session_id))
+        self.session_table.setCellWidget(row, 6, self.create_view_cell(session_id))
+
+    @staticmethod
+    def _apply_result_item_style(item: QTableWidgetItem, value: str):
+        result_text = str(value or "").strip().lower()
+        if result_text == "ok":
+            item.setForeground(QColor(0, 140, 0))
+        elif result_text == "ng":
+            item.setForeground(QColor(200, 0, 0))
+        else:
+            item.setForeground(QColor(50, 50, 50))
+
+    def create_play_button(self, session_id: str):
+        play_btn = QToolButton()
+        play_btn.setText("播放")
+        play_btn.setFixedSize(46, 24)
+        play_btn.setAutoRaise(False)
+        play_btn.setStyleSheet(
+            """
+            QToolButton {
+                border: 1px solid rgba(120, 120, 120, 0.25);
+                background-color: rgba(120, 120, 120, 0.04);
+                border-radius: 3px;
+                padding: 0px 6px;
+            }
+            QToolButton:hover:enabled {
+                background-color: rgba(120, 120, 120, 0.08);
+            }
+            QToolButton:pressed:enabled {
+                background-color: rgba(120, 120, 120, 0.12);
+            }
+            QToolButton:disabled {
+                color: rgb(160, 160, 160);
+                border-color: rgba(160, 160, 160, 0.2);
+                background-color: rgba(120, 120, 120, 0.02);
+            }
+            """
+        )
+        play_btn.clicked.connect(lambda: self._on_play_button_clicked(session_id))
+        return play_btn
+
+    def create_view_button(self, session_id: str):
+        view_btn = QToolButton()
+        view_btn.setText("查看")
+        view_btn.setFixedSize(56, 24)
+        view_btn.setAutoRaise(False)
+        view_btn.clicked.connect(lambda: self._on_view_button_clicked(session_id))
+        return view_btn
+
+    def create_play_cell(self, session_id: str):
+        cell_widget = QWidget()
+        cell_layout = QHBoxLayout()
+        cell_layout.setContentsMargins(0, 0, 0, 0)
+        cell_layout.setSpacing(0)
+        cell_layout.addStretch()
+        cell_layout.addWidget(self.create_play_button(session_id), alignment=Qt.AlignCenter)
+        cell_layout.addStretch()
+        cell_widget.setLayout(cell_layout)
+        return cell_widget
+
+    def create_view_cell(self, session_id: str):
+        cell_widget = QWidget()
+        cell_layout = QHBoxLayout()
+        cell_layout.setContentsMargins(0, 0, 0, 0)
+        cell_layout.setSpacing(0)
+        cell_layout.addStretch()
+        cell_layout.addWidget(self.create_view_button(session_id), alignment=Qt.AlignCenter)
+        cell_layout.addStretch()
+        cell_widget.setLayout(cell_layout)
+        return cell_widget
+
+    def _on_view_button_clicked(self, session_id: str):
+        if callable(self.on_view_session):
+            self.on_view_session(session_id)
+
+    def _resolve_session_record(self, session_id: str):
+        if not callable(self.on_play_session):
+            return None
+        try:
+            return self.on_play_session(session_id)
+        except Exception:
+            return None
+
+    def _resolve_session_playback_path(self, session_id: str):
+        session_record = self._resolve_session_record(session_id)
+        if isinstance(session_record, str):
+            candidate_paths = [session_record]
+        elif isinstance(session_record, dict):
+            recorded_signal_info = session_record.get("recorded_signal_info", {}) or {}
+            candidate_paths = [
+                session_record.get("recorded_path"),
+                recorded_signal_info.get("file_path"),
+            ]
+        else:
+            candidate_paths = []
+
+        for candidate in candidate_paths:
+            if not candidate:
+                continue
+            normalized_candidate = str(candidate)
+            if not os.path.isabs(normalized_candidate):
+                normalized_candidate = os.path.join(DEFAULT_DIR, normalized_candidate).replace("\\", "/")
+            normalized_candidate = os.path.abspath(normalized_candidate)
+            if os.path.isfile(normalized_candidate):
+                return normalized_candidate
+        return None
+
+    @staticmethod
+    def _get_cell_center_widget(table, row, column):
+        cell_widget = table.cellWidget(row, column)
+        if cell_widget is None or cell_widget.layout() is None or cell_widget.layout().count() < 2:
+            return None
+        item = cell_widget.layout().itemAt(1)
+        return item.widget() if item is not None else None
+
+    def _refresh_play_button_for_session(self, session_id: str):
+        row = self.row_by_session_id.get(session_id)
+        if row is None or self.session_table is None:
+            return
+        play_btn = self._get_cell_center_widget(self.session_table, row, 5)
+        if play_btn is None:
+            return
+
+        playback_path = self._resolve_session_playback_path(session_id)
+        is_current = session_id == self._current_playing_session_id and self.playback_controller.is_audio_playing()
+
+        play_btn.setEnabled(playback_path is not None)
+        play_btn.setText("停止" if is_current else "播放")
+        if playback_path is None:
+            play_btn.setToolTip("当前记录暂无可播放音频")
+        else:
+            play_btn.setToolTip(playback_path)
+
+    def refresh_session(self, session_id: str):
+        self._refresh_play_button_for_session(session_id)
+
+    def refresh_all_play_buttons(self):
+        for session_id in list(self.row_by_session_id.keys()):
+            self._refresh_play_button_for_session(session_id)
+
+    def _clear_playing_state(self):
+        self._current_playing_session_id = None
+        self._current_playing_file = None
+        self._playback_poll_timer.stop()
+        self.refresh_all_play_buttons()
+
+    def _stop_playback_if_needed(self):
+        if self.playback_controller.is_audio_playing() or self._current_playing_session_id is not None:
+            self.playback_controller.stop_audio_playback()
+        self._clear_playing_state()
+
+    def _on_play_button_clicked(self, session_id: str):
+        playback_path = self._resolve_session_playback_path(session_id)
+        if not playback_path:
+            self._refresh_play_button_for_session(session_id)
+            return
+
+        if self.playback_controller.is_audio_playing() and session_id == self._current_playing_session_id:
+            self.playback_controller.stop_audio_playback()
+            self._clear_playing_state()
+            return
+
+        if self.playback_controller.is_audio_playing():
+            self.playback_controller.stop_audio_playback()
+            self._clear_playing_state()
+
+        code, msg = self.playback_controller.start_audio_playback(playback_path)
+        if code != error_code.OK:
+            QMessageBox.warning(self, "提示", msg)
+            self._clear_playing_state()
+            return
+
+        self._current_playing_session_id = session_id
+        self._current_playing_file = playback_path
+        self.refresh_all_play_buttons()
+        if not self._playback_poll_timer.isActive():
+            self._playback_poll_timer.start()
+
+    def _on_playback_poll_timeout(self):
+        if not self.playback_controller.is_audio_playing():
+            self._clear_playing_state()
+            return
+
+        playing_file = self.playback_controller.get_current_playing_file()
+        if not playing_file or not self._current_playing_file:
+            self._clear_playing_state()
+            return
+
+        if os.path.abspath(playing_file) != os.path.abspath(self._current_playing_file):
+            self._clear_playing_state()
+
+    def closeEvent(self, event):
+        self._stop_playback_if_needed()
+        super().closeEvent(event)
+
+    @staticmethod
+    def make_table_item(text: str):
+        item = QTableWidgetItem(text)
+        item.setTextAlignment(Qt.AlignCenter)
+        return item

--- a/ui/sequence/sequence_widget.py
+++ b/ui/sequence/sequence_widget.py
@@ -135,6 +135,13 @@ class SequenceWindow(
         self.streaming_mode = None  # "play_record" or "record_only"
         self._active_input_channels = [0]
         self.channel_workspace = None
+        self.recent_session_panel = None
+        self.recent_test_sessions = []
+        self.recent_test_session_by_id = {}
+        self._recent_session_seq = 0
+        self._recent_session_max_items = 20
+        self._current_recent_session_id = None
+        self._pending_recent_session_append = False
         self._streaming_first_chunk_logged = False
 
         # Analysis window geometry persistence (per analysis item key)

--- a/ui/sequence/sequence_widget_analysis_ops.py
+++ b/ui/sequence/sequence_widget_analysis_ops.py
@@ -1,3 +1,4 @@
+import os
 import threading
 from datetime import datetime
 
@@ -30,6 +31,21 @@ from ui.signal_analysis_window import AnalysisResultSummaryWindow, get_class_map
 
 
 class SequenceWidgetAnalysisOpsMixin:
+    _RECENT_SESSION_WAITING_TEXT = "等待测试完成"
+
+    @classmethod
+    def _format_recent_session_result_label(cls, result_label):
+        normalized = str(result_label or "").strip()
+        lowered = normalized.lower()
+        if not normalized:
+            return "not labeled"
+        if normalized == cls._RECENT_SESSION_WAITING_TEXT:
+            return cls._RECENT_SESSION_WAITING_TEXT
+        if lowered in ("ok", "ng"):
+            return lowered
+        if lowered in ("not_labeled", "not labeled", "none", "-", "null"):
+            return "not labeled"
+        return normalized
 
     def on_clicked_player_btn(self, label="not_labeled"):
         if not self.sequence_config:
@@ -64,24 +80,189 @@ class SequenceWidgetAnalysisOpsMixin:
             self.recorded_signal_info = {"file_path": file_path, "barcode": None, "labels": "not_labeled"}
         except Exception:
             pass
-        acq_detail = self.sequence_config[0]["seq1"]["acq"]["detail"]
-        sample_rate = acq_detail.get("sample_rate", 44100)
-        audio_multi, _ = librosa.load(file_path, sr=sample_rate, mono=False)
+        self._load_audio_file_to_data_struct(file_path)
+
+        self.data_btn.setEnabled(True)
+        if self.analysis_config.get("auto_analysis"):
+            self.run()
+
+    def _load_audio_file_to_data_struct(self, file_path: str, sample_rate: float | None = None):
+        if not file_path:
+            raise ValueError("missing audio file path")
+
+        target_sample_rate = sample_rate
+        if target_sample_rate is None:
+            acq_detail = self.sequence_config[0]["seq1"]["acq"]["detail"] if self.sequence_config else {}
+            target_sample_rate = acq_detail.get("sample_rate", 44100)
+
+        audio_multi, _ = librosa.load(file_path, sr=target_sample_rate, mono=False)
         audio_multi = np.asarray(audio_multi, dtype=np.float32)
         if audio_multi.ndim == 1:
             audio_multi = audio_multi.reshape(1, -1)
         audio_multi = audio_multi.T
         self.data_struct.store_wave_data_multi = audio_multi
         self.data_struct.store_wave_data = audio_multi.mean(axis=1).astype(np.float32, copy=False)
-        self.data_struct.sample_rate = sample_rate
+        self.data_struct.sample_rate = target_sample_rate
         audio_y, _ = librosa.load(file_path, sr=None)
         self.data_struct.audio_lenth = len(audio_y)
         self._clear_plot_area()
         self.plot_waveform_to_workspace(self.data_struct.store_wave_data_multi, self.data_struct.sample_rate)
 
-        self.data_btn.setEnabled(True)
-        if self.analysis_config.get("auto_analysis"):
+    @staticmethod
+    def _get_recent_session_mode_text(mode: str) -> str:
+        return ""
+
+    def _resolve_recent_session_path(self, session_record: dict | None):
+        if not isinstance(session_record, dict):
+            return None
+        candidate_paths = [session_record.get("recorded_path")]
+        recorded_signal_info = session_record.get("recorded_signal_info", {}) or {}
+        candidate_paths.append(recorded_signal_info.get("file_path"))
+        for candidate in candidate_paths:
+            if not candidate:
+                continue
+            normalized_candidate = str(candidate)
+            if not os.path.isabs(normalized_candidate):
+                normalized_candidate = os.path.join(DEFAULT_DIR, normalized_candidate).replace("\\", "/")
+            normalized_candidate = os.path.abspath(normalized_candidate)
+            if os.path.isfile(normalized_candidate):
+                return normalized_candidate
+        return None
+
+    def _build_recent_session_record(self, result_label: str):
+        recorded_path = self.recorded_path
+        if not recorded_path and isinstance(self.recorded_signal_info, dict):
+            recorded_path = self.recorded_signal_info.get("file_path")
+        if not recorded_path:
+            return None
+
+        self._recent_session_seq += 1
+        session_id = f"recent_{self._recent_session_seq:06d}"
+        now_dt = datetime.now()
+        recorded_signal_info = dict(self.recorded_signal_info or {})
+        barcode = recorded_signal_info.get("barcode") or self.lineedit_s_or_n.text().strip() or "-"
+        product_model = self.lineedit_type.text().strip() or recorded_signal_info.get("product_model") or "-"
+        mode_text = self._get_recent_session_mode_text(getattr(self.count_board, "mode", ""))
+
+        return {
+            "session_id": session_id,
+            "created_at": now_dt.isoformat(timespec="seconds"),
+            "time_text": now_dt.strftime("%H:%M:%S"),
+            "barcode": barcode,
+            "product_model": product_model,
+            "mode_text": mode_text,
+            "result_label": self._format_recent_session_result_label(result_label),
+            "recorded_path": recorded_path,
+            "recorded_signal_info": recorded_signal_info,
+            "analysis_result_dict": dict(getattr(self.data_struct, "analysis_result_dict", {}) or {}),
+            "sample_rate": self.data_struct.sample_rate,
+        }
+
+    def _append_recent_session_from_current_run(self, result_label: str):
+        session_record = self._build_recent_session_record(result_label=result_label)
+        if session_record is None:
+            return
+
+        session_id = session_record["session_id"]
+        self.recent_test_sessions.insert(0, session_id)
+        self.recent_test_session_by_id[session_id] = session_record
+        self._current_recent_session_id = session_id
+        self._pending_recent_session_append = False
+        if self.recent_session_panel is not None:
+            self.recent_session_panel.upsert_session(session_record)
+
+        while len(self.recent_test_sessions) > int(self._recent_session_max_items):
+            removed_session_id = self.recent_test_sessions.pop()
+            self.recent_test_session_by_id.pop(removed_session_id, None)
+            if self.recent_session_panel is not None:
+                self.recent_session_panel.remove_session(removed_session_id)
+
+    def _update_recent_session(self, session_id: str, **fields):
+        if not session_id:
+            return
+        session_record = self.recent_test_session_by_id.get(session_id)
+        if not isinstance(session_record, dict):
+            return
+        session_record.update(fields)
+        if self.recent_session_panel is not None:
+            self.recent_session_panel.upsert_session(session_record)
+
+    def _update_current_recent_session_result(self, result_label: str):
+        session_id = getattr(self, "_current_recent_session_id", None)
+        if not session_id:
+            return
+        self._update_recent_session(
+            session_id,
+            result_label=self._format_recent_session_result_label(result_label),
+            recorded_path=self.recorded_path,
+            recorded_signal_info=dict(self.recorded_signal_info or {}),
+            analysis_result_dict=dict(getattr(self.data_struct, "analysis_result_dict", {}) or {}),
+            sample_rate=self.data_struct.sample_rate,
+        )
+
+    def _begin_recent_session_for_current_run(self):
+        self._current_recent_session_id = None
+        self._append_recent_session_from_current_run(self._RECENT_SESSION_WAITING_TEXT)
+
+    def _resolve_recent_session(self, session_id: str):
+        return self.recent_test_session_by_id.get(session_id)
+
+    def _show_recent_session_analysis_by_id(self, session_id: str):
+        session_record = self._resolve_recent_session(session_id)
+        if not isinstance(session_record, dict):
+            return
+
+        playback_path = self._resolve_recent_session_path(session_record)
+        if not playback_path:
+            QMessageBox.information(self, "提示", "当前记录音频文件不可用，无法查看分析结果。")
+            return
+
+        previous_recorded_path = self.recorded_path
+        previous_recorded_signal_info = dict(self.recorded_signal_info or {})
+        previous_store_wave_data = (
+            None if self.data_struct.store_wave_data is None else np.asarray(self.data_struct.store_wave_data).copy()
+        )
+        previous_store_wave_data_multi = (
+            None
+            if getattr(self.data_struct, "store_wave_data_multi", None) is None
+            else np.asarray(self.data_struct.store_wave_data_multi).copy()
+        )
+        previous_sample_rate = self.data_struct.sample_rate
+        previous_audio_length = getattr(self.data_struct, "audio_lenth", 0)
+        previous_analysis_result_dict = dict(getattr(self.data_struct, "analysis_result_dict", {}) or {})
+        previous_mode = getattr(self.count_board, "mode", "")
+        previous_excel_export_cache = self._excel_export_cache
+        previous_excel_exported_record_id = self._excel_exported_record_id
+
+        try:
+            self._close_analysis_windows()
+            self.recorded_path = playback_path
+            self.recorded_signal_info = dict(session_record.get("recorded_signal_info", {}) or {})
+            if not self.recorded_signal_info.get("file_path"):
+                self.recorded_signal_info["file_path"] = playback_path
+            self._load_audio_file_to_data_struct(
+                playback_path,
+                sample_rate=session_record.get("sample_rate") or previous_sample_rate or None,
+            )
+            self.count_board.mode = "view"
             self.run()
+        except Exception as e:
+            QMessageBox.warning(self, "提示", f"查看近期测试结果失败: {e}")
+        finally:
+            self.count_board.mode = previous_mode
+            self.recorded_path = previous_recorded_path
+            self.recorded_signal_info = previous_recorded_signal_info
+            self.data_struct.store_wave_data = previous_store_wave_data
+            self.data_struct.store_wave_data_multi = previous_store_wave_data_multi
+            self.data_struct.sample_rate = previous_sample_rate
+            self.data_struct.audio_lenth = previous_audio_length
+            self.data_struct.analysis_result_dict = previous_analysis_result_dict
+            self._excel_export_cache = previous_excel_export_cache
+            self._excel_exported_record_id = previous_excel_exported_record_id
+            if previous_store_wave_data_multi is not None:
+                self.plot_waveform_to_workspace(previous_store_wave_data_multi, previous_sample_rate)
+            else:
+                self._clear_plot_area()
 
     def start_this_play(self, label="not_labeled"):
         cancel_pending_serial_trigger = getattr(self, "_cancel_pending_serial_trigger_delay", None)
@@ -281,6 +462,7 @@ class SequenceWidgetAnalysisOpsMixin:
             )
             self.streaming_mode = "record_only"
             self.streaming_stimulus_data = None
+            self._begin_recent_session_for_current_run()
 
             # Start polling timer to process queue and detect completion
             self.streaming_poll_timer.start(50)  # Poll every 50ms
@@ -415,6 +597,9 @@ class SequenceWidgetAnalysisOpsMixin:
 
         # Show summary window at the end (also in test mode), only if dict is not empty
         self._maybe_show_analysis_result_summary(width, height)
+        if getattr(self.count_board, "mode", "") != "test":
+            result_label = self.recorded_signal_info.get("labels", "-") if isinstance(self.recorded_signal_info, dict) else "-"
+            self._update_current_recent_session_result(result_label=result_label)
 
     @staticmethod
     def _is_channel_mismatch_error(err: Exception) -> bool:

--- a/ui/sequence/sequence_widget_barcode_ops.py
+++ b/ui/sequence/sequence_widget_barcode_ops.py
@@ -247,6 +247,10 @@ class SequenceWidgetBarcodeOpsMixin:
         self.update_audio_label_info()
         self._maybe_export_excel_results()
         self.update_recorded_signal_info_to_db()
+        try:
+            self._update_current_recent_session_result(self.recorded_signal_info.get("labels", "-"))
+        except Exception:
+            pass
         self._close_analysis_windows()
 
         self.mark_result()
@@ -298,6 +302,7 @@ class SequenceWidgetBarcodeOpsMixin:
 
         self._maybe_export_excel_results()
         self.update_recorded_signal_info_to_db()
+        self._update_current_recent_session_result(label)
         self.player_status_flag = False
         self.signal_info.clear()
         self.lineedit_s_or_n.clear()

--- a/ui/sequence/sequence_widget_streaming_ops.py
+++ b/ui/sequence/sequence_widget_streaming_ops.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 import numpy as np
 from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QApplication, QHBoxLayout, QMessageBox, QVBoxLayout, QDialog, QLabel
+from PyQt5.QtWidgets import QApplication, QHBoxLayout, QMessageBox, QVBoxLayout, QDialog, QLabel, QSplitter
 
 from base.excel_result_exporter import (
     build_excel_from_csv_spool,
@@ -18,6 +18,7 @@ from base.soundcard_calibration_manager import get_mic_v2pa_factor
 from consts import error_code
 from consts.running_consts import DEFAULT_DIR
 from ui.sequence.channel_plot_workspace import ChannelPlotWorkspace
+from ui.sequence.recent_session_panel import RecentSessionPanel
 
 
 class SequenceWidgetStreamingOpsMixin:
@@ -138,14 +139,27 @@ class SequenceWidgetStreamingOpsMixin:
         """
         layout = QHBoxLayout()
         self.channel_workspace = ChannelPlotWorkspace(self)
+        self.recent_session_panel = RecentSessionPanel(
+            on_play_session=self._resolve_recent_session,
+            on_view_session=self._show_recent_session_analysis_by_id,
+            parent=self,
+        )
         # try:
         #     self.refresh_channel_windows()
         # except Exception:
         #     self.channel_workspace.set_channels([0])
 
+        right_splitter = QSplitter(Qt.Vertical)
+        right_splitter.addWidget(self.channel_workspace)
+        right_splitter.addWidget(self.recent_session_panel)
+        right_splitter.setChildrenCollapsible(False)
+        right_splitter.setStretchFactor(0, 8)
+        right_splitter.setStretchFactor(1, 3)
+        right_splitter.setSizes([640, 240])
+
         layout.addWidget(self.count_board, stretch=1)
         layout.addSpacing(20)
-        layout.addWidget(self.channel_workspace, stretch=8)
+        layout.addWidget(right_splitter, stretch=8)
         layout.setContentsMargins(40, 20, 40, 20)
         layout.setSpacing(30)
         return layout
@@ -606,6 +620,12 @@ class SequenceWidgetStreamingOpsMixin:
 
             self._awaiting_ok_ng = True
             self._sn_clear_on_next_scan = True
+            self._pending_recent_session_append = True
+            try:
+                current_label = (self.recorded_signal_info or {}).get("labels", "not_labeled")
+            except Exception:
+                current_label = "not_labeled"
+            self._update_current_recent_session_result(current_label)
             # 更稳的体验：录音结束后让下一次扫码直接覆盖旧 S/N（避免拼接）
             if self.barcode_scanner_box.isChecked():
                 try:
@@ -644,6 +664,7 @@ class SequenceWidgetStreamingOpsMixin:
             self.replayer_btn.setEnabled(True)
             self._awaiting_ok_ng = False
             self._sn_clear_on_next_scan = False
+            self._pending_recent_session_append = False
             self._record_workflow_busy = False
             self.update_player_btn_is_paused()
             try:


### PR DESCRIPTION
## Summary
- 在测试主界面新增近期测试历史面板，支持顶部追加最近记录、结果状态展示和播放最近录音
- 支持从近期记录重新打开对应分析结果，并在回看后恢复当前工作态
- 优化面板显示细节，包括结果颜色、可拖拽高度、标题与列宽调整

## Test Plan
- [x] 对相关 Python 文件执行 python -m py_compile
- [x] 检查相关文件 IDE 诊断，无新增 linter 报错
- [ ] 在应用中手动验证录音、播放和查看结果流程