### PR TITLE
完善近期测试历史的标签编辑与交互体验。

### DIFF
--- a/base/file_ops.py
+++ b/base/file_ops.py
@@ -251,12 +251,13 @@ class FileOps(object):
         """
         Move the recorded WAV file to the directory corresponding to its label.
 
-        This function moves the recorded audio file to a predefined directory structure based on its label (OK/NG).
+        This function moves the recorded audio file to a predefined directory structure based on its label
+        (OK/NG/not_labeled).
         If the target directories do not exist, they will be created automatically.
 
         Args:
             recorded_path (str): The full path of the recorded file
-            label (str): File label, should be either "OK" or "NG"
+            label (str): File label, should be either "OK", "NG" or "not_labeled"
 
         Returns:
             str: The full path of the file after moving, or an empty string if the filename is empty
@@ -269,14 +270,21 @@ class FileOps(object):
         for path in dir_paths:
             if not os.path.exists(path):
                 os.makedirs(path)
-        file_name = os.path.basename(recorded_path)
+        source_path = str(recorded_path or "")
+        file_name = os.path.basename(source_path)
         target_path = ""
         if file_name:
             if label == "OK":
                 target_path = model_consts.STORED_RECORDED_OK_PATH + "/" + file_name
             elif label == "NG":
                 target_path = model_consts.STORED_RECORDED_NG_PATH + "/" + file_name
+            elif label == "not_labeled":
+                target_path = model_consts.STORED_RECORDED_UNLABELED_PATH + "/" + file_name
             else:
                 return
-            shutil.move(recorded_path, target_path)
+            if os.path.abspath(source_path) == os.path.abspath(target_path):
+                return target_path
+            if os.path.exists(target_path):
+                raise FileExistsError(f"Target file already exists: {target_path}")
+            shutil.move(source_path, target_path)
         return target_path

--- a/ui/sequence/recent_session_panel.py
+++ b/ui/sequence/recent_session_panel.py
@@ -3,13 +3,15 @@ from __future__ import annotations
 import os
 from typing import Any, Callable
 
-from PyQt5.QtCore import QSize, Qt, QTimer
+from PyQt5.QtCore import QEvent, QSize, Qt, QTimer
 from PyQt5.QtGui import QColor
 from PyQt5.QtWidgets import (
     QAbstractItemView,
+    QComboBox,
     QHBoxLayout,
     QHeaderView,
     QMessageBox,
+    QSizePolicy,
     QTableWidget,
     QTableWidgetItem,
     QToolButton,
@@ -23,17 +25,52 @@ from consts.running_consts import DEFAULT_DIR
 from ui.sequence.motor_panel_common import MotorSectionCard
 
 
+class _ClickableResultComboBox(QComboBox):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setEditable(True)
+        if self.lineEdit() is not None:
+            self.lineEdit().installEventFilter(self)
+
+    def mousePressEvent(self, event):
+        if self.isEnabled() and event is not None and event.button() == Qt.LeftButton:
+            self.setFocus(Qt.MouseFocusReason)
+            self.showPopup()
+            event.accept()
+            return
+        super().mousePressEvent(event)
+
+    def eventFilter(self, watched, event):
+        if (
+            watched is self.lineEdit()
+            and event is not None
+            and event.type() == QEvent.MouseButtonPress
+            and getattr(event, "button", lambda: None)() == Qt.LeftButton
+            and self.isEnabled()
+        ):
+            self.setFocus(Qt.MouseFocusReason)
+            self.showPopup()
+            return True
+        return super().eventFilter(watched, event)
+
+
 class RecentSessionPanel(QWidget):
+    _RESULT_OPTIONS = ("OK", "NG", "not_labeled")
+    _RESULT_WAITING_TEXT = "等待测试完成"
+
     def __init__(
         self,
         on_play_session: Callable[[str], Any] | None = None,
         on_view_session: Callable[[str], None] | None = None,
+        on_change_session_result: Callable[[str, str], Any] | None = None,
         parent=None,
     ):
         super().__init__(parent)
         self.on_play_session = on_play_session
         self.on_view_session = on_view_session
+        self.on_change_session_result = on_change_session_result
         self.row_by_session_id = {}
+        self._result_editable = False
         self.playback_controller = PlaybackController()
         self._playback_poll_timer = QTimer(self)
         self._playback_poll_timer.setInterval(150)
@@ -118,16 +155,16 @@ class RecentSessionPanel(QWidget):
         header.setDefaultAlignment(Qt.AlignCenter)
         header.setStretchLastSection(False)
         header.setSectionResizeMode(0, QHeaderView.Fixed)
-        header.setSectionResizeMode(1, QHeaderView.Stretch)
-        header.setSectionResizeMode(2, QHeaderView.Fixed)
+        header.setSectionResizeMode(1, QHeaderView.Fixed)
+        header.setSectionResizeMode(2, QHeaderView.Stretch)
         header.setSectionResizeMode(3, QHeaderView.Fixed)
         header.setSectionResizeMode(4, QHeaderView.Fixed)
         header.setSectionResizeMode(5, QHeaderView.Fixed)
         header.setSectionResizeMode(6, QHeaderView.Fixed)
         self.session_table.setColumnWidth(0, 158)
-        self.session_table.setColumnWidth(2, 120)
+        self.session_table.setColumnWidth(1, 136)
         self.session_table.setColumnWidth(3, 62)
-        self.session_table.setColumnWidth(4, 110)
+        self.session_table.setColumnWidth(4, 138)
         self.session_table.setColumnWidth(5, 72)
         self.session_table.setColumnWidth(6, 92)
 
@@ -188,15 +225,13 @@ class RecentSessionPanel(QWidget):
             session_record.get("barcode") or "-",
             session_record.get("product_model") or "-",
             session_record.get("mode_text", ""),
-            session_record.get("result_label") or "-",
         ]
         for col, value in enumerate(values):
             item = self.make_table_item(str(value))
             if col in (1, 2):
                 item.setToolTip(str(value))
-            elif col == 4:
-                self._apply_result_item_style(item, str(value))
             self.session_table.setItem(row, col, item)
+        self._set_result_cell(row, session_record)
         session_id = str(session_record.get("session_id") or "")
         self.session_table.setCellWidget(row, 5, self.create_play_cell(session_id))
         self.session_table.setCellWidget(row, 6, self.create_view_cell(session_id))
@@ -210,6 +245,149 @@ class RecentSessionPanel(QWidget):
             item.setForeground(QColor(200, 0, 0))
         else:
             item.setForeground(QColor(50, 50, 50))
+
+    @classmethod
+    def _normalize_result_label_for_edit(cls, session_record: dict[str, Any] | None):
+        if not isinstance(session_record, dict):
+            return ""
+        recorded_signal_info = session_record.get("recorded_signal_info", {}) or {}
+        candidate_values = [recorded_signal_info.get("labels"), session_record.get("result_label")]
+        for value in candidate_values:
+            normalized = str(value or "").strip()
+            lowered = normalized.lower()
+            if lowered == "ok":
+                return "OK"
+            if lowered == "ng":
+                return "NG"
+            if normalized == cls._RESULT_WAITING_TEXT:
+                return cls._RESULT_WAITING_TEXT
+            if lowered in ("not_labeled", "not labeled", "none", "-", "null"):
+                return "not_labeled"
+        return ""
+
+    def _create_result_item(self, session_record: dict[str, Any]):
+        value = str(session_record.get("result_label") or "-")
+        item = self.make_table_item(value)
+        self._apply_result_item_style(item, value)
+        if value == self._RESULT_WAITING_TEXT:
+            item.setToolTip(value)
+        return item
+
+    def _apply_result_combo_style(self, combo: QComboBox, value: str):
+        normalized = str(value or "").strip().lower()
+        color = "#323232"
+        if normalized == "ok":
+            color = "#008c00"
+        elif normalized == "ng":
+            color = "#c80000"
+        combo.setStyleSheet(
+            f"""
+            QComboBox {{
+                color: {color};
+                background: transparent;
+                border: none;
+                padding: 0px 16px 0px 2px;
+                font-family: 'SimSun';
+                font-size: 13px;
+            }}
+            QComboBox:hover {{
+                background: rgba(68, 114, 196, 0.06);
+                border-radius: 3px;
+            }}
+            QComboBox::drop-down {{
+                width: 14px;
+                border: none;
+                background: transparent;
+            }}
+            QComboBox::down-arrow {{
+                width: 8px;
+                height: 8px;
+            }}
+            QComboBox QAbstractItemView {{
+                padding: 2px;
+            }}
+            QComboBox QLineEdit {{
+                background: transparent;
+                border: none;
+                selection-background-color: transparent;
+            }}
+            """
+        )
+
+    def _create_result_combo(self, session_id: str, session_record: dict[str, Any]):
+        combo = _ClickableResultComboBox()
+        combo.lineEdit().setReadOnly(True)
+        combo.lineEdit().setAlignment(Qt.AlignCenter)
+        combo.lineEdit().setFrame(False)
+        combo.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        combo.setFixedHeight(24)
+        for option in self._RESULT_OPTIONS:
+            combo.addItem(option)
+        current_value = self._normalize_result_label_for_edit(session_record) or "not_labeled"
+        combo.setCurrentText(current_value)
+        self._apply_result_combo_style(combo, current_value)
+        combo.currentTextChanged.connect(lambda value, sid=session_id: self._on_result_combo_changed(sid, value))
+        return combo
+
+    def _can_edit_result_for_session(self, session_record: dict[str, Any]):
+        if str(session_record.get("result_label") or "").strip() == self._RESULT_WAITING_TEXT:
+            return False
+        normalized = self._normalize_result_label_for_edit(session_record)
+        return self._result_editable and normalized in self._RESULT_OPTIONS
+
+    def _set_result_cell(self, row: int, session_record: dict[str, Any]):
+        if self.session_table is None:
+            return
+        session_id = str(session_record.get("session_id") or "")
+        self.session_table.removeCellWidget(row, 4)
+        existing_item = self.session_table.takeItem(row, 4)
+        if existing_item is not None:
+            del existing_item
+        if self._can_edit_result_for_session(session_record):
+            cell_widget = QWidget()
+            cell_layout = QHBoxLayout()
+            cell_layout.setContentsMargins(0, 0, 0, 0)
+            cell_layout.setSpacing(0)
+            cell_layout.addWidget(self._create_result_combo(session_id, session_record))
+            cell_widget.setLayout(cell_layout)
+            self.session_table.setCellWidget(row, 4, cell_widget)
+            return
+        self.session_table.setItem(row, 4, self._create_result_item(session_record))
+
+    def _refresh_result_cell_for_session(self, session_id: str):
+        row = self.row_by_session_id.get(session_id)
+        if row is None:
+            return
+        session_record = self._resolve_session_record(session_id)
+        if not isinstance(session_record, dict):
+            return
+        self._set_result_cell(row, session_record)
+
+    def set_result_editable(self, editable: bool):
+        editable = bool(editable)
+        if self._result_editable == editable:
+            return
+        self._result_editable = editable
+        for session_id in list(self.row_by_session_id.keys()):
+            self._refresh_result_cell_for_session(session_id)
+
+    def _on_result_combo_changed(self, session_id: str, new_label: str):
+        if not self._result_editable or not callable(self.on_change_session_result):
+            self._refresh_result_cell_for_session(session_id)
+            return
+        session_record = self._resolve_session_record(session_id)
+        current_label = self._normalize_result_label_for_edit(session_record)
+        if current_label == str(new_label or "").strip():
+            combo = self._get_cell_center_widget(self.session_table, self.row_by_session_id.get(session_id), 4)
+            if isinstance(combo, QComboBox):
+                self._apply_result_combo_style(combo, current_label)
+            return
+        try:
+            changed = self.on_change_session_result(session_id, str(new_label or "").strip())
+        except Exception:
+            changed = False
+        if changed is False:
+            self._refresh_result_cell_for_session(session_id)
 
     def create_play_button(self, session_id: str):
         play_btn = QToolButton()
@@ -309,9 +487,10 @@ class RecentSessionPanel(QWidget):
     @staticmethod
     def _get_cell_center_widget(table, row, column):
         cell_widget = table.cellWidget(row, column)
-        if cell_widget is None or cell_widget.layout() is None or cell_widget.layout().count() < 2:
+        if cell_widget is None or cell_widget.layout() is None or cell_widget.layout().count() == 0:
             return None
-        item = cell_widget.layout().itemAt(1)
+        item_index = 1 if cell_widget.layout().count() >= 2 else 0
+        item = cell_widget.layout().itemAt(item_index)
         return item.widget() if item is not None else None
 
     def _refresh_play_button_for_session(self, session_id: str):
@@ -325,7 +504,8 @@ class RecentSessionPanel(QWidget):
         playback_path = self._resolve_session_playback_path(session_id)
         is_current = session_id == self._current_playing_session_id and self.playback_controller.is_audio_playing()
 
-        play_btn.setEnabled(playback_path is not None)
+        # Keep the button clickable so missing historical audio can show a user-facing prompt.
+        play_btn.setEnabled(True)
         play_btn.setText("停止" if is_current else "播放")
         if playback_path is None:
             play_btn.setToolTip("当前记录暂无可播放音频")
@@ -353,6 +533,7 @@ class RecentSessionPanel(QWidget):
     def _on_play_button_clicked(self, session_id: str):
         playback_path = self._resolve_session_playback_path(session_id)
         if not playback_path:
+            QMessageBox.information(self, "提示", "当前记录音频文件不可用，无法播放音频。")
             self._refresh_play_button_for_session(session_id)
             return
 

--- a/ui/sequence/sequence_widget_analysis_ops.py
+++ b/ui/sequence/sequence_widget_analysis_ops.py
@@ -7,6 +7,7 @@ import numpy as np
 from PyQt5.QtCore import QSize
 from PyQt5.QtWidgets import QApplication, QFileDialog, QMessageBox
 
+from consts import error_code
 from base.excel_result_exporter import (
     build_excel_from_csv_spool,
     export_analysis_to_csv_spool,
@@ -46,6 +47,18 @@ class SequenceWidgetAnalysisOpsMixin:
         if lowered in ("not_labeled", "not labeled", "none", "-", "null"):
             return "not labeled"
         return normalized
+
+    @staticmethod
+    def _normalize_recent_session_storage_label(result_label):
+        normalized = str(result_label or "").strip()
+        lowered = normalized.lower()
+        if lowered == "ok":
+            return "OK"
+        if lowered == "ng":
+            return "NG"
+        if lowered in ("not_labeled", "not labeled", "none", "-", "null"):
+            return "not_labeled"
+        return ""
 
     def _extract_ai_result_scores_for_left_panel(self):
         for instance in self.analysis_window or []:
@@ -238,6 +251,56 @@ class SequenceWidgetAnalysisOpsMixin:
 
     def _resolve_recent_session(self, session_id: str):
         return self.recent_test_session_by_id.get(session_id)
+
+    def _change_recent_session_result_by_id(self, session_id: str, new_label: str):
+        if str(getattr(self.count_board, "mode", "") or "") != "mark":
+            return False
+
+        session_record = self._resolve_recent_session(session_id)
+        if not isinstance(session_record, dict):
+            return False
+
+        normalized_label = self._normalize_recent_session_storage_label(new_label)
+        if normalized_label not in ("OK", "NG", "not_labeled"):
+            return False
+
+        recorded_signal_info = dict(session_record.get("recorded_signal_info", {}) or {})
+        current_label = self._normalize_recent_session_storage_label(
+            recorded_signal_info.get("labels") or session_record.get("result_label")
+        )
+        if current_label == normalized_label:
+            return True
+
+        recorded_path = self._resolve_recent_session_path(session_record)
+        if not recorded_path:
+            QMessageBox.information(self, "提示", "当前记录音频文件不可用，无法修改结果。")
+            return False
+
+        save_code, msg, new_recorded_path, updated_signal_info = self._relabel_stored_audio_record(
+            recorded_path,
+            recorded_signal_info,
+            normalized_label,
+        )
+        if save_code != error_code.OK:
+            QMessageBox.warning(self, "提示", f"修改近期历史结果失败: {msg}")
+            return False
+
+        update_mark_result_file_on_relabel = getattr(self.count_board, "update_mark_result_file_on_relabel", None)
+        if callable(update_mark_result_file_on_relabel):
+            update_mark_result_file_on_relabel(current_label, normalized_label)
+
+        self._update_recent_session(
+            session_id,
+            result_label=self._format_recent_session_result_label(normalized_label),
+            recorded_path=new_recorded_path,
+            recorded_signal_info=updated_signal_info,
+        )
+
+        current_recorded_path = str(getattr(self, "recorded_path", "") or "")
+        if current_recorded_path and os.path.abspath(current_recorded_path) == os.path.abspath(recorded_path):
+            self.recorded_path = new_recorded_path
+            self.recorded_signal_info = dict(updated_signal_info or {})
+        return True
 
     def _show_recent_session_analysis_by_id(self, session_id: str):
         session_record = self._resolve_recent_session(session_id)

--- a/ui/sequence/sequence_widget_barcode_ops.py
+++ b/ui/sequence/sequence_widget_barcode_ops.py
@@ -4,6 +4,8 @@ from datetime import datetime
 from PyQt5.QtCore import QSignalBlocker
 from PyQt5.QtWidgets import QMessageBox, QApplication
 
+from consts import error_code
+
 
 class SequenceWidgetBarcodeOpsMixin:
     _INVALID_FILENAME_CHARS = set('\\/:*?"<>|')
@@ -358,7 +360,10 @@ class SequenceWidgetBarcodeOpsMixin:
                 return
         self.update_audio_label_info()
         self._maybe_export_excel_results()
-        self.update_recorded_signal_info_to_db()
+        save_code, save_msg = self.update_recorded_signal_info_to_db()
+        if save_code != error_code.OK:
+            QMessageBox.warning(self, "提示", f"更新音频标签失败: {save_msg}")
+            return
         try:
             self._update_current_recent_session_result(self.recorded_signal_info.get("labels", "-"))
         except Exception:
@@ -413,7 +418,10 @@ class SequenceWidgetBarcodeOpsMixin:
             return
 
         self._maybe_export_excel_results()
-        self.update_recorded_signal_info_to_db()
+        save_code, save_msg = self.update_recorded_signal_info_to_db()
+        if save_code != error_code.OK:
+            QMessageBox.warning(self, "提示", f"更新音频标签失败: {save_msg}")
+            return
         if update_recent_session:
             self._update_current_recent_session_result(label)
         self.player_status_flag = False

--- a/ui/sequence/sequence_widget_streaming_ops.py
+++ b/ui/sequence/sequence_widget_streaming_ops.py
@@ -22,6 +22,80 @@ from ui.sequence.recent_session_panel import RecentSessionPanel
 
 
 class SequenceWidgetStreamingOpsMixin:
+    @staticmethod
+    def _normalize_audio_label(label: str) -> str:
+        normalized = str(label or "").strip()
+        lowered = normalized.lower()
+        if lowered == "ok":
+            return "OK"
+        if lowered == "ng":
+            return "NG"
+        if lowered in ("not_labeled", "not labeled", "none", "-", "null"):
+            return "not_labeled"
+        return ""
+
+    @staticmethod
+    def _resolve_audio_path_to_abs(file_path: str | None):
+        normalized = str(file_path or "").strip()
+        if not normalized:
+            return None
+        if not os.path.isabs(normalized):
+            normalized = os.path.join(DEFAULT_DIR, normalized).replace("\\", "/")
+        return os.path.abspath(normalized)
+
+    @staticmethod
+    def _normalize_db_audio_path(file_path: str):
+        normalized = str(file_path or "").replace("\\", "/")
+        default_dir = DEFAULT_DIR.replace("\\", "/")
+        if normalized.startswith(default_dir):
+            return normalized.replace(default_dir, "", 1)
+        return normalized
+
+    def _relabel_stored_audio_record(self, recorded_path, recorded_signal_info, label):
+        target_label = self._normalize_audio_label(label)
+        if target_label not in ("OK", "NG", "not_labeled"):
+            return error_code.INVALID_TYPE_DATA, "不支持的标签结果。", None, None
+        if not isinstance(recorded_signal_info, dict):
+            return error_code.INVALID_TYPE_DATA, "缺少录音元信息。", None, None
+
+        source_path = self._resolve_audio_path_to_abs(recorded_path or recorded_signal_info.get("file_path"))
+        if not source_path or not os.path.isfile(source_path):
+            return error_code.INVALID_PATH, "当前记录音频文件不存在。", None, None
+
+        updated_signal_info = dict(recorded_signal_info or {})
+        previous_label = self._normalize_audio_label(updated_signal_info.get("labels"))
+        old_file_path_candidates = []
+        for candidate in (updated_signal_info.get("file_path"), source_path, recorded_path):
+            normalized_candidate = self._normalize_db_audio_path(candidate)
+            if normalized_candidate and normalized_candidate not in old_file_path_candidates:
+                old_file_path_candidates.append(normalized_candidate)
+
+        try:
+            new_file_path = FileOps.move_wav_to_dir(source_path, target_label)
+        except Exception as exc:
+            return error_code.INVALID_MOVE, f"移动音频文件失败: {exc}", None, None
+
+        if not new_file_path:
+            return error_code.INVALID_MOVE, "未能生成新的音频路径。", None, None
+
+        updated_signal_info["labels"] = target_label
+        updated_signal_info["file_path"] = self._normalize_db_audio_path(new_file_path)
+        save_code = error_code.INVALID_UPDATE
+        msg = "未找到可更新的数据库记录。"
+        for old_file_path in old_file_path_candidates:
+            save_code, msg = RecordingManager().update_audio_label(updated_signal_info, old_file_path)
+            if save_code == error_code.OK:
+                break
+        if save_code != error_code.OK and os.path.abspath(new_file_path) != os.path.abspath(source_path):
+            try:
+                rollback_label = previous_label or "not_labeled"
+                rollback_path = FileOps.move_wav_to_dir(new_file_path, rollback_label)
+                if rollback_path:
+                    updated_signal_info["file_path"] = self._normalize_db_audio_path(rollback_path)
+            except Exception:
+                pass
+        return save_code, msg, new_file_path, updated_signal_info
+
     def _should_run_silent_analysis_after_recording(self) -> bool:
         if bool((getattr(self, "analysis_config", {}) or {}).get("auto_analysis", False)):
             return True
@@ -147,8 +221,12 @@ class SequenceWidgetStreamingOpsMixin:
         self.recent_session_panel = RecentSessionPanel(
             on_play_session=self._resolve_recent_session,
             on_view_session=self._show_recent_session_analysis_by_id,
+            on_change_session_result=self._change_recent_session_result_by_id,
             parent=self,
         )
+        self.recent_session_panel.set_result_editable(str(getattr(self.count_board, "mode", "") or "") == "mark")
+        if self.count_board is not None:
+            self.count_board.register_mode_change_callback(self._on_recent_session_mode_changed)
         # try:
         #     self.refresh_channel_windows()
         # except Exception:
@@ -413,15 +491,25 @@ class SequenceWidgetStreamingOpsMixin:
 
     def update_recorded_signal_info_to_db(self):
         if self.recorded_signal_info["labels"] == "not_labeled":
-            return
-        new_file_path = FileOps.move_wav_to_dir(self.recorded_path, self.recorded_signal_info["labels"])
-        old_file_path = self.recorded_signal_info["file_path"]
-        self.recorded_signal_info["file_path"] = new_file_path.replace(DEFAULT_DIR, "")
-        save_code, msg = RecordingManager().update_audio_label(self.recorded_signal_info, old_file_path)
+            return error_code.OK, ""
+        save_code, msg, new_file_path, updated_signal_info = self._relabel_stored_audio_record(
+            self.recorded_path,
+            self.recorded_signal_info,
+            self.recorded_signal_info.get("labels"),
+        )
         if save_code == error_code.OK:
+            self.recorded_path = new_file_path
+            self.recorded_signal_info = updated_signal_info
             self.default_logger.info("Recorded signal successfully updated.")
         else:
-            self.default_logger.error("Failed to update recorded signal.")
+            self.default_logger.error(f"Failed to update recorded signal: {msg}")
+        return save_code, msg
+
+    def _on_recent_session_mode_changed(self, state: dict | None):
+        if self.recent_session_panel is None:
+            return
+        mode = str((state or {}).get("mode") or "")
+        self.recent_session_panel.set_result_editable(mode == "mark")
 
     def update_audio_label_info(self):
         button = self.sender()

--- a/ui/sequence/sequencement_count_board.py
+++ b/ui/sequence/sequencement_count_board.py
@@ -406,3 +406,56 @@ class SequenceCountBoard(QWidget):
         with open(mark_result_path, "w") as f:
             json.dump(data, f, indent=4)
 
+    @staticmethod
+    def _normalize_mark_label(label: str) -> str:
+        lowered = str(label or "").strip().lower()
+        if lowered == "ok":
+            return "OK"
+        if lowered == "ng":
+            return "NG"
+        if lowered in ("not_labeled", "not labeled", "none", "-", "null"):
+            return "not_labeled"
+        return ""
+
+    def update_mark_result_file_on_relabel(self, old_label: str, new_label: str):
+        old_normalized = self._normalize_mark_label(old_label)
+        new_normalized = self._normalize_mark_label(new_label)
+        if old_normalized == new_normalized:
+            return
+
+        mark_result_path = DEFAULT_DIR + "ui/ui_config/mark_result.json"
+        with open(mark_result_path, "r") as f:
+            data = json.load(f)
+
+        def _is_labeled(value: str) -> bool:
+            return value in ("OK", "NG")
+
+        total = int(data.get("total", 0) or 0)
+        ok = int(data.get("ok", 0) or 0)
+        ng = int(data.get("ng", 0) or 0)
+        not_labels = int(data.get("not_labels", 0) or 0)
+
+        if old_normalized == "OK":
+            ok = max(0, ok - 1)
+        elif old_normalized == "NG":
+            ng = max(0, ng - 1)
+        elif old_normalized == "not_labeled":
+            not_labels = max(0, not_labels - 1)
+
+        if new_normalized == "OK":
+            ok += 1
+        elif new_normalized == "NG":
+            ng += 1
+        elif new_normalized == "not_labeled":
+            not_labels += 1
+
+        total = max(0, total - (1 if _is_labeled(old_normalized) else 0) + (1 if _is_labeled(new_normalized) else 0))
+        data["total"] = total
+        data["ok"] = ok
+        data["ng"] = ng
+        data["not_labels"] = not_labels
+        data["datatime"] = datetime.now().strftime("%Y-%m-%d")
+        with open(mark_result_path, "w") as f:
+            json.dump(data, f, indent=4)
+        self.set_mark_text()
+

--- a/unit_test/test_recent_session_label_update.py
+++ b/unit_test/test_recent_session_label_update.py
@@ -1,0 +1,125 @@
+import logging
+import sys
+import types
+import unittest
+from types import SimpleNamespace
+
+if "concurrent_log_handler" not in sys.modules:
+    concurrent_log_handler = types.ModuleType("concurrent_log_handler")
+
+    class _ConcurrentRotatingFileHandler(logging.Handler):
+        def __init__(self, *args, **kwargs):
+            super().__init__()
+            self.args = args
+            self.kwargs = kwargs
+
+        def emit(self, record):
+            return None
+
+        def close(self):
+            super().close()
+
+    concurrent_log_handler.ConcurrentRotatingFileHandler = _ConcurrentRotatingFileHandler
+    sys.modules["concurrent_log_handler"] = concurrent_log_handler
+
+from consts import error_code
+from ui.sequence.sequence_widget_analysis_ops import SequenceWidgetAnalysisOpsMixin
+
+
+class _DummyRecentSessionPanel:
+    def __init__(self):
+        self.upserted_records = []
+
+    def upsert_session(self, session_record):
+        self.upserted_records.append(dict(session_record))
+
+
+class _DummySequenceWidget(SequenceWidgetAnalysisOpsMixin):
+    def __init__(self):
+        self.count_board = SimpleNamespace(mode="mark")
+        self.count_board_relabel_updates = []
+        self.count_board.update_mark_result_file_on_relabel = self._record_mark_result_update
+        self.recent_session_panel = _DummyRecentSessionPanel()
+        self.recent_test_session_by_id = {
+            "recent_1": {
+                "session_id": "recent_1",
+                "result_label": "not labeled",
+                "recorded_path": "D:/audio_data/stored_data/not_labeled/test.wav",
+                "recorded_signal_info": {
+                    "file_path": "audio_data/stored_data/not_labeled/test.wav",
+                    "labels": "not_labeled",
+                },
+            }
+        }
+        self.recorded_path = "D:/audio_data/stored_data/not_labeled/test.wav"
+        self.recorded_signal_info = {
+            "file_path": "audio_data/stored_data/not_labeled/test.wav",
+            "labels": "not_labeled",
+        }
+        self.relabel_calls = []
+
+    def _record_mark_result_update(self, old_label, new_label):
+        self.count_board_relabel_updates.append((old_label, new_label))
+
+    def _resolve_recent_session_path(self, session_record):
+        return session_record.get("recorded_path")
+
+    def _relabel_stored_audio_record(self, recorded_path, recorded_signal_info, label):
+        self.relabel_calls.append((recorded_path, dict(recorded_signal_info), label))
+        return (
+            error_code.OK,
+            "ok",
+            "D:/audio_data/stored_data/OK/test.wav",
+            {
+                "file_path": "audio_data/stored_data/OK/test.wav",
+                "labels": "OK",
+            },
+        )
+
+
+class TestRecentSessionLabelUpdate(unittest.TestCase):
+    def test_change_recent_session_result_updates_session_and_runtime_paths(self):
+        widget = _DummySequenceWidget()
+
+        changed = widget._change_recent_session_result_by_id("recent_1", "OK")
+
+        self.assertTrue(changed)
+        self.assertEqual(
+            widget.relabel_calls,
+            [
+                (
+                    "D:/audio_data/stored_data/not_labeled/test.wav",
+                    {
+                        "file_path": "audio_data/stored_data/not_labeled/test.wav",
+                        "labels": "not_labeled",
+                    },
+                    "OK",
+                )
+            ],
+        )
+        self.assertEqual(widget.recent_test_session_by_id["recent_1"]["result_label"], "ok")
+        self.assertEqual(widget.recent_test_session_by_id["recent_1"]["recorded_path"], "D:/audio_data/stored_data/OK/test.wav")
+        self.assertEqual(
+            widget.recent_test_session_by_id["recent_1"]["recorded_signal_info"],
+            {
+                "file_path": "audio_data/stored_data/OK/test.wav",
+                "labels": "OK",
+            },
+        )
+        self.assertEqual(widget.recorded_path, "D:/audio_data/stored_data/OK/test.wav")
+        self.assertEqual(
+            widget.recorded_signal_info,
+            {
+                "file_path": "audio_data/stored_data/OK/test.wav",
+                "labels": "OK",
+            },
+        )
+        self.assertEqual(
+            widget.recent_session_panel.upserted_records[-1]["recorded_path"],
+            "D:/audio_data/stored_data/OK/test.wav",
+        )
+        self.assertEqual(widget.count_board_relabel_updates, [("not_labeled", "OK")])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unit_test/test_recent_session_panel_style.py
+++ b/unit_test/test_recent_session_panel_style.py
@@ -1,8 +1,11 @@
 import sys
 import types
 import unittest
+from unittest.mock import patch
 
-from PyQt5.QtWidgets import QApplication
+from PyQt5.QtCore import QEvent, QPointF, Qt
+from PyQt5.QtGui import QMouseEvent
+from PyQt5.QtWidgets import QApplication, QComboBox
 
 if "base.playback_controller" not in sys.modules:
     playback_controller = types.ModuleType("base.playback_controller")
@@ -24,6 +27,18 @@ from ui.sequence.recent_session_panel import RecentSessionPanel
 
 
 class TestRecentSessionPanelStyle(unittest.TestCase):
+    @staticmethod
+    def _build_left_click_event():
+        return QMouseEvent(
+            QEvent.MouseButtonPress,
+            QPointF(1, 1),
+            QPointF(1, 1),
+            QPointF(1, 1),
+            Qt.LeftButton,
+            Qt.LeftButton,
+            Qt.NoModifier,
+        )
+
     @classmethod
     def setUpClass(cls):
         cls.app = QApplication.instance() or QApplication([])
@@ -35,6 +50,148 @@ class TestRecentSessionPanelStyle(unittest.TestCase):
         self.assertIn("selection-background-color", style)
         self.assertIn("selection-color", style)
         self.assertIn("QTableWidget::item:selected", style)
+
+    def test_missing_playback_file_shows_information_dialog(self):
+        panel = RecentSessionPanel()
+        panel.upsert_session(
+            {
+                "session_id": "recent_1",
+                "time_text": "2026-04-16 10:00:00",
+                "barcode": "SN001",
+                "product_model": "MODEL",
+                "mode_text": "正转",
+                "result_label": "ok",
+                "recorded_signal_info": {},
+            }
+        )
+
+        panel._refresh_play_button_for_session("recent_1")
+        play_btn = panel._get_cell_center_widget(panel.session_table, 0, 5)
+
+        self.assertIsNotNone(play_btn)
+        self.assertTrue(play_btn.isEnabled())
+        self.assertEqual(play_btn.toolTip(), "当前记录暂无可播放音频")
+
+        with patch("ui.sequence.recent_session_panel.QMessageBox.information") as mock_information:
+            panel._on_play_button_clicked("recent_1")
+
+        mock_information.assert_called_once_with(panel, "提示", "当前记录音频文件不可用，无法播放音频。")
+
+    def test_result_column_switches_between_text_and_combo_by_mode(self):
+        session_record = {
+            "session_id": "recent_1",
+            "time_text": "2026-04-16 10:00:00",
+            "barcode": "SN001",
+            "product_model": "MODEL",
+            "mode_text": "正转",
+            "result_label": "ok",
+            "recorded_signal_info": {"labels": "OK"},
+        }
+        session_store = {"recent_1": session_record}
+        panel = RecentSessionPanel(on_play_session=lambda session_id: session_store.get(session_id))
+        panel.upsert_session(session_record)
+
+        self.assertEqual(panel.session_table.item(0, 4).text(), "ok")
+        self.assertIsNone(panel.session_table.cellWidget(0, 4))
+
+        panel.set_result_editable(True)
+        combo = panel._get_cell_center_widget(panel.session_table, 0, 4)
+
+        self.assertIsInstance(combo, QComboBox)
+        self.assertEqual(combo.currentText(), "OK")
+
+        panel.set_result_editable(False)
+        self.assertEqual(panel.session_table.item(0, 4).text(), "ok")
+        self.assertIsNone(panel.session_table.cellWidget(0, 4))
+
+    def test_waiting_result_keeps_text_item_in_edit_mode(self):
+        session_record = {
+            "session_id": "recent_1",
+            "time_text": "2026-04-16 10:00:00",
+            "barcode": "SN001",
+            "product_model": "MODEL",
+            "mode_text": "正转",
+            "result_label": "等待测试完成",
+            "recorded_signal_info": {"labels": "not_labeled"},
+        }
+        session_store = {"recent_1": session_record}
+        panel = RecentSessionPanel(on_play_session=lambda session_id: session_store.get(session_id))
+        panel.set_result_editable(True)
+        panel.upsert_session(session_record)
+
+        self.assertIsNone(panel.session_table.cellWidget(0, 4))
+        self.assertEqual(panel.session_table.item(0, 4).text(), "等待测试完成")
+        self.assertEqual(panel.session_table.item(0, 4).toolTip(), "等待测试完成")
+
+    def test_recent_session_column_widths_match_updated_layout(self):
+        panel = RecentSessionPanel()
+
+        self.assertEqual(panel.session_table.columnWidth(1), 136)
+        self.assertEqual(panel.session_table.columnWidth(4), 138)
+
+    def test_clicking_result_cell_opens_dropdown(self):
+        session_record = {
+            "session_id": "recent_1",
+            "time_text": "2026-04-16 10:00:00",
+            "barcode": "SN001",
+            "product_model": "MODEL",
+            "mode_text": "正转",
+            "result_label": "ok",
+            "recorded_signal_info": {"labels": "OK"},
+        }
+        session_store = {"recent_1": session_record}
+        panel = RecentSessionPanel(on_play_session=lambda session_id: session_store.get(session_id))
+        panel.set_result_editable(True)
+        panel.upsert_session(session_record)
+        combo = panel._get_cell_center_widget(panel.session_table, 0, 4)
+
+        with patch.object(combo, "showPopup") as mock_show_popup:
+            combo.mousePressEvent(self._build_left_click_event())
+
+        mock_show_popup.assert_called_once()
+
+    def test_clicking_result_text_area_opens_dropdown(self):
+        session_record = {
+            "session_id": "recent_1",
+            "time_text": "2026-04-16 10:00:00",
+            "barcode": "SN001",
+            "product_model": "MODEL",
+            "mode_text": "正转",
+            "result_label": "ok",
+            "recorded_signal_info": {"labels": "OK"},
+        }
+        session_store = {"recent_1": session_record}
+        panel = RecentSessionPanel(on_play_session=lambda session_id: session_store.get(session_id))
+        panel.set_result_editable(True)
+        panel.upsert_session(session_record)
+        combo = panel._get_cell_center_widget(panel.session_table, 0, 4)
+
+        with patch.object(combo, "showPopup") as mock_show_popup:
+            combo.eventFilter(combo.lineEdit(), self._build_left_click_event())
+
+        mock_show_popup.assert_called_once()
+
+    def test_clicking_result_text_area_does_not_trigger_popup_twice(self):
+        session_record = {
+            "session_id": "recent_1",
+            "time_text": "2026-04-16 10:00:00",
+            "barcode": "SN001",
+            "product_model": "MODEL",
+            "mode_text": "正转",
+            "result_label": "ok",
+            "recorded_signal_info": {"labels": "OK"},
+        }
+        session_store = {"recent_1": session_record}
+        panel = RecentSessionPanel(on_play_session=lambda session_id: session_store.get(session_id))
+        panel.set_result_editable(True)
+        panel.upsert_session(session_record)
+        combo = panel._get_cell_center_widget(panel.session_table, 0, 4)
+
+        with patch.object(combo, "showPopup") as mock_show_popup:
+            combo.eventFilter(combo.lineEdit(), self._build_left_click_event())
+            combo.eventFilter(combo.lineEdit(), QEvent(QEvent.MouseButtonRelease))
+
+        mock_show_popup.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- 支持在标记模式下直接修改近期测试历史结果，并同步更新音频路径、数据库标签和标记统计。
- 优化近期历史结果列的交互与样式，支持点击整格展开下拉，同时保留等待测试完成的只读展示。
- 补充近期历史结果列交互、改标签同步和回看逻辑的单元测试覆盖。

## Test plan
- [x] python -m pytest "unit_test/test_recent_session_panel_style.py" "unit_test/test_recent_session_view.py" "unit_test/test_recent_session_label_update.py"
- [ ] 手动验证标记模式下点击结果单元格任意位置只弹出一次下拉框
- [ ] 手动验证修改 OK / NG / not_labeled 后播放、查看结果和数据库记录保持一致

Made with [Cursor](https://cursor.com)