### PR TITLE
Redesign left panel: merge mode switch into summary card

### DIFF
--- a/consts/ui_style_const.py
+++ b/consts/ui_style_const.py
@@ -422,34 +422,18 @@ motor_stage_title_style = """
             }
 """
 
-motor_mode_switch_panel_style = """
-            QFrame {
-                background-color: #eef3fa;
-                border: 1px solid #c7d6e8;
-                border-radius: 5px;
-            }
-"""
-
-motor_mode_switch_label_style = """
-            QLabel {
-                font-family: 'SimSun';
-                font-size: 15px;
-                color: #6980a4;
-                background: transparent;
-            }
-"""
-
 motor_mode_switch_button_base_style = """
             QPushButton {
-                min-height: 32px;
+                min-height: 40px;
+                min-width: 90px;
                 border: 1px solid #bfd0e5;
-                border-radius: 4px;
+                border-radius: 5px;
                 background-color: #fafcff;
                 color: #5f7599;
                 font-family: 'SimSun';
-                font-size: 15px;
+                font-size: 17px;
                 font-weight: bold;
-                padding: 2px 11px;
+                padding: 4px 18px;
             }
 """
 

--- a/ui/sequence/motor_left_panel.py
+++ b/ui/sequence/motor_left_panel.py
@@ -19,7 +19,7 @@ class MotorDetectionLeftPanel(QWidget):
         super().__init__(parent)
         self.mode_switch_panel = MotorModeSwitchPanel(summary_widget, self)
         self.ai_result_panel = MotorAiResultPanel(self)
-        self.summary_panel = MotorSummaryPanel(summary_widget, self)
+        self.summary_panel = MotorSummaryPanel(summary_widget, self.mode_switch_panel, self)
         self._init_ui()
 
     def _init_ui(self):
@@ -29,7 +29,6 @@ class MotorDetectionLeftPanel(QWidget):
 
         content_widget = QWidget(self)
         content_layout = QVBoxLayout()
-        content_layout.addWidget(self.mode_switch_panel)
         content_layout.addWidget(self.ai_result_panel)
         content_layout.addWidget(self.summary_panel)
         content_layout.addStretch(1)

--- a/ui/sequence/motor_mode_switch_panel.py
+++ b/ui/sequence/motor_mode_switch_panel.py
@@ -1,4 +1,4 @@
-from PyQt5.QtWidgets import QFrame, QHBoxLayout, QLabel, QPushButton, QWidget
+from PyQt5.QtWidgets import QHBoxLayout, QMessageBox, QPushButton, QWidget
 
 from consts import ui_style_const
 
@@ -7,7 +7,6 @@ class MotorModeSwitchPanel(QWidget):
     def __init__(self, count_board, parent=None):
         super().__init__(parent)
         self.count_board = count_board
-        self.mode_label = QLabel("模式")
         self.test_btn = QPushButton("测试")
         self.mark_btn = QPushButton("标记")
         self._init_ui()
@@ -15,10 +14,6 @@ class MotorModeSwitchPanel(QWidget):
         self.sync_from_count_board()
 
     def _init_ui(self):
-        frame = QFrame()
-        frame.setStyleSheet(ui_style_const.motor_mode_switch_panel_style)
-
-        self.mode_label.setStyleSheet(ui_style_const.motor_mode_switch_label_style)
         self.test_btn.setStyleSheet(
             ui_style_const.motor_mode_switch_button_base_style + ui_style_const.motor_mode_switch_button_inactive_style
         )
@@ -26,18 +21,13 @@ class MotorModeSwitchPanel(QWidget):
             ui_style_const.motor_mode_switch_button_base_style + ui_style_const.motor_mode_switch_button_inactive_style
         )
 
-        frame_layout = QHBoxLayout()
-        frame_layout.setContentsMargins(12, 6, 12, 6)
-        frame_layout.setSpacing(6)
-        frame_layout.addWidget(self.mode_label)
-        frame_layout.addStretch()
-        frame_layout.addWidget(self.test_btn)
-        frame_layout.addWidget(self.mark_btn)
-        frame.setLayout(frame_layout)
-
         root_layout = QHBoxLayout()
         root_layout.setContentsMargins(0, 0, 0, 0)
-        root_layout.addWidget(frame)
+        root_layout.setSpacing(12)
+        root_layout.addStretch()
+        root_layout.addWidget(self.test_btn)
+        root_layout.addWidget(self.mark_btn)
+        root_layout.addStretch()
         self.setLayout(root_layout)
 
     def _connect_signals(self):
@@ -46,11 +36,60 @@ class MotorModeSwitchPanel(QWidget):
         if hasattr(self.count_board, "register_mode_change_callback"):
             self.count_board.register_mode_change_callback(self.sync_from_count_board)
 
+    _MODE_SWITCH_DIALOG_STYLE = """
+        QMessageBox {
+            background-color: #f0f0f0;
+        }
+        QMessageBox QLabel {
+            color: #1a1a1a;
+            font-family: 'SimSun';
+            font-size: 16px;
+            background: transparent;
+        }
+        QMessageBox QPushButton {
+            background-color: #e8eef6;
+            color: #2c3e5a;
+            font-family: 'SimSun';
+            font-size: 15px;
+            font-weight: bold;
+            border: 1px solid #b0c4de;
+            border-radius: 4px;
+            min-width: 72px;
+            min-height: 30px;
+            padding: 4px 16px;
+        }
+        QMessageBox QPushButton:hover {
+            background-color: #d6e2f0;
+        }
+        QMessageBox QPushButton:pressed {
+            background-color: #c0d0e4;
+        }
+    """
+
+    def _confirm_mode_switch(self, target_mode: str) -> bool:
+        current_mode = str(getattr(self.count_board, "mode", "") or "")
+        if current_mode == target_mode:
+            return True
+        msg_box = QMessageBox(self)
+        msg_box.setWindowTitle("切换模式")
+        msg_box.setText("切换模式将重新计算汇总信息，是否继续？")
+        msg_box.setIcon(QMessageBox.Question)
+        msg_box.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
+        msg_box.setDefaultButton(QMessageBox.No)
+        msg_box.button(QMessageBox.Yes).setText("确定")
+        msg_box.button(QMessageBox.No).setText("取消")
+        msg_box.setStyleSheet(self._MODE_SWITCH_DIALOG_STYLE)
+        return msg_box.exec_() == QMessageBox.Yes
+
     def _on_test_clicked(self):
+        if not self._confirm_mode_switch("test"):
+            return
         self.count_board.on_test_btn_clicked()
         self.sync_from_count_board()
 
     def _on_mark_clicked(self):
+        if not self._confirm_mode_switch("mark"):
+            return
         self.count_board.on_mark_btn_clicked()
         self.sync_from_count_board()
 

--- a/ui/sequence/motor_panel_common.py
+++ b/ui/sequence/motor_panel_common.py
@@ -13,10 +13,11 @@ class MotorSectionCard(QFrame):
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
 
-        title = QLabel(title_text)
-        title.setAlignment(Qt.AlignCenter)
-        title.setStyleSheet(ui_style_const.motor_section_title_style)
-        layout.addWidget(title)
+        if title_text:
+            title = QLabel(title_text)
+            title.setAlignment(Qt.AlignCenter)
+            title.setStyleSheet(ui_style_const.motor_section_title_style)
+            layout.addWidget(title)
 
         self.content_layout = QVBoxLayout()
         self.content_layout.setContentsMargins(0, 0, 0, 0)

--- a/ui/sequence/motor_summary_panel.py
+++ b/ui/sequence/motor_summary_panel.py
@@ -1,12 +1,15 @@
-from PyQt5.QtWidgets import QSizePolicy, QVBoxLayout, QWidget
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QFrame, QLabel, QSizePolicy, QVBoxLayout, QWidget
 
+from consts import ui_style_const
 from ui.sequence.motor_panel_common import MotorSectionCard
 
 
 class MotorSummaryPanel(QWidget):
-    def __init__(self, summary_widget: QWidget, parent=None):
+    def __init__(self, summary_widget: QWidget, mode_switch_panel: QWidget | None = None, parent=None):
         super().__init__(parent)
         self.summary_widget = summary_widget
+        self.mode_switch_panel = mode_switch_panel
         self._init_ui()
 
     def _init_ui(self):
@@ -15,17 +18,39 @@ class MotorSummaryPanel(QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
 
-        card = MotorSectionCard("汇总信息")
+        card = MotorSectionCard("操作面板")
         card.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Maximum)
-        card.content_layout.setContentsMargins(6, 4, 6, 4)
-        card.content_layout.setSpacing(0)
+        card.content_layout.setContentsMargins(14, 14, 14, 14)
+        card.content_layout.setSpacing(12)
+
+        if self.mode_switch_panel is not None:
+            card.content_layout.addWidget(self._create_caption("模式切换"))
+            self.mode_switch_panel.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Maximum)
+            card.content_layout.addWidget(self.mode_switch_panel)
+            card.content_layout.addWidget(self._create_divider())
 
         if self.summary_widget is not None:
+            card.content_layout.addWidget(self._create_caption("汇总信息"))
             if hasattr(self.summary_widget, "set_mode_switch_visible"):
                 self.summary_widget.set_mode_switch_visible(False)
             self.summary_widget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Maximum)
             card.content_layout.addWidget(self.summary_widget)
-            card.content_layout.addSpacing(42)
 
         layout.addWidget(card)
         self.setLayout(layout)
+
+    @staticmethod
+    def _create_caption(text: str) -> QLabel:
+        label = QLabel(text)
+        label.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+        label.setStyleSheet(ui_style_const.motor_result_caption_style)
+        return label
+
+    @staticmethod
+    def _create_divider() -> QFrame:
+        divider = QFrame()
+        divider.setFrameShape(QFrame.HLine)
+        divider.setFrameShadow(QFrame.Plain)
+        divider.setFixedHeight(2)
+        divider.setStyleSheet(ui_style_const.motor_result_divider_style)
+        return divider

--- a/ui/sequence/sequence_widget_analysis_ops.py
+++ b/ui/sequence/sequence_widget_analysis_ops.py
@@ -294,6 +294,14 @@ class SequenceWidgetAnalysisOpsMixin:
             sample_rate=self.data_struct.sample_rate,
         )
 
+    def _clear_recent_session_history(self):
+        self.recent_test_sessions = []
+        self.recent_test_session_by_id = {}
+        self._current_recent_session_id = None
+        self._pending_recent_session_append = False
+        if self.recent_session_panel is not None:
+            self.recent_session_panel.reset_sessions()
+
     def _begin_recent_session_for_current_run(self):
         self._current_recent_session_id = None
         self._append_recent_session_from_current_run(self._RECENT_SESSION_WAITING_TEXT)

--- a/ui/sequence/sequence_widget_streaming_ops.py
+++ b/ui/sequence/sequence_widget_streaming_ops.py
@@ -292,7 +292,8 @@ class SequenceWidgetStreamingOpsMixin:
             on_change_session_result=self._change_recent_session_result_by_id,
             parent=self,
         )
-        self.recent_session_panel.set_result_editable(str(getattr(self.count_board, "mode", "") or "") == "mark")
+        self._last_recent_session_mode = str(getattr(self.count_board, "mode", "") or "")
+        self.recent_session_panel.set_result_editable(self._last_recent_session_mode == "mark")
         if self.count_board is not None:
             self.count_board.register_mode_change_callback(self._on_recent_session_mode_changed)
         # try:
@@ -578,7 +579,40 @@ class SequenceWidgetStreamingOpsMixin:
         if self.recent_session_panel is None:
             return
         mode = str((state or {}).get("mode") or "")
+        previous_mode = str(getattr(self, "_last_recent_session_mode", "") or "")
+        if mode and previous_mode and mode != previous_mode:
+            self._clear_recent_session_history()
+            self._reset_statistics_for_mode(mode)
+        self._last_recent_session_mode = mode
         self.recent_session_panel.set_result_editable(mode == "mark")
+
+    def _reset_statistics_for_mode(self, mode: str):
+        try:
+            if mode == "test":
+                self.reset_test_reord()
+            elif mode == "mark":
+                self._reset_mark_record()
+        except Exception as e:
+            try:
+                self.default_logger.error(f"reset_statistics_on_mode_switch_error: {e}")
+            except Exception:
+                pass
+
+    def _reset_mark_record(self):
+        mark_result_path = DEFAULT_DIR + "ui/ui_config/mark_result.json"
+        data = {
+            "total": 0,
+            "ok": 0,
+            "ng": 0,
+            "not_labels": 0,
+            "datatime": datetime.now().strftime("%Y-%m-%d"),
+        }
+        with open(mark_result_path, "w") as f:
+            json.dump(data, f, indent=4)
+        try:
+            self.count_board.set_mark_text()
+        except Exception:
+            pass
 
     def update_audio_label_info(self):
         button = self.sender()

--- a/ui/sequence/sequencement_count_board.py
+++ b/ui/sequence/sequencement_count_board.py
@@ -211,11 +211,6 @@ class SequenceCountBoard(QWidget):
         ng_layout = self.create_horizontal_layout("NG    数：", self.ng_line_edit)
         yield_layout = self.create_horizontal_layout("合 格 率：", self.yield_line_edit)
         datatime_layout = self.create_horizontal_layout("录制日期：", self.datatime_line_edit)
-        reset_btn_layout = QHBoxLayout()
-        reset_btn_layout.addStretch()
-        reset_btn_layout.addWidget(self.reset_btn)
-        reset_btn_layout.addStretch()
-
         test_layout = QVBoxLayout()
         test_layout.setContentsMargins(0, 0, 0, 0)
         test_layout.setSpacing(10)
@@ -224,7 +219,6 @@ class SequenceCountBoard(QWidget):
         test_layout.addLayout(ng_layout)
         test_layout.addLayout(yield_layout)
         test_layout.addLayout(datatime_layout)
-        test_layout.addLayout(reset_btn_layout)
 
         test_widget = QWidget()
         test_widget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Maximum)

--- a/unit_test/test_motor_left_panel_layout.py
+++ b/unit_test/test_motor_left_panel_layout.py
@@ -1,0 +1,43 @@
+import unittest
+
+from PyQt5.QtWidgets import QApplication, QLabel, QWidget
+
+from ui.sequence.motor_ai_result_panel import MotorAiResultPanel
+from ui.sequence.motor_left_panel import MotorDetectionLeftPanel
+from ui.sequence.motor_mode_switch_panel import MotorModeSwitchPanel
+from ui.sequence.motor_panel_common import MotorSectionCard
+from ui.sequence.motor_summary_panel import MotorSummaryPanel
+
+
+class TestMotorLeftPanelLayout(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.app = QApplication.instance() or QApplication([])
+
+    def test_card_has_blue_title_and_two_sections(self):
+        summary_widget = QWidget()
+        panel = MotorDetectionLeftPanel(summary_widget)
+        scroll_area = panel.layout().itemAt(0).widget()
+        content_widget = scroll_area.widget()
+        content_layout = content_widget.layout()
+
+        first_widget = content_layout.itemAt(0).widget()
+        second_widget = content_layout.itemAt(1).widget()
+
+        self.assertIsInstance(first_widget, MotorAiResultPanel)
+        self.assertIsInstance(second_widget, MotorSummaryPanel)
+
+        card = second_widget.layout().itemAt(0).widget()
+        self.assertIsInstance(card, MotorSectionCard)
+
+        labels = [lbl.text() for lbl in second_widget.findChildren(QLabel)]
+        self.assertIn("操作面板", labels)
+        self.assertIn("模式切换", labels)
+        self.assertIn("汇总信息", labels)
+
+        embedded_mode_switch = card.content_layout.itemAt(1).widget()
+        self.assertIsInstance(embedded_mode_switch, MotorModeSwitchPanel)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unit_test/test_recent_session_mode_switch.py
+++ b/unit_test/test_recent_session_mode_switch.py
@@ -1,0 +1,82 @@
+import unittest
+import logging
+import sys
+import types
+
+if "concurrent_log_handler" not in sys.modules:
+    concurrent_log_handler = types.ModuleType("concurrent_log_handler")
+
+    class _ConcurrentRotatingFileHandler(logging.Handler):
+        def __init__(self, *args, **kwargs):
+            super().__init__()
+            self.args = args
+            self.kwargs = kwargs
+
+        def emit(self, record):
+            return None
+
+        def close(self):
+            super().close()
+
+    concurrent_log_handler.ConcurrentRotatingFileHandler = _ConcurrentRotatingFileHandler
+    sys.modules["concurrent_log_handler"] = concurrent_log_handler
+
+from ui.sequence.sequence_widget_streaming_ops import SequenceWidgetStreamingOpsMixin
+
+
+class _DummyRecentSessionPanel:
+    def __init__(self):
+        self.editable_states = []
+        self.reset_count = 0
+
+    def set_result_editable(self, editable: bool):
+        self.editable_states.append(bool(editable))
+
+    def reset_sessions(self):
+        self.reset_count += 1
+
+
+class _DummySequenceWidget(SequenceWidgetStreamingOpsMixin):
+    def __init__(self):
+        self.recent_session_panel = _DummyRecentSessionPanel()
+        self.recent_test_sessions = ["recent_1", "recent_2"]
+        self.recent_test_session_by_id = {"recent_1": {"session_id": "recent_1"}, "recent_2": {"session_id": "recent_2"}}
+        self._current_recent_session_id = "recent_2"
+        self._pending_recent_session_append = True
+        self._last_recent_session_mode = "mark"
+
+    def _clear_recent_session_history(self):
+        self.recent_test_sessions = []
+        self.recent_test_session_by_id = {}
+        self._current_recent_session_id = None
+        self._pending_recent_session_append = False
+        self.recent_session_panel.reset_sessions()
+
+
+class TestRecentSessionModeSwitch(unittest.TestCase):
+    def test_mode_switch_clears_recent_history(self):
+        widget = _DummySequenceWidget()
+
+        widget._on_recent_session_mode_changed({"mode": "test"})
+
+        self.assertEqual(widget.recent_session_panel.editable_states, [False])
+        self.assertEqual(widget.recent_session_panel.reset_count, 1)
+        self.assertEqual(widget.recent_test_sessions, [])
+        self.assertEqual(widget.recent_test_session_by_id, {})
+        self.assertIsNone(widget._current_recent_session_id)
+        self.assertFalse(widget._pending_recent_session_append)
+        self.assertEqual(widget._last_recent_session_mode, "test")
+
+    def test_same_mode_update_does_not_clear_recent_history(self):
+        widget = _DummySequenceWidget()
+
+        widget._on_recent_session_mode_changed({"mode": "mark"})
+
+        self.assertEqual(widget.recent_session_panel.editable_states, [True])
+        self.assertEqual(widget.recent_session_panel.reset_count, 0)
+        self.assertEqual(widget.recent_test_sessions, ["recent_1", "recent_2"])
+        self.assertEqual(widget._last_recent_session_mode, "mark")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Merged the mode-switch area and summary-info area into a single unified card with a blue title bar, matching the AI result card style
- Added confirmation dialog before mode switch, warning that stats will be recalculated
- Reset summary statistics to zero on mode switch (both test and mark modes)
- Enlarged test/mark buttons, removed redundant reset-stats button
- Cleaned up unused style constants

## Test plan
- [x] test_motor_left_panel_layout.py - verifies card structure and embedded widgets
- [x] test_recent_session_mode_switch.py - verifies history clearing on mode switch
- [ ] Manual: confirm mode-switch dialog appears with readable text on light background
- [ ] Manual: verify stats reset to 0 after switching modes