### PR TITLE
Refine the sequence workspace layout for resizable top-bottom panels

### DIFF
--- a/ui/sequence/motor_ai_result_panel.py
+++ b/ui/sequence/motor_ai_result_panel.py
@@ -1,5 +1,5 @@
 from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QFrame, QHBoxLayout, QLabel, QVBoxLayout, QWidget, QSizePolicy
+from PyQt5.QtWidgets import QFrame, QHBoxLayout, QLabel, QScrollArea, QVBoxLayout, QWidget, QSizePolicy
 
 from consts import ui_style_const
 from ui.sequence.motor_panel_common import (
@@ -41,33 +41,48 @@ class MotorAiResultPanel(QWidget):
         self.reset()
 
     def _init_ui(self):
-        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Maximum)
+        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         layout = QVBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
 
         card = MotorSectionCard("AI评判结果")
-        card.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Maximum)
-        card.content_layout.setContentsMargins(14, 14, 14, 14)
-        card.content_layout.setSpacing(12)
+        card.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        card.content_layout.setContentsMargins(0, 0, 0, 0)
+        card.content_layout.setSpacing(0)
 
-        card.content_layout.addWidget(self._create_direction_result_section(
+        content_widget = QWidget(card)
+        content_layout = QVBoxLayout()
+        content_layout.setContentsMargins(14, 14, 14, 14)
+        content_layout.setSpacing(12)
+
+        content_layout.addWidget(self._create_direction_result_section(
             self.forward_title_label,
             self.forward_value,
             self.forward_ok_score_label,
             self.forward_ng_score_label,
         ))
-        card.content_layout.addWidget(self._create_divider())
-        card.content_layout.addWidget(self._create_direction_result_section(
+        content_layout.addWidget(self._create_divider())
+        content_layout.addWidget(self._create_direction_result_section(
             self.reverse_title_label,
             self.reverse_value,
             self.reverse_ok_score_label,
             self.reverse_ng_score_label,
         ))
-        card.content_layout.addWidget(self._create_divider())
-        card.content_layout.addWidget(self._create_final_result_section())
+        content_layout.addWidget(self._create_divider())
+        content_layout.addWidget(self._create_final_result_section())
+        content_layout.addStretch(1)
+        content_widget.setLayout(content_layout)
 
-        layout.addWidget(card)
+        scroll_area = QScrollArea(card)
+        scroll_area.setWidgetResizable(True)
+        scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        scroll_area.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
+        scroll_area.setFrameShape(QFrame.NoFrame)
+        scroll_area.setWidget(content_widget)
+
+        card.content_layout.addWidget(scroll_area, stretch=1)
+        layout.addWidget(card, stretch=1)
         self.setLayout(layout)
         self._apply_result_visual_hierarchy()
 

--- a/ui/sequence/motor_left_panel.py
+++ b/ui/sequence/motor_left_panel.py
@@ -27,28 +27,47 @@ class MotorDetectionLeftPanel(QWidget):
         self.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Expanding)
         self.setStyleSheet(ui_style_const.motor_left_panel_style)
 
-        content_widget = QWidget(self)
-        content_layout = QVBoxLayout()
-        content_layout.addWidget(self.ai_result_panel)
-        content_layout.addWidget(self.summary_panel)
-        content_layout.addStretch(1)
-        content_layout.setContentsMargins(0, 0, 6, 0)
-        content_layout.setSpacing(12)
-        content_widget.setLayout(content_layout)
+        self.content_widget = QWidget(self)
+        self.content_layout = QVBoxLayout()
+        self.content_layout.addWidget(self.ai_result_panel)
+        self.content_layout.addWidget(self.summary_panel)
+        self.content_layout.addStretch(1)
+        self.content_layout.setContentsMargins(0, 0, 6, 0)
+        self.content_layout.setSpacing(12)
+        self.content_widget.setLayout(self.content_layout)
 
-        scroll_area = QScrollArea(self)
-        scroll_area.setWidgetResizable(True)
-        scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
-        scroll_area.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
-        scroll_area.setFrameShape(QFrame.NoFrame)
-        scroll_area.setWidget(content_widget)
-        scroll_area.setStyleSheet(ui_style_const.motor_left_panel_scroll_area_style)
+        self.scroll_area = QScrollArea(self)
+        self.scroll_area.setWidgetResizable(True)
+        self.scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.scroll_area.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
+        self.scroll_area.setFrameShape(QFrame.NoFrame)
+        self.scroll_area.setWidget(self.content_widget)
+        self.scroll_area.setStyleSheet(ui_style_const.motor_left_panel_scroll_area_style)
 
         layout = QVBoxLayout()
-        layout.addWidget(scroll_area)
+        layout.addWidget(self.scroll_area)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
         self.setLayout(layout)
+
+    def take_split_sections(self):
+        return (
+            self._detach_section_widget(self.ai_result_panel),
+            self._detach_section_widget(self.summary_panel),
+        )
+
+    def _detach_section_widget(self, widget: QWidget):
+        if widget is None:
+            return None
+        if getattr(self, "content_layout", None) is not None:
+            index = self.content_layout.indexOf(widget)
+            if index >= 0:
+                item = self.content_layout.takeAt(index)
+                if item is not None and item.widget() is not None:
+                    item.widget().setParent(None)
+        if widget.parent() is not None:
+            widget.setParent(None)
+        return widget
 
     def reset_ai_result_panel(self):
         self.ai_result_panel.reset()

--- a/ui/sequence/motor_summary_panel.py
+++ b/ui/sequence/motor_summary_panel.py
@@ -1,5 +1,5 @@
 from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QFrame, QLabel, QSizePolicy, QVBoxLayout, QWidget
+from PyQt5.QtWidgets import QFrame, QLabel, QScrollArea, QSizePolicy, QVBoxLayout, QWidget
 
 from consts import ui_style_const
 from ui.sequence.motor_panel_common import MotorSectionCard
@@ -13,30 +13,46 @@ class MotorSummaryPanel(QWidget):
         self._init_ui()
 
     def _init_ui(self):
-        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Maximum)
+        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         layout = QVBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
 
         card = MotorSectionCard("操作面板")
-        card.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Maximum)
-        card.content_layout.setContentsMargins(14, 14, 14, 14)
-        card.content_layout.setSpacing(12)
+        card.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        card.content_layout.setContentsMargins(0, 0, 0, 0)
+        card.content_layout.setSpacing(0)
+
+        content_widget = QWidget(card)
+        content_layout = QVBoxLayout()
+        content_layout.setContentsMargins(14, 14, 14, 14)
+        content_layout.setSpacing(12)
 
         if self.mode_switch_panel is not None:
-            card.content_layout.addWidget(self._create_caption("模式切换"))
+            content_layout.addWidget(self._create_caption("模式切换"))
             self.mode_switch_panel.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Maximum)
-            card.content_layout.addWidget(self.mode_switch_panel)
-            card.content_layout.addWidget(self._create_divider())
+            content_layout.addWidget(self.mode_switch_panel)
+            content_layout.addWidget(self._create_divider())
 
         if self.summary_widget is not None:
-            card.content_layout.addWidget(self._create_caption("汇总信息"))
+            content_layout.addWidget(self._create_caption("汇总信息"))
             if hasattr(self.summary_widget, "set_mode_switch_visible"):
                 self.summary_widget.set_mode_switch_visible(False)
             self.summary_widget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Maximum)
-            card.content_layout.addWidget(self.summary_widget)
+            content_layout.addWidget(self.summary_widget)
 
-        layout.addWidget(card)
+        content_layout.addStretch(1)
+        content_widget.setLayout(content_layout)
+
+        scroll_area = QScrollArea(card)
+        scroll_area.setWidgetResizable(True)
+        scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        scroll_area.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
+        scroll_area.setFrameShape(QFrame.NoFrame)
+        scroll_area.setWidget(content_widget)
+
+        card.content_layout.addWidget(scroll_area, stretch=1)
+        layout.addWidget(card, stretch=1)
         self.setLayout(layout)
 
     @staticmethod

--- a/ui/sequence/sequence_widget_streaming_ops.py
+++ b/ui/sequence/sequence_widget_streaming_ops.py
@@ -278,13 +278,14 @@ class SequenceWidgetStreamingOpsMixin:
         """
             Create the main work area layout.
 
-            Left side is the motor sidebar (AI result + summary board), and
-            right side remains the waveform workspace.
+            Arrange the workspace into a top-bottom structure:
+            top row = AI result + waveform workspace
+            bottom row = operation panel + recent session history
 
             Returns:
-                QHBoxLayout: The configured layout object.
+                QVBoxLayout: The configured layout object.
         """
-        layout = QHBoxLayout()
+        layout = QVBoxLayout()
         self.channel_workspace = ChannelPlotWorkspace(self)
         self.recent_session_panel = RecentSessionPanel(
             on_play_session=self._resolve_recent_session,
@@ -302,19 +303,39 @@ class SequenceWidgetStreamingOpsMixin:
         #     self.channel_workspace.set_channels([0])
         self._configure_direction_waveform_workspace()
 
-        right_splitter = QSplitter(Qt.Vertical)
-        right_splitter.addWidget(self.channel_workspace)
-        right_splitter.addWidget(self.recent_session_panel)
-        right_splitter.setChildrenCollapsible(False)
-        right_splitter.setStretchFactor(0, 9)
-        right_splitter.setStretchFactor(1, 11)
-        right_splitter.setSizes([460, 560])
+        ai_result_panel, summary_panel = self.left_panel.take_split_sections()
+        if ai_result_panel is not None:
+            ai_result_panel.setMinimumWidth(340)
+        if summary_panel is not None:
+            summary_panel.setMinimumWidth(340)
 
-        layout.addWidget(self.left_panel, stretch=0)
-        layout.addSpacing(18)
-        layout.addWidget(right_splitter, stretch=1)
+        top_row_splitter = QSplitter(Qt.Horizontal)
+        top_row_splitter.addWidget(ai_result_panel)
+        top_row_splitter.addWidget(self.channel_workspace)
+        top_row_splitter.setChildrenCollapsible(False)
+        top_row_splitter.setStretchFactor(0, 4)
+        top_row_splitter.setStretchFactor(1, 9)
+        top_row_splitter.setSizes([380, 920])
+
+        bottom_row_splitter = QSplitter(Qt.Horizontal)
+        bottom_row_splitter.addWidget(summary_panel)
+        bottom_row_splitter.addWidget(self.recent_session_panel)
+        bottom_row_splitter.setChildrenCollapsible(False)
+        bottom_row_splitter.setStretchFactor(0, 4)
+        bottom_row_splitter.setStretchFactor(1, 9)
+        bottom_row_splitter.setSizes([380, 920])
+
+        main_splitter = QSplitter(Qt.Vertical)
+        main_splitter.addWidget(top_row_splitter)
+        main_splitter.addWidget(bottom_row_splitter)
+        main_splitter.setChildrenCollapsible(False)
+        main_splitter.setStretchFactor(0, 9)
+        main_splitter.setStretchFactor(1, 11)
+        main_splitter.setSizes([450, 550])
+
+        layout.addWidget(main_splitter)
         layout.setContentsMargins(40, 20, 40, 20)
-        layout.setSpacing(18)
+        layout.setSpacing(0)
         return layout
 
     def init_fft_and_stft_flag(self):

--- a/unit_test/test_motor_left_panel_layout.py
+++ b/unit_test/test_motor_left_panel_layout.py
@@ -27,7 +27,7 @@ class TestMotorLeftPanelLayout(unittest.TestCase):
         self.assertIsInstance(first_widget, MotorAiResultPanel)
         self.assertIsInstance(second_widget, MotorSummaryPanel)
 
-        card = second_widget.layout().itemAt(0).widget()
+        card = second_widget.findChild(MotorSectionCard)
         self.assertIsInstance(card, MotorSectionCard)
 
         labels = [lbl.text() for lbl in second_widget.findChildren(QLabel)]
@@ -35,7 +35,9 @@ class TestMotorLeftPanelLayout(unittest.TestCase):
         self.assertIn("模式切换", labels)
         self.assertIn("汇总信息", labels)
 
-        embedded_mode_switch = card.content_layout.itemAt(1).widget()
+        content_scroll_area = card.content_layout.itemAt(0).widget()
+        content_widget = content_scroll_area.widget()
+        embedded_mode_switch = content_widget.layout().itemAt(1).widget()
         self.assertIsInstance(embedded_mode_switch, MotorModeSwitchPanel)
 
 

--- a/unit_test/test_sequence_main_layout.py
+++ b/unit_test/test_sequence_main_layout.py
@@ -1,0 +1,156 @@
+import logging
+import sys
+import types
+import unittest
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QApplication, QSplitter, QVBoxLayout, QWidget
+
+if "concurrent_log_handler" not in sys.modules:
+    concurrent_log_handler = types.ModuleType("concurrent_log_handler")
+
+    class _ConcurrentRotatingFileHandler(logging.Handler):
+        def emit(self, record):
+            return None
+
+    concurrent_log_handler.ConcurrentRotatingFileHandler = _ConcurrentRotatingFileHandler
+    sys.modules["concurrent_log_handler"] = concurrent_log_handler
+
+from ui.sequence.motor_left_panel import MotorDetectionLeftPanel
+from ui.sequence.motor_panel_common import MotorSectionCard
+from ui.sequence.sequencement_count_board import SequenceCountBoard
+from ui.sequence.sequence_widget_streaming_ops import SequenceWidgetStreamingOpsMixin
+
+
+class _DummyCountBoard(QWidget):
+    def __init__(self):
+        super().__init__()
+        self.mode = "test"
+        self.mode_change_callbacks = []
+
+    def register_mode_change_callback(self, callback):
+        self.mode_change_callbacks.append(callback)
+
+
+class _DummySequenceWidget(QWidget, SequenceWidgetStreamingOpsMixin):
+    def __init__(self):
+        super().__init__()
+        self.count_board = _DummyCountBoard()
+        self.left_panel = MotorDetectionLeftPanel(self.count_board)
+        self.channel_workspace = None
+        self.recent_session_panel = None
+        self._last_recent_session_mode = ""
+
+    def _resolve_recent_session(self, session_id: str):
+        return None
+
+    def _show_recent_session_analysis_by_id(self, session_id: str):
+        return None
+
+    def _change_recent_session_result_by_id(self, session_id: str, label: str):
+        return None
+
+    def _configure_direction_waveform_workspace(self):
+        return None
+
+    def _on_recent_session_mode_changed(self, mode: str):
+        self._last_recent_session_mode = mode
+
+
+class _RealisticSequenceWidget(_DummySequenceWidget):
+    def __init__(self):
+        QWidget.__init__(self)
+        self.count_board = SequenceCountBoard({})
+        self.left_panel = MotorDetectionLeftPanel(self.count_board)
+        self.channel_workspace = None
+        self.recent_session_panel = None
+        self._last_recent_session_mode = ""
+
+
+class TestSequenceMainLayout(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.app = QApplication.instance() or QApplication([])
+
+    def test_waveform_layout_uses_top_bottom_split_with_two_horizontal_rows(self):
+        widget = _DummySequenceWidget()
+
+        layout = widget.create_waveform_layout()
+
+        self.assertIsInstance(layout, QVBoxLayout)
+        self.assertEqual(layout.count(), 1)
+
+        main_splitter = layout.itemAt(0).widget()
+        self.assertIsInstance(main_splitter, QSplitter)
+        self.assertEqual(main_splitter.orientation(), Qt.Vertical)
+        self.assertEqual(main_splitter.count(), 2)
+
+        top_row_splitter = main_splitter.widget(0)
+        bottom_row_splitter = main_splitter.widget(1)
+        self.assertIsInstance(top_row_splitter, QSplitter)
+        self.assertIsInstance(bottom_row_splitter, QSplitter)
+        self.assertEqual(top_row_splitter.orientation(), Qt.Horizontal)
+        self.assertEqual(bottom_row_splitter.orientation(), Qt.Horizontal)
+
+        self.assertIs(top_row_splitter.widget(0), widget.left_panel.ai_result_panel)
+        self.assertIs(top_row_splitter.widget(1), widget.channel_workspace)
+        self.assertIs(bottom_row_splitter.widget(0), widget.left_panel.summary_panel)
+        self.assertIs(bottom_row_splitter.widget(1), widget.recent_session_panel)
+
+    def test_common_window_size_keeps_waveform_and_history_readable(self):
+        widget = _DummySequenceWidget()
+        widget.setLayout(widget.create_waveform_layout())
+        widget.resize(1400, 900)
+        widget.show()
+        self.app.processEvents()
+
+        self.assertGreaterEqual(widget.channel_workspace.width(), 700)
+        self.assertGreaterEqual(widget.channel_workspace.height(), 360)
+        self.assertGreaterEqual(widget.recent_session_panel.width(), 700)
+        self.assertGreaterEqual(widget.recent_session_panel.height(), 300)
+        self.assertGreater(widget.channel_workspace.width(), widget.left_panel.ai_result_panel.width())
+        self.assertGreater(widget.recent_session_panel.width(), widget.left_panel.summary_panel.width())
+
+    def test_real_operation_panel_keeps_minimum_height_within_window_budget(self):
+        widget = _RealisticSequenceWidget()
+        widget.setLayout(widget.create_waveform_layout())
+        widget.resize(1400, 700)
+        widget.show()
+        self.app.processEvents()
+
+        self.assertLessEqual(widget.minimumSizeHint().height(), 700)
+
+    def test_left_cards_stretch_to_match_their_row_heights(self):
+        widget = _RealisticSequenceWidget()
+        widget.setLayout(widget.create_waveform_layout())
+        widget.resize(1400, 900)
+        widget.show()
+        self.app.processEvents()
+
+        ai_card = widget.left_panel.ai_result_panel.findChild(MotorSectionCard)
+        summary_card = widget.left_panel.summary_panel.findChild(MotorSectionCard)
+
+        self.assertIsNotNone(ai_card)
+        self.assertIsNotNone(summary_card)
+        self.assertEqual(ai_card.height(), widget.left_panel.ai_result_panel.height())
+        self.assertEqual(summary_card.height(), widget.left_panel.summary_panel.height())
+
+    def test_default_main_splitter_ratio_is_45_to_55(self):
+        widget = _RealisticSequenceWidget()
+        layout = widget.create_waveform_layout()
+        widget.setLayout(layout)
+        widget.resize(1400, 900)
+        widget.show()
+        self.app.processEvents()
+
+        main_splitter = layout.itemAt(0).widget()
+        top_height, bottom_height = main_splitter.sizes()
+        total_height = top_height + bottom_height
+
+        self.assertGreater(total_height, 0)
+        self.assertAlmostEqual(top_height / total_height, 0.45, delta=0.03)
+        self.assertAlmostEqual(bottom_height / total_height, 0.55, delta=0.03)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- change the sequence workspace from a left-right layout into a top-bottom structure with AI results and waveforms on top and operation controls plus recent history on the bottom
- make the AI result and operation cards stretch with their neighboring panes while keeping their internal content scrollable under tighter heights
- add layout regression coverage for the new structure, stretch behavior, minimum height budget, and default 45:55 splitter ratio

## Test plan
- [x] `python -m pytest unit_test/test_sequence_main_layout.py unit_test/test_motor_left_panel_layout.py unit_test/test_recent_session_mode_switch.py unit_test/test_recent_session_panel_style.py unit_test/test_recent_session_view.py`