### PR TITLE
Remember the S/N checkbox state

### DIFF
--- a/ui/sequence/sequence_widget.py
+++ b/ui/sequence/sequence_widget.py
@@ -176,3 +176,4 @@ class SequenceWindow(
         self.init_lineedit_text()
         self.init_ui()
         self._serial_trigger_runtime_initialized = False
+        self.restore_scanner_checkbox_state()

--- a/ui/sequence/sequence_widget_barcode_ops.py
+++ b/ui/sequence/sequence_widget_barcode_ops.py
@@ -4,11 +4,64 @@ from datetime import datetime
 from PyQt5.QtCore import QSignalBlocker
 from PyQt5.QtWidgets import QMessageBox, QApplication
 
+from base.load_config import LoadUiConfig
+from base.save_data import save_recorded_data_to_json
 from consts import error_code
 
 
 class SequenceWidgetBarcodeOpsMixin:
     _INVALID_FILENAME_CHARS = set('\\/:*?"<>|')
+
+    @staticmethod
+    def _normalize_saved_scanner_checkbox_state(value) -> bool:
+        return value if isinstance(value, bool) else False
+
+    def _persist_scanner_checkbox_state(self) -> None:
+        save_recorded_data_to_json(
+            self.lineedit_type.text(),
+            self.lineedit_count.text(),
+            self.lineedit_s_or_n.text(),
+            self.barcode_scanner_box.isChecked(),
+        )
+
+    def _apply_scanner_enabled_state(self, enabled: bool, persist: bool = True) -> None:
+        enabled = bool(enabled)
+        self.barcode_scanner_box.setChecked(enabled)
+
+        if enabled:
+            # 配置文件加载失败不再致命：扫码枪可进入自动识别模式（支持热插拔）。
+            # 注意：光电开关仍依赖 hotkey 配置。
+            if not self.hw_manager.ensure_config_loaded():
+                self.default_logger.warning(
+                    "无法加载扫码枪/光电开关配置，将进入扫码枪自动识别模式（光电开关可能不可用）。"
+                )
+
+            self.lineedit_s_or_n.setEnabled(True)
+            # 键盘楔入模式依赖“输入框有焦点”，开启后把焦点给 S/N 输入框
+            try:
+                self.lineedit_s_or_n.setFocus()
+                self.lineedit_s_or_n.selectAll()
+            except Exception:
+                pass
+            if self.hw_manager.start_scanner_and_sensor_listeners():
+                self.default_logger.info("硬件监听已启动")
+            else:
+                self.default_logger.warning("硬件初始化失败，已静默降级为普通键盘输入模式")
+        else:
+            self.lineedit_s_or_n.clear()
+            self.lineedit_s_or_n.setDisabled(True)
+            self.hw_manager.stop_scanner_and_sensor_listeners()
+            self.default_logger.info("硬件监听已停止")
+
+        if persist:
+            self._persist_scanner_checkbox_state()
+
+    def restore_scanner_checkbox_state(self) -> None:
+        last_recorded_info = LoadUiConfig.load_last_recorded_info(self.default_logger)
+        if not isinstance(last_recorded_info, dict):
+            last_recorded_info = {}
+        saved_enabled = self._normalize_saved_scanner_checkbox_state(last_recorded_info.get("scanner_barcode_check"))
+        self._apply_scanner_enabled_state(saved_enabled, persist=False)
 
     @staticmethod
     def _normalize_trigger_direction(direction: str) -> str:
@@ -203,30 +256,7 @@ class SequenceWidgetBarcodeOpsMixin:
 
     def clicked_scanner(self):
         """Checkbox 状态改变时的回调"""
-        if self.barcode_scanner_box.isChecked():
-            # 配置文件加载失败不再致命：扫码枪可进入自动识别模式（支持热插拔）。
-            # 注意：光电开关仍依赖 hotkey 配置。
-            if not self.hw_manager.ensure_config_loaded():
-                self.default_logger.warning(
-                    "无法加载扫码枪/光电开关配置，将进入扫码枪自动识别模式（光电开关可能不可用）。"
-                )
-
-            self.lineedit_s_or_n.setEnabled(True)
-            # 键盘楔入模式依赖“输入框有焦点”，开启后把焦点给 S/N 输入框
-            try:
-                self.lineedit_s_or_n.setFocus()
-                self.lineedit_s_or_n.selectAll()
-            except Exception:
-                pass
-            if self.hw_manager.start_scanner_and_sensor_listeners():
-                self.default_logger.info("硬件监听已启动")
-            else:
-                self.default_logger.warning("硬件初始化失败，已静默降级为普通键盘输入模式")
-        else:
-            self.lineedit_s_or_n.clear()
-            self.lineedit_s_or_n.setDisabled(True)
-            self.hw_manager.stop_scanner_and_sensor_listeners()
-            self.default_logger.info("硬件监听已停止")
+        self._apply_scanner_enabled_state(self.barcode_scanner_box.isChecked(), persist=True)
 
     def on_barcode_received(self, barcode):
         """处理扫码枪信号（HID 模式）"""

--- a/unit_test/test_sn_checkbox_persistence.py
+++ b/unit_test/test_sn_checkbox_persistence.py
@@ -1,0 +1,151 @@
+import logging
+import os
+import sys
+import types
+
+import pytest
+from PyQt5.QtWidgets import QApplication, QCheckBox, QLineEdit
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(__file__))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+if "concurrent_log_handler" not in sys.modules:
+    concurrent_log_handler = types.ModuleType("concurrent_log_handler")
+
+    class _ConcurrentRotatingFileHandler(logging.Handler):
+        def emit(self, record):
+            return None
+
+    concurrent_log_handler.ConcurrentRotatingFileHandler = _ConcurrentRotatingFileHandler
+    sys.modules["concurrent_log_handler"] = concurrent_log_handler
+
+from ui.sequence import sequence_widget_barcode_ops as barcode_ops
+from ui.sequence.sequence_widget_barcode_ops import SequenceWidgetBarcodeOpsMixin
+
+
+class _DummyLogger:
+    def __init__(self):
+        self.infos = []
+        self.warnings = []
+
+    def info(self, message):
+        self.infos.append(message)
+
+    def warning(self, message):
+        self.warnings.append(message)
+
+
+class _DummyHardwareManager:
+    def __init__(self):
+        self.ensure_calls = 0
+        self.start_calls = 0
+        self.stop_calls = 0
+
+    def ensure_config_loaded(self):
+        self.ensure_calls += 1
+        return True
+
+    def start_scanner_and_sensor_listeners(self):
+        self.start_calls += 1
+        return True
+
+    def stop_scanner_and_sensor_listeners(self):
+        self.stop_calls += 1
+
+
+class _DummyWidget(SequenceWidgetBarcodeOpsMixin):
+    def __init__(self):
+        self.barcode_scanner_box = QCheckBox()
+        self.lineedit_s_or_n = QLineEdit()
+        self.lineedit_type = QLineEdit()
+        self.lineedit_count = QLineEdit()
+        self.default_logger = _DummyLogger()
+        self.hw_manager = _DummyHardwareManager()
+        self.lineedit_type.setText("MODEL")
+        self.lineedit_count.setText("7")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def app():
+    return QApplication.instance() or QApplication([])
+
+
+def test_restore_scanner_checkbox_state_uses_saved_flag(monkeypatch):
+    widget = _DummyWidget()
+    saved_payload = {"scanner_barcode_check": True}
+    save_calls = []
+
+    monkeypatch.setattr(barcode_ops.LoadUiConfig, "load_last_recorded_info", staticmethod(lambda logger: saved_payload))
+    monkeypatch.setattr(barcode_ops, "save_recorded_data_to_json", lambda *args: save_calls.append(args), raising=False)
+
+    widget.restore_scanner_checkbox_state()
+
+    assert widget.barcode_scanner_box.isChecked() is True
+    assert widget.lineedit_s_or_n.isEnabled() is True
+    assert widget.hw_manager.start_calls == 1
+    assert save_calls == []
+
+
+def test_restore_scanner_checkbox_state_defaults_to_disabled(monkeypatch):
+    widget = _DummyWidget()
+    widget.barcode_scanner_box.setChecked(True)
+    widget.lineedit_s_or_n.setEnabled(True)
+    widget.lineedit_s_or_n.setText("SN001")
+    save_calls = []
+
+    monkeypatch.setattr(
+        barcode_ops.LoadUiConfig,
+        "load_last_recorded_info",
+        staticmethod(lambda logger: {"scanner_barcode_check": "invalid"}),
+    )
+    monkeypatch.setattr(barcode_ops, "save_recorded_data_to_json", lambda *args: save_calls.append(args), raising=False)
+
+    widget.restore_scanner_checkbox_state()
+
+    assert widget.barcode_scanner_box.isChecked() is False
+    assert widget.lineedit_s_or_n.isEnabled() is False
+    assert widget.lineedit_s_or_n.text() == ""
+    assert widget.hw_manager.stop_calls == 1
+    assert save_calls == []
+
+
+@pytest.mark.parametrize("saved_payload", [None, [1], "invalid"])
+def test_restore_scanner_checkbox_state_handles_missing_or_malformed_payload(monkeypatch, saved_payload):
+    widget = _DummyWidget()
+    widget.barcode_scanner_box.setChecked(True)
+    widget.lineedit_s_or_n.setEnabled(True)
+    widget.lineedit_s_or_n.setText("SN001")
+    save_calls = []
+
+    monkeypatch.setattr(
+        barcode_ops.LoadUiConfig,
+        "load_last_recorded_info",
+        staticmethod(lambda logger: saved_payload),
+    )
+    monkeypatch.setattr(barcode_ops, "save_recorded_data_to_json", lambda *args: save_calls.append(args), raising=False)
+
+    widget.restore_scanner_checkbox_state()
+
+    assert widget.barcode_scanner_box.isChecked() is False
+    assert widget.lineedit_s_or_n.isEnabled() is False
+    assert widget.lineedit_s_or_n.text() == ""
+    assert widget.hw_manager.stop_calls == 1
+    assert save_calls == []
+
+
+def test_clicked_scanner_persists_checkbox_state(monkeypatch):
+    widget = _DummyWidget()
+    save_calls = []
+
+    monkeypatch.setattr(barcode_ops, "save_recorded_data_to_json", lambda *args: save_calls.append(args), raising=False)
+
+    widget.barcode_scanner_box.setChecked(True)
+    widget.clicked_scanner()
+    widget.barcode_scanner_box.setChecked(False)
+    widget.clicked_scanner()
+
+    assert save_calls == [
+        ("MODEL", "7", "", True),
+        ("MODEL", "7", "", False),
+    ]


### PR DESCRIPTION
## Summary
- restore the S/N scanner checkbox state from the existing persisted UI config when the main sequence window starts
- persist S/N checkbox toggles immediately and reuse a shared enable/disable path for startup restore and user clicks
- add regression tests for saved, missing, and malformed checkbox state payloads

## Test plan
- [x] `pytest "unit_test/test_sn_checkbox_persistence.py" "unit_test/test_sequence_main_layout.py" -q`
- [x] `ReadLints` on the edited files returned no errors