### PR TITLE
feat(pr): add Prominence Ratio analysis module

### DIFF
--- a/base/__init__.py
+++ b/base/__init__.py
@@ -1,0 +1,2 @@
+"""base package."""
+

--- a/base/core_algorithm/__init__.py
+++ b/base/core_algorithm/__init__.py
@@ -1,0 +1,2 @@
+"""base.core_algorithm package."""
+

--- a/base/core_algorithm/response/ecma_critical_band.py
+++ b/base/core_algorithm/response/ecma_critical_band.py
@@ -1,0 +1,239 @@
+"""ECMA-418-1 / 客户 15% 临界带纯函数层（Prominence Ratio 算法基础）。
+
+本模块只放“无状态纯函数”，集中实现 ECMA-418-1:2022 的临界带几何、相邻带边界、
+低频修正与模式绑定计权。`prominence_ratio_analyzer.py`
+负责编排（FFT/PSD、主音检测、决策），不在本文件之外重复实现这些公式。
+
+设计要点（与开发规划 4.1 一致）：
+- 所有 ECMA 公式集中在此，便于逐位对标标准与单测（T15/T16/T17）。
+- PR 为带功率比值，默认在线性/不计权(Z)功率域计算；A/C 仅作为显式高级覆盖项。
+- 临界带宽 / 相邻带二次拟合系数来源：ECMA-418-1:2022 Clause 10 / 12。
+参考公式编号映射见 docs/PR模块与PR频谱模块开发规划.md 4.1.4。
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple, Optional
+
+import numpy as np
+
+from base.core_algorithm.response.frequency_band_analyzer import get_weighting_fn
+
+# ---------------------------------------------------------------------------
+# 常量（ECMA-418-1:2022 频率适用范围）
+# ---------------------------------------------------------------------------
+ECMA_FT_MIN_HZ = 89.1            # 三分之一倍频程 100 Hz 段下沿
+ECMA_SCOPE_FT_MAX_HZ = 11220.0   # 三分之一倍频程 10 kHz 段上沿（适用范围）
+ECMA_FORMULA_FIT_MAX_HZ = 11200.0  # 部分拟合公式/工具采用的上界（兼容用）
+LOW_FREQ_CORRECTION_FT_HZ = 171.4  # ft <= 171.4 Hz 时启用下临界带截断修正
+MIDDLE_BAND_ARITH_MAX_HZ = 500.0   # ft <= 500 Hz 用算术对称，否则用几何边界
+
+
+class BandTriplet(NamedTuple):
+    """单个候选主音的三连续临界带边界 (Hz)。
+
+    lower=(f1L, f2L)，middle=(f1M, f2M)，upper=(f1U, f2U)。
+    满足 f1L < f2L == f1M < f2M == f1U < f2U。
+    """
+
+    lower: tuple[float, float]
+    middle: tuple[float, float]
+    upper: tuple[float, float]
+    valid: bool
+    reason: Optional[str]
+
+
+# ---------------------------------------------------------------------------
+# 临界带宽与 middle band 边界
+# ---------------------------------------------------------------------------
+def critical_bandwidth_hz(ft: float) -> float:
+    """Zwicker 临界带宽 Δfc(ft)（ECMA-418-1 Clause 10 / Formula 2）。
+
+    Δfc(ft) = 25 + 75 * (1 + 1.4 * (ft / 1000)^2)^0.69
+
+    校核值：Δfc(500)≈117.3 Hz，Δfc(1000)≈162.2 Hz，Δfc(5000)≈914 Hz。
+    """
+    ratio = ft / 1000.0
+    return 25.0 + 75.0 * (1.0 + 1.4 * ratio * ratio) ** 0.69
+
+
+def ecma_middle_band(ft: float, fit_max_hz: float = ECMA_FORMULA_FIT_MAX_HZ) -> tuple[float, float]:
+    """目标 middle critical band 边界 (f1M, f2M)。
+
+    ft <= 500 Hz：算术对称（Formulae 4/5）
+        f1M = ft - Δfc/2, f2M = ft + Δfc/2
+    500 < ft <= fit_max：几何边界（Formulae 7/8）
+        f1M = (-Δfc + sqrt(Δfc^2 + 4*ft^2)) / 2, f2M = f1M + Δfc
+    """
+    dfc = critical_bandwidth_hz(ft)
+    if ft <= MIDDLE_BAND_ARITH_MAX_HZ:
+        half = dfc / 2.0
+        return ft - half, ft + half
+    f1m = (-dfc + np.sqrt(dfc * dfc + 4.0 * ft * ft)) / 2.0
+    return f1m, f1m + dfc
+
+
+def ecma_adjacent_bands(
+    ft: float,
+    f1m: float,
+    f2m: float,
+    fit_max_hz: float = ECMA_FORMULA_FIT_MAX_HZ,
+) -> tuple[tuple[float, float], tuple[float, float]]:
+    """下/上相邻临界带边界，返回 ((f1L, f2L), (f1U, f2U))。
+
+    连续性约束：f2L = f1M，f1U = f2M。
+
+    下相邻带下沿 f1L（ECMA-418-1 Clause 12 二次拟合）：
+        89.1 <= ft < 171.4:        f1L = 20.0
+        171.4 <= ft <= 1600:       f1L = -149.5 + 1.001*ft - 6.90e-5*ft^2
+        1600 < ft <= fit_max:      f1L = 6.8 + 0.806*ft - 8.20e-6*ft^2
+    上相邻带上沿 f2U：
+        89.1 <= ft <= 1600:        f2U = 149.5 + 1.035*ft + 7.70e-5*ft^2
+        1600 < ft <= fit_max:      f2U = 3.3 + 1.215*ft + 2.16e-5*ft^2
+
+    实现门禁：以上二次拟合系数须在编码后从干净 ECMA-418-1:2022 PDF 逐位复核。
+    """
+    f2l = f1m
+    f1u = f2m
+
+    if ft < LOW_FREQ_CORRECTION_FT_HZ:
+        f1l = 20.0
+    elif ft <= 1600.0:
+        f1l = -149.5 + 1.001 * ft - 6.90e-5 * ft * ft
+    else:
+        f1l = 6.8 + 0.806 * ft - 8.20e-6 * ft * ft
+
+    if ft <= 1600.0:
+        f2u = 149.5 + 1.035 * ft + 7.70e-5 * ft * ft
+    else:
+        f2u = 3.3 + 1.215 * ft + 2.16e-5 * ft * ft
+
+    return (f1l, f2l), (f1u, f2u)
+
+
+def customer_15pct_bands(ft: float, ratio: float = 0.15) -> BandTriplet:
+    """客户需求书 15% 简化临界带（非 ECMA 标准）。
+
+    目标带宽 bw = ratio * ft；目标带 [ft-bw/2, ft+bw/2]；
+    相邻带在目标带两侧连续布置，各占一个带宽。
+    """
+    bw = ratio * ft
+    half = bw / 2.0
+    f1m, f2m = ft - half, ft + half
+    lower = (f1m - bw, f1m)
+    upper = (f2m, f2m + bw)
+    valid = lower[0] > 0.0
+    reason = None if valid else "lower band below 0 Hz"
+    return BandTriplet(lower=lower, middle=(f1m, f2m), upper=upper, valid=valid, reason=reason)
+
+
+def get_band_triplet(
+    ft: float,
+    mode: str = "ecma",
+    *,
+    customer_band_ratio: float = 0.15,
+    ft_min_hz: float = ECMA_FT_MIN_HZ,
+    ft_max_hz: float = ECMA_SCOPE_FT_MAX_HZ,
+    fit_max_hz: float = ECMA_FORMULA_FIT_MAX_HZ,
+    nyquist_hz: Optional[float] = None,
+) -> BandTriplet:
+    """按模式返回某候选主音 ft 的三连续临界带边界。
+
+    mode=="ecma"：ECMA-418-1 临界带 + 相邻带拟合；
+    mode=="customer_15pct"：15% 简化带。
+
+    若三带未完整落在 [0, nyquist] 内，valid=False（该点 PR 无效，不参与判定）。
+    """
+    if mode == "customer_15pct":
+        triplet = customer_15pct_bands(ft, customer_band_ratio)
+    else:
+        if ft < ft_min_hz or ft > ft_max_hz:
+            reason = f"tone frequency outside ECMA range {ft_min_hz:g}-{ft_max_hz:g} Hz"
+            return BandTriplet(lower=(np.nan, np.nan), middle=(np.nan, np.nan), upper=(np.nan, np.nan),
+                               valid=False, reason=reason)
+        f1m, f2m = ecma_middle_band(ft, fit_max_hz)
+        (f1l, f2l), (f1u, f2u) = ecma_adjacent_bands(ft, f1m, f2m, fit_max_hz)
+        reason = None
+        valid = True
+        if not (f1l < f2l <= f1m + 1e-9 and f1m < f2m and f2m <= f1u + 1e-9 and f1u < f2u):
+            valid = False
+            reason = "non-monotonic band edges"
+        triplet = BandTriplet(lower=(f1l, f2l), middle=(f1m, f2m), upper=(f1u, f2u), valid=valid, reason=reason)
+
+    if not triplet.valid:
+        return triplet
+
+    if nyquist_hz is not None and triplet.upper[1] > nyquist_hz:
+        return triplet._replace(valid=False, reason="upper band exceeds Nyquist")
+    if triplet.lower[0] <= 0.0:
+        return triplet._replace(valid=False, reason="lower band below 0 Hz")
+    return triplet
+
+
+def low_freq_xl_correction_factor(ft: float, f1l: float, f2l: float) -> float:
+    """ft <= 171.4 Hz 时的下临界带截断修正因子（Formula 23）：100 / ΔfL。
+
+    XL_corr = XL * factor；ft > 171.4 Hz 时返回 1.0（不修正）。
+    """
+    if ft > LOW_FREQ_CORRECTION_FT_HZ:
+        return 1.0
+    dfl = f2l - f1l
+    if dfl <= 0.0:
+        return 1.0
+    return 100.0 / dfl
+
+
+# ---------------------------------------------------------------------------
+# ECMA prominent 判据（Clause 12.6 / Formulae 24/25）
+# ---------------------------------------------------------------------------
+def ecma_prominence_limit_db(ft: float, ft_max_hz: float = ECMA_SCOPE_FT_MAX_HZ) -> Optional[float]:
+    """ECMA prominent tone 阈值。
+
+    89.1 <= ft < 1000:   limit = 9 + 10*log10(1000/ft)   # Formula (24)
+    1000 <= ft <= ft_max: limit = 9                        # Formula (25)
+    超出适用范围返回 None（该点不做 ECMA prominent 判定，只能作 customer 展示）。
+    """
+    if ft < ECMA_FT_MIN_HZ or ft > ft_max_hz:
+        return None
+    if ft < 1000.0:
+        return 9.0 + 10.0 * np.log10(1000.0 / ft)
+    return 9.0
+
+
+# ---------------------------------------------------------------------------
+# 模式绑定计权
+# ---------------------------------------------------------------------------
+def resolve_weighting(mode: str, weighting: str) -> tuple[str, list[str]]:
+    """解析 PR 计算使用的有效计权，返回 (effective_weighting, warnings)。
+
+    PR = 目标带功率 / 相邻带平均功率，是一个比值；需求书 4.4.3 / 设备表把 PR 模块
+    幅度标度明确写为 dB（而非 Octave/FFT 的 dB(A)）。因此 PR 默认在**线性/不计权**
+    功率域计算（Z 计权在本工程即 flat 0 dB = 线性），与带宽模式无关。
+
+    - "auto"（默认）→ "Z"（线性/不计权）。
+    - 显式 A / C → 尊重该值（隐藏高级覆盖项，用于特殊对比需求），不再按模式强制。
+    - 显式 Z / none → "Z"。
+    """
+    warnings: list[str] = []
+    w = (weighting or "auto").strip().upper()
+
+    if w in ("AUTO", "Z", "NONE"):
+        return "Z", warnings
+    if w in ("A", "C"):
+        warnings.append(f"PR 默认线性(Z)功率；当前按高级配置使用 {w} 计权")
+        return w, warnings
+    warnings.append(f"未知计权 {weighting}，回退线性(Z)")
+    return "Z", warnings
+
+
+def weighting_correction_db(freq_hz: np.ndarray, weighting: str) -> np.ndarray:
+    """返回各频点的计权修正值 (dB)。复用 frequency_band_analyzer 的计权曲线。"""
+    return get_weighting_fn(weighting)(np.asarray(freq_hz, dtype=float))
+
+
+def apply_weighting_to_psd(psd: np.ndarray, freq_hz: np.ndarray, weighting: str) -> np.ndarray:
+    """在功率域施加计权：psd_weighted = psd * 10^(W_dB/10)。Z 计权为恒等。"""
+    if (weighting or "Z").strip().upper() in ("Z", "NONE", "AUTO"):
+        return np.asarray(psd, dtype=float)
+    w_db = weighting_correction_db(freq_hz, weighting)
+    return np.asarray(psd, dtype=float) * (10.0 ** (w_db / 10.0))

--- a/base/core_algorithm/response/prominence_ratio_analyzer.py
+++ b/base/core_algorithm/response/prominence_ratio_analyzer.py
@@ -1,0 +1,653 @@
+"""Prominence Ratio (突出比, PR) 算法编排层。
+
+信号预处理 → FFT/Welch PSD → 计权 → 临界带功率积分 → PR 频谱
+→ 候选主音检测/BPF/同带分组 → ECMA prominent + 客户 4/2/4 判定。
+
+ECMA 临界带公式统一由 ecma_critical_band 模块提供。
+PR = 10·lg(XM / ((XL + XU) / 2))，线性功率域。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional, Union
+
+import numpy as np
+from scipy import signal as sp_signal
+
+from base.core_algorithm.response import ecma_critical_band as ecb
+
+P_REF_PA = 20e-6
+MAIN_TONE_MIN_GAP_DB = 3.0
+CANDIDATE_PEAK_PROMINENCE_DB = MAIN_TONE_MIN_GAP_DB
+
+
+@dataclass
+class ProminenceRatioParams:
+    """PR 分析参数。"""
+
+    f_min: float = 100.0
+    f_max: float = 20000.0
+    standard: str = "ecma74_annexD"
+    critical_band_mode: str = "ecma"
+    mode_profile: str = "ecma2022"
+    ecma_ft_min_hz: float = ecb.ECMA_FT_MIN_HZ
+    ecma_scope_ft_max_hz: float = ecb.ECMA_SCOPE_FT_MAX_HZ
+    ecma_formula_fit_max_hz: float = ecb.ECMA_FORMULA_FIT_MAX_HZ
+    window_samples: int = 65536
+    target_resolution_hz: float = 1.0
+    overlap_ratio: float = 0.75
+    window: str = "hann"
+    weighting: str = "auto"
+    customer_band_ratio: float = 0.15
+    dc_removal: str = "mean"
+    highpass_hz: float = 20.0
+    bpf_enabled: bool = False
+    blade_count: int = 0
+    rpm: int = 0
+    bpf_tolerance_percent: float = 5.0
+    include_harmonics_in_customer_judgement: bool = False
+
+    @classmethod
+    def from_config(cls, cfg: Optional[dict]) -> tuple["ProminenceRatioParams", list[str]]:
+        """从 UI/JSON 配置构造参数，返回 (params, config_warnings)。"""
+        cfg = cfg or {}
+        adv = cfg.get("advanced", {}) or {}
+        warnings: list[str] = []
+
+        def pick(key, default):
+            if key in adv:
+                return adv[key]
+            if key in cfg:
+                return cfg[key]
+            return default
+
+        defaults = cls()
+        mode = str(pick("critical_band_mode", defaults.critical_band_mode))
+        raw_weighting = str(pick("weighting", defaults.weighting))
+        effective_weighting, w_warn = ecb.resolve_weighting(mode, raw_weighting)
+        warnings.extend(w_warn)
+
+        params = cls(
+            f_min=float(pick("f_min", defaults.f_min)),
+            f_max=float(pick("f_max", defaults.f_max)),
+            standard=str(pick("standard", defaults.standard)),
+            critical_band_mode=mode,
+            mode_profile=str(pick("mode_profile", defaults.mode_profile)),
+            window_samples=int(pick("window_samples", defaults.window_samples)),
+            target_resolution_hz=float(pick("target_resolution_hz", defaults.target_resolution_hz)),
+            overlap_ratio=float(pick("overlap_ratio", defaults.overlap_ratio)),
+            window=str(pick("window", defaults.window)),
+            weighting=effective_weighting,
+            customer_band_ratio=float(pick("customer_band_ratio", defaults.customer_band_ratio)),
+            dc_removal=str(pick("dc_removal", defaults.dc_removal)),
+            highpass_hz=float(pick("highpass_hz", defaults.highpass_hz)),
+            bpf_enabled=bool(pick("bpf_enabled", defaults.bpf_enabled)),
+            blade_count=int(pick("blade_count", defaults.blade_count)),
+            rpm=int(pick("rpm", defaults.rpm)),
+            bpf_tolerance_percent=float(pick("bpf_tolerance_percent", defaults.bpf_tolerance_percent)),
+            include_harmonics_in_customer_judgement=bool(
+                pick("include_harmonics_in_customer_judgement", defaults.include_harmonics_in_customer_judgement)
+            ),
+        )
+        return params, warnings
+
+
+@dataclass
+class ProminenceToneResult:
+    frequency_hz: float
+    peak_db: float
+    target_band_hz: tuple[float, float]
+    lower_adjacent_band_hz: tuple[float, float]
+    upper_adjacent_band_hz: tuple[float, float]
+    target_power_db: float
+    lower_adjacent_power_db: float
+    upper_adjacent_power_db: float
+    adjacent_mean_power_db: float
+    pr_db: float
+    ecma_prominence_limit_db: Optional[float]
+    ecma_prominent: Optional[bool]
+    limit_db: float
+    customer_ok: Optional[bool]
+    margin_db: float
+    is_ok: bool
+    same_band_group_id: Optional[int]
+    same_band_representative: bool
+    harmonic_order: Optional[int]
+    valid_main_tone: bool
+    bpf_verified: Optional[bool]
+    invalid_reasons: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ProminenceRatioSpectrumResult:
+    frequency_hz: np.ndarray
+    band_power_db: np.ndarray
+    pr_db: np.ndarray
+    fft_magnitude_db: np.ndarray
+    fft_freq_hz: np.ndarray
+    main_tones: list[ProminenceToneResult]
+    max_pr_db: float
+    max_pr_frequency_hz: float
+    decision_status: str
+    overall_ok: Optional[bool]
+    max_exceed_db: float
+    no_valid_main_tone: bool
+    warnings: list[str] = field(default_factory=list)
+    metadata: dict = field(default_factory=dict)
+
+
+
+def _next_power_of_two(n: int) -> int:
+    if n <= 1:
+        return 1
+    return int(2 ** np.ceil(np.log2(n)))
+
+
+def _customer_limit_db(ft: float, fan_pr_limits: list) -> float:
+    for band in fan_pr_limits:
+        f_lo, f_hi, limit = band[0], band[1], band[2]
+        if f_lo <= ft < f_hi:
+            return float(limit)
+    return 4.0
+
+
+def _power_to_level_db(power: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
+    arr = np.asarray(power, dtype=float)
+    level = 10.0 * np.log10(np.maximum(arr, 1e-30) / (P_REF_PA ** 2))
+    if np.ndim(power) == 0:
+        return float(level)
+    return level
+
+
+def _empty_invalid_result(reason: str, warnings: list[str], metadata: dict) -> ProminenceRatioSpectrumResult:
+    empty = np.asarray([], dtype=float)
+    return ProminenceRatioSpectrumResult(
+        frequency_hz=empty,
+        band_power_db=empty,
+        pr_db=empty,
+        fft_magnitude_db=empty,
+        fft_freq_hz=empty,
+        main_tones=[],
+        max_pr_db=float("nan"),
+        max_pr_frequency_hz=float("nan"),
+        decision_status="invalid",
+        overall_ok=None,
+        max_exceed_db=0.0,
+        no_valid_main_tone=True,
+        warnings=[*warnings, reason],
+        metadata=metadata,
+    )
+
+
+
+class ProminenceRatioAnalyzer:
+
+    MIN_SAMPLES = 1024
+
+    def __init__(self, sample_rate: int):
+        self.sample_rate = int(sample_rate)
+
+    def _preprocess(self, signal: np.ndarray, v2pa_factor: float, params: ProminenceRatioParams,
+                    warnings: list[str]) -> np.ndarray:
+        x = np.asarray(signal, dtype=float).flatten() * float(v2pa_factor)
+        if params.dc_removal == "mean":
+            x = x - np.mean(x)
+        if params.highpass_hz and params.highpass_hz > 0.0:
+            nyq = self.sample_rate / 2.0
+            wc = params.highpass_hz / nyq
+            if 0.0 < wc < 1.0:
+                b, a = sp_signal.butter(2, wc, btype="highpass")
+                x = sp_signal.filtfilt(b, a, x)
+            else:
+                warnings.append(f"高通截频 {params.highpass_hz}Hz 超出有效范围，已跳过")
+        return x
+
+    def _compute_psd(self, x: np.ndarray, params: ProminenceRatioParams,
+                     warnings: list[str]) -> tuple[np.ndarray, np.ndarray]:
+        nperseg = int(params.window_samples)
+        target_grid = _next_power_of_two(int(self.sample_rate / max(params.target_resolution_hz, 1e-6)))
+        nfft = max(nperseg, target_grid)
+        noverlap = int(nperseg * params.overlap_ratio)
+        freq, psd = sp_signal.welch(
+            x,
+            fs=self.sample_rate,
+            window=params.window,
+            nperseg=nperseg,
+            noverlap=noverlap,
+            nfft=nfft,
+            scaling="density",
+        )
+        return np.asarray(freq, dtype=float), np.asarray(psd, dtype=float)
+
+    @staticmethod
+    def _build_cumulative_power(freq: np.ndarray, psd: np.ndarray) -> np.ndarray:
+        seg = 0.5 * (psd[1:] + psd[:-1]) * np.diff(freq)
+        return np.concatenate(([0.0], np.cumsum(seg)))
+
+    @staticmethod
+    def _band_power(edges_lo: np.ndarray, edges_hi: np.ndarray,
+                    freq: np.ndarray, cum: np.ndarray) -> np.ndarray:
+        lo = np.interp(edges_lo, freq, cum)
+        hi = np.interp(edges_hi, freq, cum)
+        return np.maximum(hi - lo, 0.0)
+
+    @staticmethod
+    def _band_edges(f: np.ndarray, params: ProminenceRatioParams):
+        """对频率数组 f 向量化计算 (f1l,f2l,f1m,f2m,f1u,f2u,corr)。"""
+        f = np.asarray(f, dtype=float)
+        if params.critical_band_mode == "customer_15pct":
+            bw = params.customer_band_ratio * f
+            half = bw / 2.0
+            f1m, f2m = f - half, f + half
+            f1l, f2l = f1m - bw, f1m
+            f1u, f2u = f2m, f2m + bw
+            corr = np.ones_like(f)
+        else:
+            ft = f
+            dfc = ecb.critical_bandwidth_hz(ft)
+            half = dfc / 2.0
+            f1m_arith, f2m_arith = ft - half, ft + half
+            f1m_geo = (-dfc + np.sqrt(dfc * dfc + 4.0 * ft * ft)) / 2.0
+            f2m_geo = f1m_geo + dfc
+            is_arith = ft <= ecb.MIDDLE_BAND_ARITH_MAX_HZ
+            f1m = np.where(is_arith, f1m_arith, f1m_geo)
+            f2m = np.where(is_arith, f2m_arith, f2m_geo)
+            f2l = f1m
+            f1u = f2m
+            f1l = np.where(
+                ft < ecb.LOW_FREQ_CORRECTION_FT_HZ,
+                20.0,
+                np.where(ft <= 1600.0,
+                         -149.5 + 1.001 * ft - 6.90e-5 * ft * ft,
+                         6.8 + 0.806 * ft - 8.20e-6 * ft * ft),
+            )
+            f2u = np.where(ft <= 1600.0,
+                           149.5 + 1.035 * ft + 7.70e-5 * ft * ft,
+                           3.3 + 1.215 * ft + 2.16e-5 * ft * ft)
+            dfl = np.maximum(f2l - f1l, 1e-9)
+            corr = np.where(ft <= ecb.LOW_FREQ_CORRECTION_FT_HZ, 100.0 / dfl, 1.0)
+        return f1l, f2l, f1m, f2m, f1u, f2u, corr
+
+    @staticmethod
+    def _analysis_f_max(params: ProminenceRatioParams, nyq: float) -> float:
+        f_max = min(float(params.f_max), float(nyq))
+        if params.critical_band_mode != "customer_15pct":
+            f_max = min(f_max, float(params.ecma_scope_ft_max_hz))
+        return f_max
+
+    def _pr_estimate(self, f: np.ndarray, freq: np.ndarray, cum: np.ndarray,
+                     params: ProminenceRatioParams, nyq: float) -> np.ndarray:
+        f1l, f2l, f1m, f2m, f1u, f2u, corr = self._band_edges(f, params)
+        xm = self._band_power(f1m, f2m, freq, cum)
+        xl = self._band_power(f1l, f2l, freq, cum) * corr
+        xu = self._band_power(f1u, f2u, freq, cum)
+        adj = (xl + xu) / 2.0
+        with np.errstate(divide="ignore", invalid="ignore"):
+            pr = 10.0 * np.log10(np.where(adj > 0, xm / adj, np.nan))
+        invalid = (f1l <= 0.0) | (f2u > nyq)
+        if params.critical_band_mode != "customer_15pct":
+            invalid = invalid | (f < params.ecma_ft_min_hz) | (f > params.ecma_scope_ft_max_hz)
+        return np.where(invalid, np.nan, pr)
+
+    def _compute_pr_spectrum(self, freq: np.ndarray, cum: np.ndarray,
+                             params: ProminenceRatioParams) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        nyq = self.sample_rate / 2.0
+        f_max = self._analysis_f_max(params, nyq)
+        mask = (freq >= params.f_min) & (freq <= f_max)
+        f = freq[mask]
+        if f.size == 0:
+            return f, f, f
+        _f1l, _f2l, f1m, f2m, _f1u, _f2u, _corr = self._band_edges(f, params)
+        target_power = self._band_power(f1m, f2m, freq, cum)
+        invalid = (f1m <= 0.0) | (f2m > nyq)
+        band_power_db = _power_to_level_db(target_power)
+        band_power_db = np.where(invalid, np.nan, band_power_db)
+        pr = self._pr_estimate(f, freq, cum, params, nyq)
+        return f, band_power_db, pr
+
+    def _detect_tones(self, freq: np.ndarray, psd_w: np.ndarray, cum: np.ndarray,
+                      params: ProminenceRatioParams, fan_pr_limits: list,
+                      warnings: list[str]) -> list[ProminenceToneResult]:
+        nyq = self.sample_rate / 2.0
+        mag_db = 10.0 * np.log10(np.maximum(psd_w, 1e-30))
+        f_max = self._analysis_f_max(params, nyq)
+        band_mask = (freq >= params.f_min) & (freq <= f_max)
+        mag_in = mag_db[band_mask]
+        freq_in = freq[band_mask]
+        if freq_in.size < 3:
+            return []
+
+        peaks, _props = sp_signal.find_peaks(mag_in, prominence=CANDIDATE_PEAK_PROMINENCE_DB)
+        bpf_hz = (params.blade_count * params.rpm / 60.0) if (params.bpf_enabled and params.rpm > 0) else None
+
+        tones: list[ProminenceToneResult] = []
+        for pk in peaks:
+            ft = float(freq_in[pk])
+            peak_db = float(mag_in[pk])
+            invalid_reasons: list[str] = []
+
+            triplet = ecb.get_band_triplet(
+                ft,
+                mode=params.critical_band_mode,
+                customer_band_ratio=params.customer_band_ratio,
+                ft_min_hz=params.ecma_ft_min_hz,
+                ft_max_hz=params.ecma_scope_ft_max_hz,
+                fit_max_hz=params.ecma_formula_fit_max_hz,
+                nyquist_hz=nyq,
+            )
+            if not triplet.valid:
+                invalid_reasons.append(triplet.reason or "invalid band")
+
+            (f1l, f2l) = triplet.lower
+            (f1m, f2m) = triplet.middle
+            (f1u, f2u) = triplet.upper
+            corr = ecb.low_freq_xl_correction_factor(ft, f1l, f2l) if params.critical_band_mode != "customer_15pct" else 1.0
+
+            xm = float(self._band_power(np.array([f1m]), np.array([f2m]), freq, cum)[0])
+            xl = float(self._band_power(np.array([f1l]), np.array([f2l]), freq, cum)[0]) * corr
+            xu = float(self._band_power(np.array([f1u]), np.array([f2u]), freq, cum)[0])
+            adj = (xl + xu) / 2.0
+            if adj > 0 and xm > 0:
+                pr_db = 10.0 * np.log10(xm / adj)
+            else:
+                pr_db = float("nan")
+                invalid_reasons.append("non-positive band power")
+
+            if params.critical_band_mode == "customer_15pct":
+                ecma_limit = None
+                ecma_prominent = None
+            else:
+                ecma_limit = ecb.ecma_prominence_limit_db(ft, params.ecma_scope_ft_max_hz)
+                ecma_prominent = (pr_db >= ecma_limit) if (ecma_limit is not None and not np.isnan(pr_db)) else None
+
+            limit_db = _customer_limit_db(ft, fan_pr_limits)
+            if np.isnan(pr_db):
+                customer_ok = None
+                margin_db = float("nan")
+            else:
+                customer_ok = pr_db <= limit_db
+                margin_db = limit_db - pr_db
+
+            valid_main_tone = (len(invalid_reasons) == 0)
+
+            bpf_verified: Optional[bool] = None
+            harmonic_order: Optional[int] = None
+            if bpf_hz:
+                tol = params.bpf_tolerance_percent / 100.0
+                ratio = ft / bpf_hz
+                nearest = round(ratio)
+                if nearest >= 1 and abs(ratio - nearest) <= tol:
+                    bpf_verified = (nearest == 1)
+                    harmonic_order = int(nearest) if nearest > 1 else None
+                else:
+                    bpf_verified = False
+                if bpf_verified is False:
+                    valid_main_tone = False
+                    reason = "BPF/mechanical match not verified"
+                    if reason not in invalid_reasons:
+                        invalid_reasons.append(reason)
+
+            tones.append(ProminenceToneResult(
+                frequency_hz=ft,
+                peak_db=peak_db,
+                target_band_hz=(f1m, f2m),
+                lower_adjacent_band_hz=(f1l, f2l),
+                upper_adjacent_band_hz=(f1u, f2u),
+                target_power_db=_power_to_level_db(xm) if xm > 0 else float("nan"),
+                lower_adjacent_power_db=_power_to_level_db(xl) if xl > 0 else float("nan"),
+                upper_adjacent_power_db=_power_to_level_db(xu) if xu > 0 else float("nan"),
+                adjacent_mean_power_db=_power_to_level_db(adj) if adj > 0 else float("nan"),
+                pr_db=pr_db,
+                ecma_prominence_limit_db=ecma_limit,
+                ecma_prominent=ecma_prominent,
+                limit_db=limit_db,
+                customer_ok=customer_ok,
+                margin_db=margin_db,
+                is_ok=bool(customer_ok) if customer_ok is not None else True,
+                same_band_group_id=None,
+                same_band_representative=True,
+                harmonic_order=harmonic_order,
+                valid_main_tone=valid_main_tone,
+                bpf_verified=bpf_verified,
+                invalid_reasons=invalid_reasons,
+            ))
+
+        self._apply_frequency_interval_main_tone_rule(tones, fan_pr_limits)
+        self._assign_same_band_groups(tones)
+        return tones
+
+    @staticmethod
+    def _apply_frequency_interval_main_tone_rule(
+        tones: list[ProminenceToneResult],
+        fan_pr_limits: list,
+    ) -> None:
+        """按频段选出有效主音：段内最高峰且与次高峰差 >= 3dB。"""
+        valid_candidates = [t for t in tones if t.valid_main_tone]
+        if not valid_candidates:
+            return
+
+        intervals: list[tuple[float, float]] = []
+        for band in fan_pr_limits or []:
+            try:
+                f_lo, f_hi = float(band[0]), float(band[1])
+            except (TypeError, ValueError, IndexError):
+                continue
+            if np.isfinite(f_lo) and np.isfinite(f_hi) and f_hi > f_lo:
+                intervals.append((f_lo, f_hi))
+        if not intervals:
+            intervals = [(min(t.frequency_hz for t in valid_candidates), max(t.frequency_hz for t in valid_candidates) + 1.0)]
+
+        selected_ids: set[int] = set()
+        for band_idx, (f_lo, f_hi) in enumerate(intervals):
+            in_band = [
+                t for t in valid_candidates
+                if (f_lo <= t.frequency_hz < f_hi) or (band_idx == len(intervals) - 1 and f_lo <= t.frequency_hz <= f_hi)
+            ]
+            if not in_band:
+                continue
+            ranked = sorted(in_band, key=lambda t: t.peak_db, reverse=True)
+            top = ranked[0]
+            if len(ranked) > 1:
+                second = ranked[1]
+                diff = top.peak_db - second.peak_db
+                if diff < MAIN_TONE_MIN_GAP_DB:
+                    reason = f"interval top-second gap {diff:.1f}dB < {MAIN_TONE_MIN_GAP_DB:.1f}dB"
+                    for t in ranked:
+                        t.valid_main_tone = False
+                        if reason not in t.invalid_reasons:
+                            t.invalid_reasons.append(reason)
+                    continue
+            selected_ids.add(id(top))
+            for t in ranked[1:]:
+                t.valid_main_tone = False
+                reason = "not highest tone in frequency interval"
+                if reason not in t.invalid_reasons:
+                    t.invalid_reasons.append(reason)
+
+        for t in valid_candidates:
+            if id(t) not in selected_ids and t.valid_main_tone:
+                t.valid_main_tone = False
+                reason = "outside configured PR frequency intervals"
+                if reason not in t.invalid_reasons:
+                    t.invalid_reasons.append(reason)
+
+    @staticmethod
+    def _assign_same_band_groups(tones: list[ProminenceToneResult]) -> None:
+        """同一 middle critical band 内的多个有效主音归为一组，组内 PR 最大者为代表。
+
+        采用 middle band 区间重叠的传递性归并（对频率排序后线性扫描）：两音的
+        middle band 区间相交即并入同一组，避免“仅按首音判定”导致的非对称裂组。
+        代表峰 same_band_representative=True 参与 OK/NG 汇总，其余仅展示，避免共享
+        XM 总功率导致重复判 fail（见规划 4.1.4 同临界带多峰处理）。
+        """
+        for t in tones:
+            t.same_band_group_id = None
+            t.same_band_representative = bool(t.valid_main_tone)
+
+        valid = sorted(
+            (t for t in tones if t.valid_main_tone),
+            key=lambda t: t.frequency_hz,
+        )
+
+        def _flush(members: list[ProminenceToneResult]) -> None:
+            if not members:
+                return
+            rep = max(members, key=lambda m: (m.pr_db if not np.isnan(m.pr_db) else -np.inf))
+            for m in members:
+                m.same_band_representative = (m is rep)
+
+        group_id = -1
+        cur_upper = -np.inf
+        cur_members: list[ProminenceToneResult] = []
+        for t in valid:
+            f1m, f2m = t.target_band_hz
+            if cur_members and f1m <= cur_upper:
+                cur_members.append(t)
+                cur_upper = max(cur_upper, f2m)
+            else:
+                _flush(cur_members)
+                group_id += 1
+                cur_members = [t]
+                cur_upper = f2m
+            t.same_band_group_id = group_id
+        _flush(cur_members)
+
+    # -- 决策汇总 --------------------------------------------------------
+    @staticmethod
+    def _decide(tones: list[ProminenceToneResult],
+                params: ProminenceRatioParams) -> tuple[str, Optional[bool], float, bool]:
+        valid = [t for t in tones if t.valid_main_tone]
+        if not valid:
+            return "not_applicable", None, 0.0, True
+
+        reps = [t for t in valid if t.same_band_representative]
+        if not params.include_harmonics_in_customer_judgement:
+            reps = [t for t in reps if t.harmonic_order is None]
+        if not reps:
+            return "not_applicable", None, 0.0, True
+
+        if any(t.customer_ok is None for t in reps):
+            return "invalid", None, 0.0, False
+
+        exceed = [max(t.pr_db - t.limit_db, 0.0) for t in reps]
+        max_exceed = max(exceed) if exceed else 0.0
+        all_ok = all(t.customer_ok for t in reps)
+        status = "pass" if all_ok else "fail"
+        return status, all_ok, max_exceed, False
+
+    # -- 主入口 ----------------------------------------------------------
+    def compute(
+        self,
+        signal: np.ndarray,
+        v2pa_factor: float = 1.0,
+        params: Optional[ProminenceRatioParams] = None,
+        fan_pr_limits: Optional[list] = None,
+        initial_warnings: Optional[list[str]] = None,
+    ) -> ProminenceRatioSpectrumResult:
+        params = params or ProminenceRatioParams()
+        fan_pr_limits = fan_pr_limits or [[100, 2000, 4], [2000, 5000, 2], [5000, 20000, 4]]
+        warnings: list[str] = list(initial_warnings or [])
+
+        # 计权兜底：即便 params 由直接构造（weighting 仍为 "auto"），
+        # 也保证 customer_15pct 与 ecma 的默认计权一致，均为线性(Z)。
+        effective_weighting, w_warn = ecb.resolve_weighting(params.critical_band_mode, params.weighting)
+        warnings.extend(w_warn)
+
+        metadata = {
+            "standard": params.standard,
+            "critical_band_mode": params.critical_band_mode,
+            "mode_profile": params.mode_profile,
+            "effective_weighting": effective_weighting,
+            "sample_rate_hz": self.sample_rate,
+            "window": params.window,
+            "window_samples": params.window_samples,
+            "effective_window_samples": params.window_samples,
+            "calculation_downsampling": False,
+            "overlap_ratio": params.overlap_ratio,
+            "f_min": params.f_min,
+            "f_max": params.f_max,
+            "band_power_unit": "dB",
+            "band_power_reference_pa": P_REF_PA,
+        }
+
+        x = np.asarray(signal, dtype=float).flatten()
+        if x.size < self.MIN_SAMPLES:
+            return _empty_invalid_result(f"信号过短（{x.size} < {self.MIN_SAMPLES}）", warnings, metadata)
+        if params.window_samples <= 0:
+            return _empty_invalid_result(f"窗口长度无效（window_samples={params.window_samples}）", warnings, metadata)
+        if x.size < int(params.window_samples):
+            return _empty_invalid_result(
+                f"信号长度 {x.size} 小于配置窗口长度 {int(params.window_samples)}，PR 未计算；请延长采样时长或调小窗口长度",
+                warnings,
+                metadata,
+            )
+
+        nyq = self.sample_rate / 2.0
+        if nyq < params.f_max:
+            warnings.append(f"采样率不足以覆盖 {params.f_max}Hz，分析上限降为 {nyq}Hz")
+
+        x = self._preprocess(signal, v2pa_factor, params, warnings)
+        freq, psd = self._compute_psd(x, params, warnings)
+
+        # 默认线性(Z)功率；显式 A/C 仅作为高级覆盖。
+        psd_w = ecb.apply_weighting_to_psd(psd, freq, effective_weighting)
+        metadata["effective_nfft"] = int((len(freq) - 1) * 2)
+
+        cum = self._build_cumulative_power(freq, psd_w)
+        f_axis, band_power_db, pr_spectrum = self._compute_pr_spectrum(freq, cum, params)
+        tones = self._detect_tones(freq, psd_w, cum, params, fan_pr_limits, warnings)
+        pr_valid_mask = np.isfinite(pr_spectrum)
+        if pr_valid_mask.any():
+            effective_pr_f_max = float(np.nanmax(f_axis[pr_valid_mask]))
+        else:
+            effective_pr_f_max = float("nan")
+        configured_f_hi = self._analysis_f_max(params, nyq)
+        metadata["effective_pr_f_max_hz"] = effective_pr_f_max
+        pr_frequency_coverage_complete = True
+        if np.isfinite(effective_pr_f_max) and effective_pr_f_max + max(params.target_resolution_hz, 1.0) < configured_f_hi:
+            pr_frequency_coverage_complete = False
+            f1l_req, f2l_req, f1m_req, f2m_req, f1u_req, f2u_req, _ = self._band_edges(
+                np.array([configured_f_hi], dtype=float),
+                params,
+            )
+            required_sr = 2.0 * float(f2u_req[0])
+            metadata["required_sample_rate_for_configured_f_max_hz"] = required_sr
+            warnings.append(
+                f"PR 有效上限约为 {effective_pr_f_max:.0f}Hz；"
+                f"{configured_f_hi:.0f}Hz 的右相邻临界带上边界需采样率 ≥ {required_sr:.0f}Hz，"
+                f"当前采样率 {self.sample_rate}Hz 不足，超出部分无 PR 值"
+            )
+        metadata["pr_frequency_coverage_complete"] = pr_frequency_coverage_complete
+        if freq.size > 1:
+            df = float(np.median(np.diff(freq)))
+        else:
+            df = 1.0
+        spectrum_power_db = _power_to_level_db(psd_w * max(df, 1e-30))
+
+        if pr_spectrum.size and np.any(~np.isnan(pr_spectrum)):
+            i_max = int(np.nanargmax(pr_spectrum))
+            max_pr_db = float(pr_spectrum[i_max])
+            max_pr_freq = float(f_axis[i_max])
+        else:
+            max_pr_db = float("nan")
+            max_pr_freq = float("nan")
+
+        status, overall_ok, max_exceed, no_valid = self._decide(tones, params)
+
+        return ProminenceRatioSpectrumResult(
+            frequency_hz=f_axis,
+            band_power_db=band_power_db,
+            pr_db=pr_spectrum,
+            fft_magnitude_db=spectrum_power_db,
+            fft_freq_hz=freq,
+            main_tones=tones,
+            max_pr_db=max_pr_db,
+            max_pr_frequency_hz=max_pr_freq,
+            decision_status=status,
+            overall_ok=overall_ok,
+            max_exceed_db=max_exceed,
+            no_valid_main_tone=no_valid,
+            warnings=warnings,
+            metadata=metadata,
+        )

--- a/base/excel_result_exporter.py
+++ b/base/excel_result_exporter.py
@@ -661,6 +661,9 @@ def _extract_curve_xy(result: dict[str, Any]) -> tuple[list[Any], list[Any]] | N
         ("freq_value", "thd"),
         ("signal_duration", "signal_spl_raw"),
         ("signal_duration", "signal_spl"),
+        ("time_s", "loudness_sone"),
+        ("time_s", "sharpness_acum"),
+        ("frequency_hz", "pr_db"),
     ]
     for xk, yk in candidates:
         if xk in result and yk in result:
@@ -747,6 +750,14 @@ def _export_unit(item_type: Any, cfg: dict[str, Any] | None) -> str:
         return "dB"
     if t == "PRB":
         return "phon"
+    if t == "LOUD":
+        return "sone"
+    if t == "SHRP":
+        return "acum"
+    if t == "ROUGH":
+        return "asper"
+    if t == "PR":
+        return "dB"
     return ""
 
 

--- a/ui/operation_sequence.py
+++ b/ui/operation_sequence.py
@@ -5,7 +5,7 @@ import json
 import copy
 from datetime import datetime
 
-from PyQt5.QtCore import Qt, QModelIndex, QSize
+from PyQt5.QtCore import Qt, QModelIndex, QSize, QTimer
 from PyQt5.QtGui import QIcon, QStandardItemModel, QStandardItem
 from PyQt5.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QApplication, QFileDialog
 from time import time
@@ -40,6 +40,9 @@ from ui.ui_analysis_config.ai_config_dialog import AIConfigWindow
 from ui.ui_analysis_config.fr_config_dialog import FrConfigWindow
 from ui.ui_analysis_config.hd_config_dialog import HdConfigWindow
 from ui.ui_analysis_config.lp_config_dialog import LPConfigWindow
+from ui.ui_analysis_config.loudness_config_dialog import LoudnessConfigWindow
+from ui.ui_analysis_config.roughness_config_dialog import RoughnessConfigWindow, default_roughness_config
+from ui.ui_analysis_config.sharpness_config_dialog import SharpnessConfigWindow, default_sharpness_config
 from ui.ui_analysis_config.pattern_match_config_dialog import PatternMatchConfigWindow
 from ui.ui_analysis_config.pd_config_dialog import PDConfigWindow
 from ui.ui_analysis_config.perceptual_rb_config_dialog import PerceptualRbConfigWindow
@@ -51,6 +54,7 @@ from ui.ui_analysis_config.spl_config_dialog import SplConfigWindow
 from ui.ui_analysis_config.fba_config_dialog import FbaConfigWindow
 from ui.ui_analysis_config.mel_config_dialog import MelConfigWindow
 from ui.ui_analysis_config.modulation_config_dialog import ModulationConfigWindow
+from ui.ui_analysis_config.pr_config_dialog import PRConfigWindow, default_pr_config
 from ui.signal_analysis_window import get_class_mapping
 from ui.ui_analysis_config.excel_config_dialog import ExcelConfigWindow
 from ui.ui_analysis_config.pdf_config_dialog import PdfConfigWindow
@@ -219,6 +223,10 @@ class AnalysisModelSelect(QDialog):
             "参考频谱对比 (RSC) ",
             "频响 (FR) ",
             "频段能量 (FBA) ",
+            "突出比 (PR) ",
+            "响度 (LOUD) ",
+            "尖锐度 (SHRP) ",
+            "粗糙度 (ROUGH) ",
             "谐波失真 (HD) ",
             "高阶谐波失真 (RB) ",
             "感知失真 (PRB) ",
@@ -661,6 +669,7 @@ class OptionList(ListView):
         self.press_time = None
         self.is_edit_item = True
         self.index_num = None
+        self._config_dialog_opening = False
         self.config = list()
         self.drop_is_accept = True
         self.signal_len = 0
@@ -671,6 +680,7 @@ class OptionList(ListView):
         self.dragEnterEvent = self.dragenterevent
         self.dragMoveEvent = self.dragmoveevent
         self.dropEvent = self.dropevent
+        self.setEditTriggers(ListView.NoEditTriggers)
 
     @staticmethod
     def _normalize_channels(channels):
@@ -774,6 +784,15 @@ class OptionList(ListView):
         ai_list.append(name)
 
     def show_dialog(self, name):
+        if self._config_dialog_opening:
+            return
+        self._config_dialog_opening = True
+        try:
+            return self._show_dialog_impl(name)
+        finally:
+            self._config_dialog_opening = False
+
+    def _show_dialog_impl(self, name):
         model = None
         if name == self.config[0].name:
             if "播放与录制" in self.config[0].name:
@@ -814,7 +833,11 @@ class OptionList(ListView):
             model = self.create_config_dialog(model, config_manager, model_type, type, self.signal_len)
             model.setWindowTitle(name)
             if model.exec_() == QDialog.Accepted:
-                config_data = model.on_click_ok_btn()
+                config_data = getattr(model, "_accepted_config", None)
+                if config_data is None and hasattr(model, "get_default_config"):
+                    config_data = model.get_default_config()
+                if config_data is None:
+                    config_data = model.on_click_ok_btn()
                 self.add_config(name, config_data)
 
     def load_stimulus_config(self):
@@ -866,6 +889,14 @@ class OptionList(ListView):
             model = FbaConfigWindow(config_manager, name, available_channels=available_channels)
         elif type == "Modulation":
             model = ModulationConfigWindow(config_manager, name, available_channels=available_channels)
+        elif type == "PR":
+            model = PRConfigWindow(config_manager, name, available_channels=available_channels)
+        elif type == "LOUD":
+            model = LoudnessConfigWindow(config_manager, name)
+        elif type == "SHRP":
+            model = SharpnessConfigWindow(config_manager, name)
+        elif type == "ROUGH":
+            model = RoughnessConfigWindow(config_manager, name)
         elif type == "Excel":
             model = ExcelConfigWindow(config_manager, name)
         elif type == "PDF":
@@ -1079,7 +1110,7 @@ class OptionList(ListView):
                 self.darpflag = True
                 self.start_index = index
                 self.start_row_number = index.row()
-        if Qt.RightButton == e.button():
+        elif Qt.RightButton == e.button():
             self.setCurrentIndex(self.indexAt(e.pos()))
             self.index_num = index.row()
         e.accept()
@@ -1131,13 +1162,35 @@ class OptionList(ListView):
             self.start_item_name = new_item.text()
             self.index_num = self.start_row_number
             self.darpflag = False
-        if self.row_num == row_number & row_number != -1:
-            name_str = self.model().itemFromIndex(index).text()
-            self.show_dialog(name_str)
-            self.row_num = None
-        else:
-            self.row_num = row_number
+        self.row_num = row_number
         e.accept()
+
+    def mouseDoubleClickEvent(self, e):
+        if Qt.LeftButton != e.button():
+            e.ignore()
+            return
+        index = self.indexAt(e.pos())
+        if not index.isValid():
+            e.ignore()
+            return
+        self.darpflag = False
+        self.row_num = None
+        item = self.model().itemFromIndex(index)
+        if item is None:
+            e.ignore()
+            return
+        name = item.text()
+        self.show_dialog(name)
+        e.accept()
+
+    def _open_item_config_from_index(self, index):
+        if not index.isValid():
+            return
+        item = self.model().itemFromIndex(index)
+        if item is None:
+            return
+        name = item.text()
+        QTimer.singleShot(0, lambda name=name: self.show_dialog(name))
 
     def dragenterevent(self, event):
         if event.mimeData().hasText():
@@ -1298,6 +1351,28 @@ class OptionList(ListView):
             default_of_type = default_modulation_config()
         elif type == "Mel" and not default_of_type:
             default_of_type = default_mel_config()
+        if type == "SHRP" and not default_of_type:
+            default_of_type = default_sharpness_config()
+        if type == "ROUGH" and not default_of_type:
+            default_of_type = default_roughness_config()
+        if type == "PR" and not default_of_type:
+            default_of_type = default_pr_config()
+        if type == "SHRP":
+            default_of_type.setdefault("limit_checked", False)
+            default_of_type.setdefault("limit_metric", "curve_y")
+            default_of_type.setdefault("curve_limit_unit", "acum")
+            default_of_type.setdefault("curve_upper_enabled", False)
+            default_of_type.setdefault("curve_upper_value", 0.0)
+            default_of_type.setdefault("curve_lower_enabled", False)
+            default_of_type.setdefault("curve_lower_value", 0.0)
+        if type == "ROUGH":
+            default_of_type.setdefault("limit_checked", False)
+            default_of_type.setdefault("limit_metric", "curve_y")
+            default_of_type.setdefault("curve_limit_unit", "asper")
+            default_of_type.setdefault("curve_upper_enabled", False)
+            default_of_type.setdefault("curve_upper_value", 0.0)
+            default_of_type.setdefault("curve_lower_enabled", False)
+            default_of_type.setdefault("curve_lower_value", 0.0)
         self.config[0].analysis_list[list_item_text] = default_of_type
         self.config[0].analysis_list[list_item_text]["type"] = type
 

--- a/ui/sequence/sequence_widget.py
+++ b/ui/sequence/sequence_widget.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import os
 import re
@@ -81,7 +82,10 @@ class SequenceWindow(QWidget):
         self.toolsbar = SequenceToolsBar()
 
         self.v2pa_factor = None
-        self.analysis_types_requiring_v2pa = {"SPL", "SPLF", "HD", "RB", "PRB", "LP", "PD", "ED", "FBA"}
+        self.analysis_types_requiring_v2pa = {
+            "SPL", "SPLF", "HD", "RB", "PRB", "LP", "PD", "ED", "FBA",
+            "LOUD", "SHRP", "ROUGH", "PR",
+        }
         self.using_config_path, self.registry = self.get_sequence_config_from_registry()
         self.sequence_config = list()
         self.analysis_config = dict()
@@ -399,7 +403,7 @@ class SequenceWindow(QWidget):
             if t == "AI":
                 candidates.append(key)
                 continue
-            if t in ("SPL", "SPLF", "FR", "HD", "RB", "PRB"):
+            if t in ("SPL", "SPLF", "FR", "HD", "RB", "PRB", "LOUD", "SHRP", "ROUGH", "PR"):
                 if item_cfg.get("limit_checked"):
                     candidates.append(key)
 
@@ -1915,6 +1919,26 @@ class SequenceWindow(QWidget):
                     if not result:
                         continue
                     instance.show()
+                elif hasattr(instance, "calculate_pr"):
+                    result = instance.calculate_pr()
+                    if not result:
+                        continue
+                    instance.show()
+                elif hasattr(instance, "calculate_sharpness"):
+                    result = instance.calculate_sharpness()
+                    if not result:
+                        continue
+                    instance.show()
+                elif hasattr(instance, "calculate_roughness"):
+                    result = instance.calculate_roughness()
+                    if not result:
+                        continue
+                    instance.show()
+                elif hasattr(instance, "calculate_loudness"):
+                    result = instance.calculate_loudness()
+                    if not result:
+                        continue
+                    instance.show()
 
                 # Restore last geometry if available; otherwise fallback to default cascade
                 default_geo = {"x": width, "y": height, "w": window_width, "h": window_height}
@@ -2464,6 +2488,40 @@ class SequenceWindow(QWidget):
             f"{detail_text}",
         )
 
+    def _prepare_runtime_analysis_params(self, key, item_type, params):
+        runtime_params = copy.deepcopy(params) if isinstance(params, dict) else {}
+        if item_type == "SHRP":
+            upstream_loudness = self._resolve_sequence_loudness_config(
+                key,
+                loudness_type="LOUD",
+            )
+            if upstream_loudness:
+                runtime_params["upstream_loudness"] = upstream_loudness
+        return runtime_params
+
+    def _resolve_sequence_loudness_config(self, key, loudness_type="LOUD"):
+        cfg = self.analysis_config if isinstance(self.analysis_config, dict) else {}
+        display_sequence = list(cfg.get("display_sequence") or [])
+        try:
+            current_index = display_sequence.index(key)
+        except ValueError:
+            current_index = len(display_sequence)
+
+        ordered_keys = (
+            list(reversed(display_sequence[:current_index]))
+            + display_sequence[current_index + 1 :]
+            + [k for k in cfg.keys() if k != "display_sequence" and k not in display_sequence]
+        )
+
+        for item_key in ordered_keys:
+            item_cfg = cfg.get(item_key)
+            if isinstance(item_cfg, dict) and item_cfg.get("type") == loudness_type:
+                loud_cfg = copy.deepcopy(item_cfg)
+                loud_cfg.pop("type", None)
+                return loud_cfg
+
+        return {}
+
     def instance_analysis_class(self, key, type, params):
         """
         Instantiates and configures an analysis class based on the given type and parameters,
@@ -2479,12 +2537,13 @@ class SequenceWindow(QWidget):
         if type in class_mapping.keys():
             cls_map = class_mapping.get(type)
             if cls_map:
+                runtime_params = self._prepare_runtime_analysis_params(key, type, params)
                 if self.mode == "RECORD_ONLY":
                     mapped_channel = 0
                     raw_channel = 0
-                    if isinstance(params, dict):
+                    if isinstance(runtime_params, dict):
                         try:
-                            raw_channel = int(params.get("analysis_channel", 0) or 0)
+                            raw_channel = int(runtime_params.get("analysis_channel", 0) or 0)
                         except (TypeError, ValueError):
                             raw_channel = 0
                     if raw_channel < 0:
@@ -2518,13 +2577,14 @@ class SequenceWindow(QWidget):
                         except ValueError as err:
                             MessageBox.warning(self, "提示", str(err))
                             return
-                    runtime_params = dict(params) if isinstance(params, dict) else {}
                     runtime_params["analysis_channel"] = mapped_channel
                     # Inject sequence-level golden baseline path into per-item params
                     if isinstance(getattr(self, "analysis_config", None), dict):
                         golden_path = self.analysis_config.get("golden_sample_result_path")
                         if golden_path:
                             runtime_params["golden_sample_result_path"] = golden_path
+                    if hasattr(class_instance, "recorded_path"):
+                        class_instance.recorded_path = self.recorded_path
                     class_instance.analysis_config = runtime_params
                     self.analysis_window.append(class_instance)
                     return
@@ -2532,9 +2592,9 @@ class SequenceWindow(QWidget):
                 # Bind analysis key for geometry restore/persist
                 setattr(class_instance, "_sequence_analysis_key", key)
                 raw_channel = 0
-                if isinstance(params, dict):
+                if isinstance(runtime_params, dict):
                     try:
-                        raw_channel = int(params.get("analysis_channel", 0) or 0)
+                        raw_channel = int(runtime_params.get("analysis_channel", 0) or 0)
                     except (TypeError, ValueError):
                         raw_channel = 0
                 if raw_channel < 0:
@@ -2548,12 +2608,14 @@ class SequenceWindow(QWidget):
                     except ValueError as err:
                         MessageBox.warning(self, "提示", str(err))
                         return
+                if hasattr(class_instance, "recorded_path"):
+                    class_instance.recorded_path = self.recorded_path
                 # Inject sequence-level golden baseline path into per-item params
-                if isinstance(params, dict) and isinstance(getattr(self, "analysis_config", None), dict):
+                if isinstance(runtime_params, dict) and isinstance(getattr(self, "analysis_config", None), dict):
                     golden_path = self.analysis_config.get("golden_sample_result_path")
                     if golden_path:
-                        params["golden_sample_result_path"] = golden_path
-                class_instance.analysis_config = params
+                        runtime_params["golden_sample_result_path"] = golden_path
+                class_instance.analysis_config = runtime_params
                 self.analysis_window.append(class_instance)
 
     def eventFilter(self, obj, event):

--- a/ui/signal_analysis_window.py
+++ b/ui/signal_analysis_window.py
@@ -1,3 +1,4 @@
+import copy
 import csv
 import json
 import os
@@ -40,6 +41,11 @@ from base.core_algorithm.response.frequency_band_analyzer import (
 )
 from base.core_algorithm.mel_spectrogram import compute_mel_spectrogram, hz_to_mel
 from base.core_algorithm.modulation_map import compute_modulation_map
+from base.core_algorithm.response.prominence_ratio_analyzer import (
+    ProminenceRatioAnalyzer,
+    ProminenceRatioParams,
+)
+from base.core_algorithm.sound_quality import run_sound_quality
 from base.training_model_management import TrainingModelManagement
 from base.utils.smooth import smooth
 from base.utils.octave_smoothing import smooth_to_octave_grid
@@ -78,6 +84,10 @@ def get_class_mapping():
         "PM": PatternMatch,
         "ED": PipelinePdPm,
         "FBA": FrequencyBandAnalysis,
+        "PR": ProminenceRatioAnalysis,
+        "LOUD": LoudnessAnalysis,
+        "SHRP": SharpnessAnalysis,
+        "ROUGH": RoughnessAnalysis,
     }
     return class_mapping
 
@@ -121,6 +131,31 @@ def _load_golden_baseline_result(analysis_config: dict, title_name: str):
         return None
     result = item.get("result")
     return result if isinstance(result, dict) else None
+
+
+def _load_default_analysis_item_config(item_type: str) -> dict:
+    default_config_path = os.path.join(DEFAULT_DIR, "ui/ui_config/analysis_default_config.json")
+    try:
+        with open(default_config_path, "r", encoding="utf-8") as file:
+            defaults = json.load(file)
+    except Exception:
+        return {}
+    item_cfg = defaults.get(item_type, {})
+    return copy.deepcopy(item_cfg) if isinstance(item_cfg, dict) else {}
+
+
+def _merge_loudness_config_with_defaults(loud_cfg: dict) -> dict:
+    merged = _load_default_analysis_item_config("LOUD")
+    source = copy.deepcopy(loud_cfg) if isinstance(loud_cfg, dict) else {}
+    for section in ("display", "save", "advanced"):
+        section_defaults = dict(merged.get(section, {}) or {})
+        section_source = source.pop(section, {}) or {}
+        if isinstance(section_source, dict):
+            section_defaults.update(section_source)
+        merged[section] = section_defaults
+    merged.update(source)
+    merged.pop("type", None)
+    return merged
 
 
 def resolve_analysis_channel_signal(
@@ -400,6 +435,17 @@ class AnalysisGraphWidget(QWidget):
     def export_pdf_images(self, output_dir):
         image_path = export_plot_widget_image(self.analysis_plot, output_dir, "analysis_graph")
         return [{"title": self.windowTitle(), "path": image_path}]
+
+    @staticmethod
+    def apply_plot_font_style(plot_widget, font_size: int = 20):
+        font_size = ui_style_const.scale_size_px(font_size)
+        font = QFont()
+        font.setPixelSize(font_size)
+        for axis_name in ("bottom", "left"):
+            axis = plot_widget.getAxis(axis_name)
+            axis.setTickFont(font)
+            axis.setTextPen("black")
+            axis.setLabel(axis.labelText, **{"font-size": f"{font_size}px"})
 
 
 class Distortion(AnalysisGraphWidget):
@@ -3048,6 +3094,814 @@ class PipelinePdPm(QWidget):
         return self._summarize_and_notify(results, cfg.get("pass_condition", {}))
 
 
+class LoudnessAnalysis(AnalysisGraphWidget):
+    """LOUD analysis window backed by the sound-quality loudness service."""
+
+    def __init__(self, title_name):
+        super().__init__()
+        self.data_struct = DataDealStruct()
+        self.v2pa_factor = None
+        self.analysis_config = None
+        self.recorded_path = None
+        self.result = {}
+        self.export_detail = {}
+        self.specific_loudness_widget = None
+        self.specific_loudness_colorbar = None
+        self.specific_loudness_profile_widget = None
+        self.sharpness_plot = None
+        self.roughness_plot = None
+        self.title_name = title_name
+        self.setWindowTitle(title_name)
+
+    def calculate_loudness(self):
+        recorded_signal = self.data_struct.store_wave_data
+        sample_rate = self.data_struct.sample_rate
+        config = self.analysis_config or {}
+
+        if recorded_signal is None or sample_rate is None:
+            MessageBox.warning(self, "提示", "响度分析失败：没有可用录音数据。")
+            return False
+
+        sq_config = self._build_sq_config(config)
+        run_result = run_sound_quality(
+            np.asarray(recorded_signal, dtype=np.float64),
+            int(sample_rate),
+            project_v2pa_factor=float(self.v2pa_factor or 1.0),
+            sq_config=sq_config,
+        )
+        loud_result = run_result.loudness
+        if loud_result is None or not loud_result.enabled or loud_result.raw_result is None:
+            reason = getattr(loud_result, "skipped_reason", None) or run_result.skipped_reason or "unknown"
+            MessageBox.warning(self, "提示", f"响度分析跳过：{reason}")
+            return False
+
+        summary = loud_result.summary or {}
+        self._plot_loudness_curve(loud_result, config)
+        self._apply_loudness_limits(loud_result, config)
+
+        raw = loud_result.raw_result
+        self.result = {
+            "summary": summary,
+            "time_s": np.asarray(raw.time_s, dtype=np.float64).tolist(),
+            "loudness_sone": np.asarray(raw.loudness_sone, dtype=np.float64).tolist(),
+            "loudness_level_phon": np.asarray(raw.loudness_level_phon, dtype=np.float64).tolist(),
+            "metadata": dict(raw.metadata or {}),
+        }
+        self.export_detail = {
+            "specific_loudness_sum_sone": summary.get("specific_loudness_sum_sone"),
+            "specific_loudness_summed_exceedance": summary.get("specific_loudness_summed_exceedance"),
+            "steady_state_average_sone": summary.get("steady_state_average_sone"),
+            "steady_state_average_phon": summary.get("steady_state_average_phon"),
+            "max_transient_sone": summary.get("max_transient_sone"),
+            "max_transient_phon": summary.get("max_transient_phon"),
+            "nmax_sone": summary.get("nmax_sone"),
+            "n5_sone": summary.get("n5_sone"),
+            "lnmax_phon": summary.get("lnmax_phon"),
+            "ln5_phon": summary.get("ln5_phon"),
+            "mean_sone": summary.get("mean_sone"),
+            "mean_phon": summary.get("mean_phon"),
+        }
+        return self.result
+
+    @staticmethod
+    def _build_sq_config(config: dict) -> dict:
+        display_cfg = config.get("display", {}) or {}
+        save_cfg = config.get("save", {}) or {}
+        advanced_cfg = config.get("advanced", {}) or {}
+        return {
+            "enabled": True,
+            "shared": {"field_type": config.get("field_type", "free")},
+            "items": {
+                "LOUD": {
+                    "enabled": bool(config.get("enabled", True)),
+                    "method": config.get("method", "per_segment"),
+                    "display": display_cfg,
+                    "save": save_cfg,
+                    "advanced": advanced_cfg,
+                },
+                "SHRP": {"enabled": False},
+                "ROUGH": {"enabled": False},
+                "FLUC": {"enabled": False},
+                "TON": {"enabled": False},
+                "PR": {"enabled": False},
+                "TNR": {"enabled": False},
+            },
+        }
+
+    def _plot_loudness_curve(self, loud_result, config=None):
+        raw = loud_result.raw_result
+        time_s = np.asarray(raw.time_s, dtype=np.float64)
+        advanced_cfg = (config or {}).get("advanced", {}) or {}
+        curve_y_unit = str(advanced_cfg.get("curve_y_unit", "sone") or "sone").lower()
+        if curve_y_unit == "phon":
+            loudness = np.asarray(raw.loudness_level_phon, dtype=np.float64)
+            y_label = "响度级 (phon)"
+        else:
+            loudness = np.asarray(raw.loudness_sone, dtype=np.float64)
+            y_label = "响度 (sone)"
+
+        plot_time_s = time_s
+        plot_loudness = loudness
+        method = str((config or {}).get("method", "") or "").lower()
+        metadata = dict(getattr(raw, "metadata", None) or {})
+        if (
+            method == "per_segment"
+            and time_s.size
+            and loudness.size
+            and np.isfinite(time_s[0])
+            and np.isfinite(loudness[0])
+            and time_s[0] > 0.0
+        ):
+            if time_s.size > 1 and loudness.size > 1 and np.isfinite(loudness[1]):
+                plot_time_s = np.insert(time_s[1:], 0, 0.0)
+                plot_loudness = np.insert(loudness[1:], 0, loudness[1])
+            else:
+                plot_time_s = np.insert(time_s, 0, 0.0)
+                plot_loudness = np.insert(loudness, 0, loudness[0])
+            end_time_s = None
+            sample_rate = getattr(self.data_struct, "sample_rate", None)
+            recorded_signal = getattr(self.data_struct, "store_wave_data", None)
+            try:
+                if sample_rate and recorded_signal is not None:
+                    end_time_s = len(recorded_signal) / float(sample_rate)
+            except (TypeError, ValueError, ZeroDivisionError):
+                end_time_s = None
+            if end_time_s is None:
+                try:
+                    frame_duration_s = float(metadata.get("frame_duration_s"))
+                    end_time_s = float(time_s[-1]) + frame_duration_s / 2.0
+                except (TypeError, ValueError):
+                    end_time_s = None
+            if (
+                end_time_s is not None
+                and np.isfinite(end_time_s)
+                and plot_time_s.size
+                and end_time_s > float(plot_time_s[-1])
+            ):
+                plot_time_s = np.append(plot_time_s, float(end_time_s))
+                plot_loudness = np.append(plot_loudness, float(plot_loudness[-1]))
+
+        self.analysis_plot.clear()
+        if plot_time_s.size and plot_loudness.size:
+            self.analysis_plot.plot(
+                plot_time_s,
+                plot_loudness,
+                pen=mkPen(color=(51, 196, 77), width=2),
+                name="Loudness",
+            )
+            self._apply_loudness_y_axis(loudness, advanced_cfg, curve_y_unit)
+        self.analysis_plot.setLabel("left", y_label)
+        self.analysis_plot.setLabel("bottom", "时间 (s)")
+        self.analysis_plot.showGrid(x=True, y=True)
+
+        payload = loud_result.display_payload or {}
+        title_parts = []
+        for card in payload.get("summary_cards", []) or []:
+            # The summed exceedance is shown on the N'(z) profile plot (in cSones),
+            # so keep it off the loudness-time curve title to avoid duplication.
+            if card.get("key") == "specific_loudness_summed_exceedance":
+                continue
+            value = card.get("value")
+            try:
+                finite_value = value is not None and np.isfinite(float(value))
+            except (TypeError, ValueError):
+                finite_value = False
+            if finite_value:
+                title_parts.append(f"{card.get('label', card.get('key'))}: {float(value):.3g} {card.get('unit', '')}")
+        if title_parts:
+            self.analysis_plot.setTitle(" | ".join(title_parts), size="14px", color="k")
+
+        if config:
+            self._draw_loudness_limit_lines(self.analysis_plot, config)
+
+        self._plot_specific_loudness_profile(loud_result, config or {})
+        self._plot_specific_loudness_heatmap(loud_result, config or {})
+
+    def _apply_loudness_y_axis(self, loudness: np.ndarray, advanced_cfg: dict, curve_y_unit: str):
+        finite = np.asarray(loudness, dtype=np.float64)
+        finite = finite[np.isfinite(finite)]
+        if finite.size == 0:
+            return
+        y_max = float(np.max(finite))
+        if y_max <= 0.0:
+            return
+        unit = str(curve_y_unit or "sone").lower()
+        min_y_range = max(5.0, y_max * 0.08) if unit == "phon" else max(2.0, y_max * 0.12)
+        self.analysis_plot.getViewBox().setLimits(minYRange=min_y_range)
+        if not bool(advanced_cfg.get("curve_y_axis_zero_based", True)):
+            return
+        upper = y_max * 1.03
+        if upper <= y_max:
+            upper = y_max + 1.0
+        self.analysis_plot.getViewBox().setYRange(0.0, upper, padding=0.0)
+
+    def _apply_sharpness_y_axis(self, plot_widget, sharpness: np.ndarray):
+        finite = np.asarray(sharpness, dtype=np.float64)
+        finite = finite[np.isfinite(finite)]
+        if finite.size == 0:
+            return
+        y_max = float(np.max(finite))
+        upper = max(2.0, y_max * 1.3)
+        view_box = plot_widget.getViewBox()
+        view_box.setYRange(0.0, upper, padding=0.0)
+
+    def _apply_roughness_y_axis(self, plot_widget, roughness: np.ndarray):
+        finite = np.asarray(roughness, dtype=np.float64)
+        finite = finite[np.isfinite(finite)]
+        if finite.size == 0:
+            return
+        y_max = float(np.max(finite))
+        upper = max(0.5, y_max * 1.3)
+        view_box = plot_widget.getViewBox()
+        view_box.setYRange(0.0, upper, padding=0.0)
+
+    def _plot_specific_loudness_profile(self, loud_result, config=None):
+        self._remove_specific_loudness_profile()
+
+        curves = (loud_result.display_payload or {}).get("curves", []) or []
+        curve = next((item for item in curves if item.get("key") == "specific_loudness_profile"), None)
+        if not curve:
+            return
+
+        bark_axis = np.asarray(curve.get("x"), dtype=np.float64)
+        profile = np.asarray(curve.get("y"), dtype=np.float64)
+        if bark_axis.size == 0 or profile.size == 0:
+            return
+
+        plot_widget = pg.PlotWidget(background="white")
+        legend = plot_widget.addLegend(offset=(-10, 10))
+        legend.setParentItem(plot_widget.getPlotItem().getViewBox())
+        legend.anchor(itemPos=(1, 0), parentPos=(1, 0), offset=(-10, 10))
+        plot_widget.plot(
+            bark_axis,
+            profile,
+            pen=mkPen(color=(238, 126, 33), width=2),
+            name="N'(z) measured",
+        )
+        ref_curve = self._draw_specific_loudness_ref_line(plot_widget, bark_axis, profile, config or {})
+        mode = str(curve.get("profile_mode", "steady_average") or "steady_average")
+        title = "特征响度曲线 N'(z)"
+        if mode == "max_loudness":
+            title += " - 最大响度时刻"
+        else:
+            title += " - 稳态平均"
+        exceedance_csones = self._specific_loudness_exceedance_csones(loud_result)
+        if exceedance_csones is not None:
+            title += f"  |  超限总量: {exceedance_csones:.2f} cSones"
+        plot_widget.setTitle(title, size="14px", color="k")
+        plot_widget.setLabel("left", "N' (sone/Bark)")
+        plot_widget.setLabel("bottom", "Bark")
+        self.apply_plot_font_style(plot_widget, 20)
+        plot_widget.showGrid(x=True, y=True)
+        finite = profile[np.isfinite(profile)]
+        candidates = [float(np.max(finite))] if finite.size else []
+        if ref_curve is not None and ref_curve.size:
+            ref_finite = ref_curve[np.isfinite(ref_curve)]
+            if ref_finite.size:
+                candidates.append(float(np.max(ref_finite)))
+        if candidates:
+            y_max = max(candidates)
+            plot_widget.getViewBox().setYRange(0.0, max(0.1, y_max * 1.15), padding=0.0)
+        self.specific_loudness_profile_widget = plot_widget
+        self.layout().addWidget(plot_widget)
+
+    @staticmethod
+    def _specific_loudness_exceedance_csones(loud_result):
+        """Return the summed specific-loudness exceedance in cSones (0.01 sone), or None.
+
+        The value is computed by the service layer in sone; centi-sones makes the
+        small exceedance numbers easier to read on the plot title.
+        """
+        payload = loud_result.display_payload or {}
+        for card in payload.get("summary_cards", []) or []:
+            if card.get("key") != "specific_loudness_summed_exceedance":
+                continue
+            value = card.get("value")
+            try:
+                value_sone = float(value)
+            except (TypeError, ValueError):
+                return None
+            if not np.isfinite(value_sone):
+                return None
+            return value_sone * 100.0
+        return None
+
+    @staticmethod
+    def _draw_specific_loudness_ref_line(plot_widget, bark_axis, profile, config):
+        advanced_cfg = (config or {}).get("advanced", {}) or {}
+        ref_key = str(advanced_cfg.get("specific_loudness_exceedance_ref_line", "") or "").lower()
+        try:
+            from base.core_algorithm.sound_quality.psychoacoustic_constants import (
+                SSTS_SPECIFIC_LOUDNESS_REF_LINES,
+            )
+            from base.core_algorithm.sound_quality.service import _interpolate_ref_line
+        except ImportError:
+            return None
+        if ref_key not in SSTS_SPECIFIC_LOUDNESS_REF_LINES:
+            return None
+        ref_curve = _interpolate_ref_line(bark_axis, SSTS_SPECIFIC_LOUDNESS_REF_LINES[ref_key])
+        ref_label = f"Ref {ref_key[-1]} limit"
+        plot_widget.plot(
+            bark_axis,
+            ref_curve,
+            pen=mkPen(color=(214, 39, 40), width=2, style=Qt.DashLine),
+            name=ref_label,
+        )
+        excess = np.maximum(profile - ref_curve, 0.0)
+        if np.any(excess > 0.0):
+            fill_top = pg.PlotDataItem(bark_axis, np.maximum(profile, ref_curve))
+            fill_bottom = pg.PlotDataItem(bark_axis, ref_curve)
+            fill = pg.FillBetweenItem(fill_top, fill_bottom, brush=(214, 39, 40, 70))
+            plot_widget.addItem(fill)
+        return ref_curve
+
+    def _remove_specific_loudness_profile(self):
+        if self.specific_loudness_profile_widget is None:
+            return
+        try:
+            self.layout().removeWidget(self.specific_loudness_profile_widget)
+            self.specific_loudness_profile_widget.deleteLater()
+        finally:
+            self.specific_loudness_profile_widget = None
+
+    def _plot_specific_loudness_heatmap(self, loud_result, config: dict):
+        self._remove_specific_loudness_heatmap()
+
+        heatmaps = (loud_result.display_payload or {}).get("heatmaps", []) or []
+        heatmap = next((item for item in heatmaps if item.get("key") == "specific_loudness"), None)
+        if not heatmap:
+            return
+
+        time_s = np.asarray(heatmap.get("x"), dtype=np.float64)
+        bark_axis = np.asarray(heatmap.get("y"), dtype=np.float64)
+        specific = np.asarray(heatmap.get("z"), dtype=np.float64)
+        if time_s.size < 2 or bark_axis.size < 2 or specific.size == 0:
+            return
+
+        advanced_cfg = config.get("advanced", {}) or {}
+        colormap = str(advanced_cfg.get("specific_loudness_colormap", "viridis") or "viridis")
+        z = specific.T if specific.shape[0] == bark_axis.size else specific
+        self.specific_loudness_widget, self.specific_loudness_colorbar = plot_2d_image(
+            x=time_s,
+            y=bark_axis,
+            z=z,
+            title="特征响度 N'(z, t) [sone/Bark]",
+            xlabel="时间 (s)",
+            ylabel="Bark",
+            colormap=colormap,
+            x_range=(float(time_s.min()), float(time_s.max())),
+            y_range=(float(bark_axis.min()), float(bark_axis.max())),
+            background_color="white",
+        )
+        heatmap_plot = self.specific_loudness_widget.findChild(pg.PlotWidget)
+        if heatmap_plot is not None:
+            heatmap_plot.setTitle("特征响度 N'(z, t) [sone/Bark]", size="14px", color="k")
+            self.apply_plot_font_style(heatmap_plot, 20)
+        self.layout().addWidget(self.specific_loudness_widget)
+
+    def _remove_specific_loudness_heatmap(self):
+        if self.specific_loudness_widget is None:
+            return
+        try:
+            self.layout().removeWidget(self.specific_loudness_widget)
+            self.specific_loudness_widget.deleteLater()
+        finally:
+            self.specific_loudness_widget = None
+            self.specific_loudness_colorbar = None
+
+    def _apply_loudness_limits(self, loud_result, config: dict):
+        if not bool(config.get("limit_checked", False)):
+            return
+
+        raw = getattr(loud_result, "raw_result", None)
+        if raw is None:
+            self.data_struct.analysis_result_dict[self.title_name] = (False, float("nan"))
+            return
+
+        advanced_cfg = (config or {}).get("advanced", {}) or {}
+        limit_metric = str(config.get("limit_metric", "curve_y") or "curve_y").lower()
+
+        if limit_metric == "steady_state_average":
+            self._apply_loudness_scalar_limit(loud_result, config, metric="steady_state_average")
+        elif limit_metric == "max_transient":
+            self._apply_loudness_scalar_limit(loud_result, config, metric="max_transient")
+        elif limit_metric == "specific_loudness_summed_exceedance":
+            self._apply_loudness_scalar_limit(loud_result, config, metric="specific_loudness_summed_exceedance")
+        else:
+            self._apply_loudness_curve_limit(raw, config, advanced_cfg)
+
+    def _apply_loudness_scalar_limit(self, loud_result, config: dict, metric: str):
+        """Apply limit check on a single scalar metric value."""
+        summary = getattr(loud_result, "summary", None) or {}
+        if metric == "steady_state_average":
+            value = summary.get("steady_state_average_sone",
+                    summary.get("steady_state_average_phon",
+                    summary.get("mean_sone", summary.get("mean_phon"))))
+        elif metric == "max_transient":
+            value = summary.get("max_transient_sone",
+                    summary.get("max_transient_phon",
+                    summary.get("nmax_sone")))
+        elif metric == "specific_loudness_summed_exceedance":
+            value = summary.get("specific_loudness_summed_exceedance")
+        else:
+            value = None
+
+        if value is None or not np.isfinite(float(value)):
+            self.data_struct.analysis_result_dict[self.title_name] = (False, float("nan"))
+            return
+
+        value = float(value)
+        upper_enabled = bool(config.get("curve_upper_enabled", False))
+        upper_limit = float(config.get("curve_upper_value", 0.0) or 0.0)
+        lower_enabled = bool(config.get("curve_lower_enabled", False))
+        lower_limit = float(config.get("curve_lower_value", 0.0) or 0.0)
+
+        deviations = []
+        if upper_enabled and value > upper_limit:
+            deviations.append(value - upper_limit)
+        if lower_enabled and value < lower_limit:
+            deviations.append(lower_limit - value)
+
+        deviation = float(max(deviations)) if deviations else 0.0
+        self._merge_analysis_limit_result(deviation == 0.0, deviation)
+
+    def _apply_loudness_curve_limit(self, raw, config: dict, advanced_cfg: dict):
+        """Apply per-point limit check on the loudness time curve."""
+        curve_y_unit = str(advanced_cfg.get("curve_y_unit", config.get("curve_limit_unit", "sone")) or "sone").lower()
+        if curve_y_unit == "phon":
+            values = np.asarray(raw.loudness_level_phon, dtype=np.float64)
+        else:
+            values = np.asarray(raw.loudness_sone, dtype=np.float64)
+        values = values[np.isfinite(values)]
+        if values.size == 0:
+            self.data_struct.analysis_result_dict[self.title_name] = (False, float("nan"))
+            return
+
+        upper_enabled = bool(
+            config.get(
+                "curve_upper_enabled",
+                config.get("mean_upper_enabled", config.get("nmax_upper_enabled", False)),
+            )
+        )
+        upper_limit = float(
+            config.get(
+                "curve_upper_value",
+                config.get("mean_upper_sone", config.get("nmax_upper_sone", 0.0)),
+            )
+            or 0.0
+        )
+        lower_enabled = bool(
+            config.get(
+                "curve_lower_enabled",
+                config.get("mean_lower_enabled", config.get("nmax_lower_enabled", False)),
+            )
+        )
+        lower_limit = float(
+            config.get(
+                "curve_lower_value",
+                config.get("mean_lower_sone", config.get("nmax_lower_sone", 0.0)),
+            )
+            or 0.0
+        )
+
+        deviations = []
+        if upper_enabled:
+            upper_deviation = float(np.max(values - upper_limit))
+            if upper_deviation > 0.0:
+                deviations.append(upper_deviation)
+        if lower_enabled:
+            lower_deviation = float(np.max(lower_limit - values))
+            if lower_deviation > 0.0:
+                deviations.append(lower_deviation)
+
+        deviation = float(max(deviations)) if deviations else 0.0
+        self._merge_analysis_limit_result(deviation == 0.0, deviation)
+
+    def _apply_curve_limits(self, values: np.ndarray, config: dict):
+        if not bool(config.get("limit_checked", False)):
+            return
+
+        finite = np.asarray(values, dtype=np.float64)
+        finite = finite[np.isfinite(finite)]
+        if finite.size == 0:
+            self._merge_analysis_limit_result(False, float("nan"))
+            return
+
+        upper_enabled = bool(config.get("curve_upper_enabled", False))
+        upper_limit = float(config.get("curve_upper_value", 0.0) or 0.0)
+        lower_enabled = bool(config.get("curve_lower_enabled", False))
+        lower_limit = float(config.get("curve_lower_value", 0.0) or 0.0)
+
+        deviations = []
+        if upper_enabled:
+            upper_deviation = float(np.max(finite - upper_limit))
+            if upper_deviation > 0.0:
+                deviations.append(upper_deviation)
+        if lower_enabled:
+            lower_deviation = float(np.max(lower_limit - finite))
+            if lower_deviation > 0.0:
+                deviations.append(lower_deviation)
+
+        deviation = float(max(deviations)) if deviations else 0.0
+        self._merge_analysis_limit_result(deviation == 0.0, deviation)
+
+    @staticmethod
+    def _draw_limit_lines(plot_widget, config: dict, x_range=None):
+        """Draw horizontal limit lines on a plot if configured."""
+        if not bool(config.get("limit_checked", False)):
+            return
+        upper_enabled = bool(config.get("curve_upper_enabled", False))
+        lower_enabled = bool(config.get("curve_lower_enabled", False))
+        dashed_pen = mkPen(color=(128, 0, 128), width=2, style=Qt.DashLine)
+        if upper_enabled:
+            val = float(config.get("curve_upper_value", 0.0) or 0.0)
+            plot_widget.addLine(y=val, pen=dashed_pen)
+        if lower_enabled:
+            val = float(config.get("curve_lower_value", 0.0) or 0.0)
+            plot_widget.addLine(y=val, pen=dashed_pen)
+
+    @staticmethod
+    def _draw_loudness_limit_lines(plot_widget, config: dict):
+        """Draw horizontal limit lines for loudness plot."""
+        if not bool(config.get("limit_checked", False)):
+            return
+        upper_enabled = bool(
+            config.get("curve_upper_enabled",
+                        config.get("mean_upper_enabled", config.get("nmax_upper_enabled", False)))
+        )
+        lower_enabled = bool(
+            config.get("curve_lower_enabled",
+                        config.get("mean_lower_enabled", config.get("nmax_lower_enabled", False)))
+        )
+        dashed_pen = mkPen(color=(128, 0, 128), width=2, style=Qt.DashLine)
+        if upper_enabled:
+            val = float(
+                config.get("curve_upper_value",
+                            config.get("mean_upper_sone", config.get("nmax_upper_sone", 0.0))) or 0.0
+            )
+            plot_widget.addLine(y=val, pen=dashed_pen)
+        if lower_enabled:
+            val = float(
+                config.get("curve_lower_value",
+                            config.get("mean_lower_sone", config.get("nmax_lower_sone", 0.0))) or 0.0
+            )
+            plot_widget.addLine(y=val, pen=dashed_pen)
+
+    def _merge_analysis_limit_result(self, is_ok: bool, deviation: float):
+        existing = self.data_struct.analysis_result_dict.get(self.title_name)
+        if not isinstance(existing, (tuple, list)) or len(existing) < 2:
+            self.data_struct.analysis_result_dict[self.title_name] = (bool(is_ok), float(deviation))
+            return
+
+        existing_ok = bool(existing[0])
+        try:
+            existing_deviation = float(existing[1])
+        except (TypeError, ValueError):
+            existing_deviation = float("nan")
+
+        if np.isfinite(existing_deviation) and np.isfinite(float(deviation)):
+            merged_deviation = max(existing_deviation, float(deviation))
+        elif np.isfinite(existing_deviation):
+            merged_deviation = existing_deviation
+        else:
+            merged_deviation = float(deviation)
+        self.data_struct.analysis_result_dict[self.title_name] = (existing_ok and bool(is_ok), merged_deviation)
+
+
+class RoughnessAnalysis(LoudnessAnalysis):
+    """Standalone ROUGH analysis backed by Daniel-Weber / Aures roughness."""
+
+    def calculate_roughness(self):
+        recorded_signal = self.data_struct.store_wave_data
+        sample_rate = self.data_struct.sample_rate
+        config = self.analysis_config or {}
+
+        if recorded_signal is None or sample_rate is None:
+            MessageBox.warning(self, "提示", "粗糙度分析失败：没有可用录音数据。")
+            return False
+
+        sq_config = self._build_sq_config(config)
+        run_result = run_sound_quality(
+            np.asarray(recorded_signal, dtype=np.float64),
+            int(sample_rate),
+            project_v2pa_factor=float(self.v2pa_factor or 1.0),
+            sq_config=sq_config,
+        )
+
+        roughness_result = run_result.roughness
+        if roughness_result is None or not roughness_result.enabled or roughness_result.raw_result is None:
+            reason = getattr(roughness_result, "skipped_reason", None) or run_result.skipped_reason or "unknown"
+            MessageBox.warning(self, "提示", f"粗糙度分析跳过：{reason}")
+            return False
+
+        self._plot_roughness_curve(roughness_result, config)
+        self._apply_curve_limits(roughness_result.raw_result.roughness_asper, config)
+
+        raw = roughness_result.raw_result
+        summary = roughness_result.summary or {}
+        self.result = {
+            "summary": summary,
+            "time_s": np.asarray(raw.time_s, dtype=np.float64).tolist(),
+            "roughness_asper": np.asarray(raw.roughness_asper, dtype=np.float64).tolist(),
+            "bark_axis": np.asarray(raw.bark_axis, dtype=np.float64).tolist(),
+            "metadata": dict(raw.metadata or {}),
+        }
+        self.export_detail = {
+            "rmean_asper": summary.get("r_mean_asper"),
+        }
+        return self.result
+
+    @staticmethod
+    def _build_sq_config(config: dict) -> dict:
+        display_cfg = config.get("display", {}) or {}
+        save_cfg = config.get("save", {}) or {}
+        advanced_cfg = config.get("advanced", {}) or {}
+        return {
+            "enabled": True,
+            "shared": {"field_type": "free"},
+            "items": {
+                "LOUD": {"enabled": False},
+                "SHRP": {"enabled": False},
+                "ROUGH": {
+                    "enabled": bool(config.get("enabled", True)),
+                    "display": display_cfg,
+                    "save": save_cfg,
+                    "advanced": advanced_cfg,
+                },
+                "FLUC": {"enabled": False},
+                "TON": {"enabled": False},
+                "PR": {"enabled": False},
+                "TNR": {"enabled": False},
+            },
+        }
+
+    def _plot_roughness_curve(self, roughness_result, config=None):
+        payload = roughness_result.display_payload or {}
+        curves = payload.get("curves", []) or []
+        curve = next((item for item in curves if item.get("key") == "roughness_time"), None)
+
+        self.analysis_plot.clear()
+        if curve:
+            time_s = np.asarray(curve.get("x"), dtype=np.float64)
+            roughness = np.asarray(curve.get("y"), dtype=np.float64)
+            if time_s.size and roughness.size:
+                self.analysis_plot.plot(
+                    time_s,
+                    roughness,
+                    pen=mkPen(color=(105, 85, 190), width=2),
+                    name="Roughness",
+                    connect="finite",
+                )
+                self._apply_roughness_y_axis(self.analysis_plot, roughness)
+
+        self.analysis_plot.setLabel("left", "Roughness R (asper)")
+        self.analysis_plot.setLabel("bottom", "Time (s)")
+        self.analysis_plot.showGrid(x=True, y=True)
+
+        if config:
+            self._draw_limit_lines(self.analysis_plot, config)
+
+        title_parts = []
+        for card in payload.get("summary_cards", []) or []:
+            value = card.get("value")
+            try:
+                finite_value = value is not None and np.isfinite(float(value))
+            except (TypeError, ValueError):
+                finite_value = False
+            if finite_value:
+                title_parts.append(f"{card.get('label', card.get('key'))}: {float(value):.3g} {card.get('unit', '')}")
+        if title_parts:
+            self.analysis_plot.setTitle(" | ".join(title_parts), size="14px", color="k")
+
+
+class SharpnessAnalysis(LoudnessAnalysis):
+    """Standalone SHRP analysis backed by DIN 45692 sharpness."""
+
+    def calculate_sharpness(self):
+        recorded_signal = self.data_struct.store_wave_data
+        sample_rate = self.data_struct.sample_rate
+        config = self.analysis_config or {}
+
+        if recorded_signal is None or sample_rate is None:
+            MessageBox.warning(self, "提示", "尖锐度分析失败：没有可用录音数据。")
+            return False
+
+        sq_config = self._build_sq_config(config)
+        run_result = run_sound_quality(
+            np.asarray(recorded_signal, dtype=np.float64),
+            int(sample_rate),
+            project_v2pa_factor=float(self.v2pa_factor or 1.0),
+            sq_config=sq_config,
+        )
+
+        sharpness_result = run_result.sharpness
+        if sharpness_result is None or not sharpness_result.enabled or sharpness_result.raw_result is None:
+            reason = getattr(sharpness_result, "skipped_reason", None) or run_result.skipped_reason or "unknown"
+            MessageBox.warning(self, "提示", f"尖锐度分析跳过：{reason}")
+            return False
+
+        self._plot_sharpness_curve(sharpness_result, config)
+        self._apply_curve_limits(sharpness_result.raw_result.sharpness_acum, config)
+
+        raw = sharpness_result.raw_result
+        summary = sharpness_result.summary or {}
+        self.result = {
+            "summary": summary,
+            "time_s": np.asarray(raw.time_s, dtype=np.float64).tolist(),
+            "sharpness_acum": np.asarray(raw.sharpness_acum, dtype=np.float64).tolist(),
+            "metadata": dict(raw.metadata or {}),
+        }
+        self.export_detail = {
+            "smean_acum": summary.get("s_mean_acum"),
+            "sstationary_acum": summary.get("s_stationary_acum"),
+        }
+        return self.result
+
+    @staticmethod
+    def _build_sq_config(config: dict) -> dict:
+        display_cfg = config.get("display", {}) or {}
+        save_cfg = config.get("save", {}) or {}
+        advanced_cfg = config.get("advanced", {}) or {}
+
+        loud_cfg = _merge_loudness_config_with_defaults(
+            config.get("upstream_loudness", {}) or config.get("loudness", {}) or {}
+        )
+        loud_display = dict(loud_cfg.get("display", {}) or {})
+        loud_display.setdefault("summary_metrics", [])
+        loud_display.setdefault("curves", [])
+        loud_display.setdefault("heatmaps", [])
+
+        loud_save = dict(loud_cfg.get("save", {}) or {})
+        loud_save.setdefault("summary", False)
+        loud_save.setdefault("curve", False)
+        loud_save.setdefault("specific_loudness", False)
+
+        loud_advanced = dict(loud_cfg.get("advanced", {}) or {})
+
+        return {
+            "enabled": True,
+            "shared": {"field_type": "free"},
+            "items": {
+                "LOUD": {
+                    "enabled": True,
+                    "method": loud_cfg.get("method", config.get("loudness_method", "per_segment")),
+                    "display": loud_display,
+                    "save": loud_save,
+                    "advanced": loud_advanced,
+                },
+                "SHRP": {
+                    "enabled": bool(config.get("enabled", True)),
+                    "display": display_cfg,
+                    "save": save_cfg,
+                    "advanced": advanced_cfg,
+                },
+                "ROUGH": {"enabled": False},
+                "FLUC": {"enabled": False},
+                "TON": {"enabled": False},
+                "PR": {"enabled": False},
+                "TNR": {"enabled": False},
+            },
+        }
+
+    def _plot_sharpness_curve(self, sharpness_result, config=None):
+        payload = sharpness_result.display_payload or {}
+        curves = payload.get("curves", []) or []
+        curve = next((item for item in curves if item.get("key") == "sharpness_time"), None)
+
+        self.analysis_plot.clear()
+        if curve:
+            time_s = np.asarray(curve.get("x"), dtype=np.float64)
+            sharpness = np.asarray(curve.get("y"), dtype=np.float64)
+            if time_s.size and sharpness.size:
+                self.analysis_plot.plot(
+                    time_s,
+                    sharpness,
+                    pen=mkPen(color=(225, 122, 39), width=2),
+                    name="Sharpness",
+                    connect="finite",
+                )
+                self._apply_sharpness_y_axis(self.analysis_plot, sharpness)
+
+        self.analysis_plot.setLabel("left", "Sharpness S (acum)")
+        self.analysis_plot.setLabel("bottom", "Time (s)")
+        self.analysis_plot.showGrid(x=True, y=True)
+
+        if config:
+            self._draw_limit_lines(self.analysis_plot, config)
+
+        title_parts = []
+        for card in payload.get("summary_cards", []) or []:
+            value = card.get("value")
+            try:
+                finite_value = value is not None and np.isfinite(float(value))
+            except (TypeError, ValueError):
+                finite_value = False
+            if finite_value:
+                title_parts.append(f"{card.get('label', card.get('key'))}: {float(value):.3g} {card.get('unit', '')}")
+        if title_parts:
+            self.analysis_plot.setTitle(" | ".join(title_parts), size="14px", color="k")
+
+
 class FrequencyBandAnalysis(AnalysisGraphWidget):
     """
     频段能量分析 (Frequency Band Analysis) 窗口。
@@ -3333,6 +4187,451 @@ class FrequencyBandAnalysis(AnalysisGraphWidget):
         self.analysis_plot.setTitle(f"Overall: {overall:.1f} {weight_label} [SPL]", size="14px", color="k")
 
         self.analysis_plot.showGrid(x=False, y=True)
+
+
+def _decimate_peak_envelope(x: np.ndarray, y: np.ndarray, max_points: int):
+    """峰值包络降采样：把密集曲线压到约 max_points 点，保留每段的最小/最大值。
+
+    频谱有数万点时 pyqtgraph 宽线渲染很慢；普通抽稀会丢掉窄带峰，这里按桶取
+    min/max 两点并按 x 顺序排列，视觉上峰谷与原曲线一致。
+    """
+    x = np.asarray(x, dtype=float)
+    y = np.asarray(y, dtype=float)
+    n = x.size
+    if max_points <= 0 or n <= max_points:
+        return x, y
+    buckets = max(1, max_points // 2)
+    step = n // buckets
+    if step < 2:
+        return x, y
+    usable = step * buckets
+    xr = x[:usable].reshape(buckets, step)
+    yr = y[:usable].reshape(buckets, step)
+    cols = np.arange(buckets)
+    imin = yr.argmin(axis=1)
+    imax = yr.argmax(axis=1)
+    first_is_min = imin <= imax
+    out_x = np.empty(buckets * 2, dtype=float)
+    out_y = np.empty(buckets * 2, dtype=float)
+    out_x[0::2] = np.where(first_is_min, xr[cols, imin], xr[cols, imax])
+    out_y[0::2] = np.where(first_is_min, yr[cols, imin], yr[cols, imax])
+    out_x[1::2] = np.where(first_is_min, xr[cols, imax], xr[cols, imin])
+    out_y[1::2] = np.where(first_is_min, yr[cols, imax], yr[cols, imin])
+    if usable < n:
+        out_x = np.concatenate([out_x, x[usable:]])
+        out_y = np.concatenate([out_y, y[usable:]])
+    return out_x, out_y
+
+
+class ProminenceRatioAnalysis(AnalysisGraphWidget):
+    """突出比 (PR / Prominence Ratio) 分析窗口（双轨图）。
+
+    需求书《笔记本电脑风扇噪音核心测试要求书》PR 频谱模块：
+    - 标题沿用“线性功率谱 + PR 值分布曲线”；上轨按需求纵轴定义绘制临界频带功率 dB。
+    - 下轨：PR 值分布曲线 dB；横轴 Frequency (kHz)。
+    - 默认计算口径：ECMA-74 Annex D / ECMA-418-1 标准临界带 + 线性(Z)/不计权功率。
+      15% 固定比例仅按需求书作为图面划分线显示，不参与默认 PR 功率积分。
+    - 图面按需求书展示名称标注，不显示 mode/df/FFT/weighting 等内部调试参数。
+    """
+
+    def __init__(self, title_name):
+        super().__init__()
+        self.data_struct = DataDealStruct()
+        self.v2pa_factor = None
+        self.analysis_config = None
+        self.result = {}
+        self.export_detail = {}
+        self.title_name = title_name
+        self.setWindowTitle(title_name)
+
+        # 下轨 PR 曲线（上轨复用基类 self.analysis_plot 作为临界带功率谱）
+        self.pr_plot = pg.PlotWidget()
+        self.pr_plot.setBackground("white")
+        self.apply_plot_font_style(self.pr_plot, 20)
+        self.layout().addWidget(self.pr_plot)
+        # 双轨共用同一频率横轴：与下轨联动，并隐藏上轨重复的 X 刻度，仅下轨保留一条频率轴
+        self.analysis_plot.setXLink(self.pr_plot)
+        self.analysis_plot.getAxis("bottom").setStyle(showValues=False)
+
+    def calculate_pr(self):
+        """执行 PR 分析并绘制双轨图。"""
+        config = self.analysis_config or {}
+        try:
+            recorded_signal = resolve_analysis_channel_signal(self.data_struct, self.analysis_config, self.title_name)
+        except Exception as e:
+            MessageBox.warning(self, "提示", str(e))
+            return False
+        sample_rate = self.data_struct.sample_rate
+        if sample_rate is None:
+            return False
+
+        params, cfg_warnings = ProminenceRatioParams.from_config(config)
+        fan_pr_limits = config.get("fan_pr_limits") or [[100, 2000, 4], [2000, 5000, 2], [5000, 20000, 4]]
+
+        try:
+            analyzer = ProminenceRatioAnalyzer(int(sample_rate))
+            res = analyzer.compute(
+                recorded_signal,
+                self.v2pa_factor or 1.0,
+                params,
+                fan_pr_limits,
+                initial_warnings=cfg_warnings,
+            )
+        except Exception as e:
+            MessageBox.warning(self, "提示", f"PR 分析失败: {str(e)[:200]}")
+            return False
+
+        if res.decision_status == "invalid" and (res.frequency_hz is None or len(res.frequency_hz) == 0):
+            MessageBox.warning(self, "提示", "PR 分析无有效数据:\n" + "\n".join(res.warnings[:6]))
+            return False
+
+        self._plot_dual_track(res, params, fan_pr_limits)
+
+        # OK/NG 仅在启用限值且判定为 pass/fail（overall_ok 为 bool）时写入汇总
+        limit_checked = bool(config.get("limit_checked", True))
+        if limit_checked and res.decision_status in ("pass", "fail") and res.overall_ok is not None:
+            self.data_struct.analysis_result_dict[self.title_name] = (bool(res.overall_ok), float(res.max_exceed_db))
+
+        if res.warnings:
+            MessageBox.warning(self, "提示", "PR 分析提示:\n" + "\n".join(res.warnings[:6]))
+
+        self.result = {
+            "frequency_hz": np.asarray(res.frequency_hz, dtype=float).tolist(),
+            "band_power_db": np.asarray(res.band_power_db, dtype=float).tolist(),
+            "pr_db": np.asarray(res.pr_db, dtype=float).tolist(),
+            "fft_freq_hz": np.asarray(res.fft_freq_hz, dtype=float).tolist(),
+            "fft_magnitude_db": np.asarray(res.fft_magnitude_db, dtype=float).tolist(),
+            "max_pr_db": res.max_pr_db,
+            "max_pr_frequency_hz": res.max_pr_frequency_hz,
+            "decision_status": res.decision_status,
+            "overall_ok": res.overall_ok,
+            "max_exceed_db": res.max_exceed_db,
+            "no_valid_main_tone": res.no_valid_main_tone,
+            "main_tones": [self._tone_to_dict(t) for t in res.main_tones],
+            "warnings": list(res.warnings),
+            "metadata": dict(res.metadata),
+        }
+        self.export_detail = {
+            "max_pr_db": res.max_pr_db,
+            "max_pr_frequency_hz": res.max_pr_frequency_hz,
+            "max_exceed_db": res.max_exceed_db,
+            "decision_status": res.decision_status,
+            "tone_count": int(sum(1 for t in res.main_tones if t.valid_main_tone)),
+            "critical_band_mode": res.metadata.get("critical_band_mode"),
+            "effective_weighting": res.metadata.get("effective_weighting"),
+            "warnings": list(res.warnings),
+        }
+        return self.result
+
+    @staticmethod
+    def _tone_to_dict(t):
+        return {
+            "frequency_hz": t.frequency_hz,
+            "peak_db": t.peak_db,
+            "target_band_hz": list(t.target_band_hz),
+            "lower_adjacent_band_hz": list(t.lower_adjacent_band_hz),
+            "upper_adjacent_band_hz": list(t.upper_adjacent_band_hz),
+            "pr_db": t.pr_db,
+            "limit_db": t.limit_db,
+            "margin_db": t.margin_db,
+            "ecma_prominent": t.ecma_prominent,
+            "customer_ok": t.customer_ok,
+            "is_ok": t.is_ok,
+            "valid_main_tone": t.valid_main_tone,
+            "same_band_group_id": t.same_band_group_id,
+            "same_band_representative": t.same_band_representative,
+            "harmonic_order": t.harmonic_order,
+            "bpf_verified": t.bpf_verified,
+            "invalid_reasons": list(t.invalid_reasons),
+        }
+
+    @staticmethod
+    def _finite_float(value, default=float("nan")):
+        try:
+            out = float(value)
+        except (TypeError, ValueError):
+            return default
+        return out if np.isfinite(out) else default
+
+    @staticmethod
+    def _tone_sort_key(t):
+        pr_db = ProminenceRatioAnalysis._finite_float(getattr(t, "pr_db", float("nan")), -1e9)
+        limit_db = ProminenceRatioAnalysis._finite_float(getattr(t, "limit_db", float("nan")), 0.0)
+        exceed_db = pr_db - limit_db
+        is_ng = getattr(t, "customer_ok", None) is False
+        is_rep = bool(getattr(t, "same_band_representative", True))
+        return (1 if is_ng else 0, 1 if is_rep else 0, exceed_db, pr_db)
+
+    def _select_pr_plot_tones(self, tones):
+        cfg = self.analysis_config or {}
+        max_labels = int(cfg.get("max_pr_annotation_tones", 8) or 8)
+        max_labels = max(1, min(max_labels, 20))
+        valid = [
+            t for t in tones
+            if getattr(t, "valid_main_tone", False)
+            and np.isfinite(self._finite_float(getattr(t, "pr_db", float("nan"))))
+        ]
+        if not valid:
+            return []
+        primary = [
+            t for t in valid
+            if getattr(t, "customer_ok", None) is False
+            or bool(getattr(t, "same_band_representative", True))
+        ]
+        pool = primary or valid
+        return sorted(pool, key=self._tone_sort_key, reverse=True)[:max_labels]
+
+    @staticmethod
+    def _reset_pr_legend(plot, offset=(-10, 10)):
+        plot_item = plot.getPlotItem()
+        legend = getattr(plot_item, "legend", None)
+        if legend is None:
+            legend = plot.addLegend(offset=offset)
+            legend.setParentItem(plot_item.getViewBox())
+        else:
+            legend.clear()
+        legend.anchor(itemPos=(1, 0), parentPos=(1, 0), offset=offset)
+        try:
+            legend.setBrush(QColor(255, 255, 255, 220))
+            legend.setPen(mkPen(color=(180, 180, 180), width=1))
+        except Exception:
+            pass
+        return legend
+
+    @staticmethod
+    def _add_legend_sample(plot, name, *, color, width=2, style=Qt.SolidLine, symbol=None, line=True, fill=None):
+        """向图例添加一个不参与绘图的样本条目。
+
+        fill 给定 RGBA 时，图例样本渲染为“半透明填充块 + 同色细边”，与频带色块
+        （LinearRegionItem 填充 + InfiniteLine 边线）一致，避免图例颜色比实际更鲜艳。
+        """
+        if fill is not None:
+            # RGBA 预合成到白底，与画面上半透明色块视觉一致
+            r, g, b = fill[:3]
+            a = fill[3] / 255.0
+            premul = (int(255 * (1 - a) + r * a),
+                      int(255 * (1 - a) + g * a),
+                      int(255 * (1 - a) + b * a))
+            plot.plot([], [], pen=mkPen(color=premul, width=8), name=name)
+            return
+
+        kwargs = {
+            "pen": mkPen(color=color, width=width, style=style) if (line and color is not None) else mkPen(None),
+            "name": name,
+        }
+        if symbol:
+            kwargs.update({
+                "symbol": symbol,
+                "symbolSize": 9,
+                "symbolBrush": color,
+                "symbolPen": mkPen(color=color, width=1) if color is not None else None,
+            })
+        plot.plot([], [], **kwargs)
+
+    @staticmethod
+    def _add_pr_band_region(plot, band_hz, color):
+        f1, f2 = [ProminenceRatioAnalysis._finite_float(v) for v in band_hz]
+        if not (np.isfinite(f1) and np.isfinite(f2)) or f2 <= f1:
+            return
+        x1, x2 = f1 / 1000.0, f2 / 1000.0
+        region = pg.LinearRegionItem(
+            values=(x1, x2),
+            orientation=pg.LinearRegionItem.Vertical,
+            movable=False,
+            brush=QColor(color[0], color[1], color[2], color[3]),
+            pen=mkPen(color=color[:3], width=1),
+        )
+        region.setZValue(-10)
+        plot.addItem(region)
+
+    @staticmethod
+    def _vline_label_font():
+        """竖线标签（如 15%）用较大字体。"""
+        font = QFont()
+        font.setPixelSize(ui_style_const.scale_size_px(13))
+        return font
+
+    @staticmethod
+    def _add_pr_vertical_line(plot, x_hz, pen, label=None, label_y=None):
+        x = ProminenceRatioAnalysis._finite_float(x_hz)
+        if not np.isfinite(x):
+            return
+        plot.addItem(pg.InfiniteLine(pos=x / 1000.0, angle=90, pen=pen))
+        if label and label_y is not None and np.isfinite(label_y):
+            text = pg.TextItem(label, color=(90, 90, 90), anchor=(0.5, 1.0))
+            text.setFont(ProminenceRatioAnalysis._vline_label_font())
+            text.setPos(x / 1000.0, label_y)
+            plot.addItem(text)
+
+    @staticmethod
+    def _format_band_line(name, band_hz, power_db):
+        """格式化单行频带信息：名称 频率范围 功率。"""
+        f1 = ProminenceRatioAnalysis._finite_float(band_hz[0])
+        f2 = ProminenceRatioAnalysis._finite_float(band_hz[1])
+        power = ProminenceRatioAnalysis._finite_float(power_db)
+        if not (np.isfinite(f1) and np.isfinite(f2)):
+            return ""
+        pwr = f"{power:.1f}dB" if np.isfinite(power) else "--dB"
+        return f"{name} {f1:.0f}-{f2:.0f}Hz {pwr}"
+
+    def _plot_pr_band_annotations(self, tones, params, y_top, y_span):
+        """上轨频带色块 + 信息卡片（白底框，放在色块右侧）。"""
+        ratio = self._finite_float(getattr(params, "customer_band_ratio", 0.15), 0.15)
+        dashed_15pct = mkPen(color=(120, 120, 120), width=1, style=Qt.DashLine)
+        for idx, t in enumerate(tones):
+            xm = self._finite_float(getattr(t, "target_power_db", float("nan")))
+            xl = self._finite_float(getattr(t, "lower_adjacent_power_db", float("nan")))
+            xu = self._finite_float(getattr(t, "upper_adjacent_power_db", float("nan")))
+            lower_band = getattr(t, "lower_adjacent_band_hz", (np.nan, np.nan))
+            target_band = getattr(t, "target_band_hz", (np.nan, np.nan))
+            upper_band = getattr(t, "upper_adjacent_band_hz", (np.nan, np.nan))
+
+            self._add_pr_band_region(self.analysis_plot, lower_band, (33, 102, 172, 34))
+            self._add_pr_band_region(self.analysis_plot, upper_band, (33, 102, 172, 34))
+            self._add_pr_band_region(self.analysis_plot, target_band, (214, 39, 40, 42))
+
+            # 信息卡片：三行汇总，白底半透明框，放在上邻带右侧
+            lines = [
+                self._format_band_line("下邻带", lower_band, xl),
+                self._format_band_line("目标带", target_band, xm),
+                self._format_band_line("上邻带", upper_band, xu),
+            ]
+            card_text = "\n".join(ln for ln in lines if ln)
+            if card_text:
+                upper_f2 = self._finite_float(upper_band[1])
+                card_x = (upper_f2 / 1000.0 + 0.05) if np.isfinite(upper_f2) else 0
+                card_y = y_top - (0.03 + 0.30 * idx) * y_span
+                card = pg.TextItem(
+                    card_text, color=(50, 50, 50), anchor=(0.0, 0.0),
+                    border=mkPen(color=(160, 160, 160), width=1),
+                    fill=QColor(255, 255, 255, 200),
+                )
+                card.setPos(card_x, card_y)
+                self.analysis_plot.addItem(card)
+
+            ft = self._finite_float(getattr(t, "frequency_hz", float("nan")))
+            if np.isfinite(ft):
+                half_15 = 0.5 * ratio * ft
+                line_label = "15%" if idx == 0 else None
+                self._add_pr_vertical_line(self.analysis_plot, ft - half_15, dashed_15pct,
+                                           line_label, y_top + 0.14 * y_span)
+                self._add_pr_vertical_line(self.analysis_plot, ft + half_15, dashed_15pct)
+                self._add_pr_vertical_line(
+                    self.analysis_plot,
+                    ft,
+                    mkPen(color=(45, 45, 45), width=1, style=Qt.DotLine),
+                )
+
+    def _plot_dual_track(self, res, params, fan_pr_limits):
+        # 批量绘图期间冻结视图更新，避免每次 addItem 都触发重绘
+        for pw in (self.analysis_plot, self.pr_plot):
+            pw.getPlotItem().getViewBox().blockSignals(True)
+            pw.getPlotItem().getViewBox().disableAutoRange()
+        try:
+            self._plot_dual_track_inner(res, params, fan_pr_limits)
+        finally:
+            for pw in (self.analysis_plot, self.pr_plot):
+                pw.getPlotItem().getViewBox().blockSignals(False)
+            # 上轨已手动 setYRange；下轨需要解冻后自动适配
+            self.pr_plot.getPlotItem().getViewBox().enableAutoRange()
+            self.pr_plot.getPlotItem().getViewBox().autoRange()
+
+    def _plot_dual_track_inner(self, res, params, fan_pr_limits):
+        self.analysis_plot.clear()
+        self.pr_plot.clear()
+        self._reset_pr_legend(self.analysis_plot)
+        self._reset_pr_legend(self.pr_plot)
+
+        freq = np.asarray(res.frequency_hz, dtype=float)
+        if freq.size == 0:
+            return
+        f_khz = freq / 1000.0
+        band_power = np.asarray(res.band_power_db, dtype=float)
+        pr = np.asarray(res.pr_db, dtype=float)
+
+        # ---- 上轨：临界频带功率 + 频带功率标注 ----
+        # 谱可达数万点，pyqtgraph 宽线渲染极慢；先做峰值包络降采样（保留峰，渲染快约 10×）
+        max_pts = int((self.analysis_config or {}).get("max_plot_points", 2000))
+        f_lo_hz = self._finite_float(getattr(params, "f_min", 0.0), 0.0)
+        configured_f_hi_hz = self._finite_float(getattr(params, "f_max", freq[-1]), float(freq[-1]))
+        f_hi_hz = configured_f_hi_hz
+        band_valid = np.isfinite(band_power) & (freq >= f_lo_hz) & (freq <= f_hi_hz)
+        bx, by = _decimate_peak_envelope(f_khz[band_valid], band_power[band_valid], max_pts)
+        self.analysis_plot.plot(bx, by, pen=mkPen(color=(51, 196, 77), width=2), name="临界频带功率")
+        finite_upper = band_power[band_valid]
+        self.analysis_plot.setLabel("left", "临界频带功率 [dB]")
+        self.analysis_plot.showGrid(x=True, y=True)
+        self.analysis_plot.setTitle("线性功率谱 + PR值分布曲线", size="12px", color="k")
+
+        if finite_upper.size:
+            y_top = float(np.nanmax(finite_upper))
+            y_bottom = float(np.nanmin(finite_upper))
+            y_span = max(y_top - y_bottom, 1.0)
+            # 顶部留白，给抬高的 15% 标签和信息卡片腾出空间
+            self.analysis_plot.setYRange(y_bottom - 0.02 * y_span, y_top + 0.18 * y_span, padding=0)
+        else:
+            y_top, y_span = 1.0, 1.0
+        plot_tones = self._select_pr_plot_tones(res.main_tones)
+        self._plot_pr_band_annotations(plot_tones, params, y_top, y_span)
+        if plot_tones:
+            # 图例色块直接用画色块时的颜色（取 RGB 实色，便于辨认）
+            self._add_legend_sample(self.analysis_plot, "目标频带", color=(214, 39, 40), fill=(214, 39, 40, 42))
+            self._add_legend_sample(self.analysis_plot, "相邻频带", color=(33, 102, 172), fill=(33, 102, 172, 34))
+            self._add_legend_sample(
+                self.analysis_plot,
+                "15%划分线",
+                color=(120, 120, 120),
+                width=1,
+                style=Qt.DashLine,
+            )
+        # ---- 下轨：PR 曲线 + 限值线 + 主音标注 ----
+        valid = np.isfinite(pr)
+        px, py = _decimate_peak_envelope(f_khz[valid], pr[valid], max_pts)
+        self.pr_plot.plot(px, py, pen=mkPen(color=(33, 102, 172), width=2), name="PR")
+        self.pr_plot.setLabel("left", "PR值 [dB]")
+        self.pr_plot.setLabel("bottom", "频率 [kHz]")
+        self.pr_plot.showGrid(x=True, y=True)
+
+        x_min = max(0.0, f_lo_hz / 1000.0)
+        x_max = f_hi_hz / 1000.0
+        if np.isfinite(x_max) and x_max > x_min:
+            x_pad = (x_max - x_min) * 0.02
+            self.analysis_plot.setXRange(x_min, x_max + x_pad, padding=0)
+            self.pr_plot.setXRange(x_min, x_max + x_pad, padding=0)
+            self.analysis_plot.getViewBox().setLimits(xMin=x_min, xMax=x_max + x_pad)
+            self.pr_plot.getViewBox().setLimits(xMin=x_min, xMax=x_max + x_pad)
+
+        # 分段限值线（仅在启用限值时绘制）
+        if bool((self.analysis_config or {}).get("limit_checked", True)):
+            self._add_legend_sample(
+                self.pr_plot,
+                "PR限值",
+                color=(214, 39, 40),
+                width=2,
+                style=Qt.DashLine,
+            )
+            for band in fan_pr_limits:
+                f_lo, f_hi, lim = float(band[0]), float(band[1]), float(band[2])
+                self.pr_plot.plot(
+                    [f_lo / 1000.0, f_hi / 1000.0], [lim, lim],
+                    pen=mkPen(color=(214, 39, 40), width=2, style=Qt.DashLine),
+                )
+
+        # 主音标注：只标代表峰/NG 峰，避免候选峰文本铺满图面
+        if plot_tones:
+            self._add_legend_sample(self.pr_plot, "有效主音", color=(76, 175, 80), symbol="o", line=False)
+        for idx, t in enumerate(plot_tones):
+            is_ng = (t.customer_ok is False)
+            color = (214, 39, 40) if is_ng else (76, 175, 80)
+            self.pr_plot.plot(
+                [t.frequency_hz / 1000.0], [t.pr_db],
+                pen=mkPen(None), symbol="o", symbolSize=9, symbolBrush=color,
+            )
+            prefix = "NG " if is_ng else ""
+            label = f"{prefix}{t.frequency_hz:.0f}Hz  PR={t.pr_db:.1f} dB, Limit={t.limit_db:.0f} dB"
+            text = pg.TextItem(label, color=color, anchor=(0.5, 1.15 + 0.25 * (idx % 3)))
+            text.setPos(t.frequency_hz / 1000.0, t.pr_db + 0.15 * (idx % 3))
+            self.pr_plot.addItem(text)
 
 
 if __name__ == "__main__":

--- a/ui/signal_analysis_window.py
+++ b/ui/signal_analysis_window.py
@@ -4227,7 +4227,7 @@ class ProminenceRatioAnalysis(AnalysisGraphWidget):
     """突出比 (PR / Prominence Ratio) 分析窗口（双轨图）。
 
     需求书《笔记本电脑风扇噪音核心测试要求书》PR 频谱模块：
-    - 标题沿用“线性功率谱 + PR 值分布曲线”；上轨按需求纵轴定义绘制临界频带功率 dB。
+    - 上轨：线性功率谱曲线，红/蓝临界频带框内标注频带积分功率 dB。
     - 下轨：PR 值分布曲线 dB；横轴 Frequency (kHz)。
     - 默认计算口径：ECMA-74 Annex D / ECMA-418-1 标准临界带 + 线性(Z)/不计权功率。
       15% 固定比例仅按需求书作为图面划分线显示，不参与默认 PR 功率积分。
@@ -4244,7 +4244,7 @@ class ProminenceRatioAnalysis(AnalysisGraphWidget):
         self.title_name = title_name
         self.setWindowTitle(title_name)
 
-        # 下轨 PR 曲线（上轨复用基类 self.analysis_plot 作为临界带功率谱）
+        # 下轨 PR 曲线（上轨复用基类 self.analysis_plot 作为线性功率谱）
         self.pr_plot = pg.PlotWidget()
         self.pr_plot.setBackground("white")
         self.apply_plot_font_style(self.pr_plot, 20)
@@ -4546,20 +4546,42 @@ class ProminenceRatioAnalysis(AnalysisGraphWidget):
         if freq.size == 0:
             return
         f_khz = freq / 1000.0
-        band_power = np.asarray(res.band_power_db, dtype=float)
         pr = np.asarray(res.pr_db, dtype=float)
+        spectrum_freq = np.asarray(getattr(res, "fft_freq_hz", []), dtype=float)
+        spectrum_power = np.asarray(getattr(res, "fft_magnitude_db", []), dtype=float)
 
-        # ---- 上轨：临界频带功率 + 频带功率标注 ----
+        # ---- 上轨：线性功率谱 + 频带功率标注 ----
         # 谱可达数万点，pyqtgraph 宽线渲染极慢；先做峰值包络降采样（保留峰，渲染快约 10×）
         max_pts = int((self.analysis_config or {}).get("max_plot_points", 2000))
         f_lo_hz = self._finite_float(getattr(params, "f_min", 0.0), 0.0)
         configured_f_hi_hz = self._finite_float(getattr(params, "f_max", freq[-1]), float(freq[-1]))
         f_hi_hz = configured_f_hi_hz
-        band_valid = np.isfinite(band_power) & (freq >= f_lo_hz) & (freq <= f_hi_hz)
-        bx, by = _decimate_peak_envelope(f_khz[band_valid], band_power[band_valid], max_pts)
-        self.analysis_plot.plot(bx, by, pen=mkPen(color=(51, 196, 77), width=2), name="临界频带功率")
-        finite_upper = band_power[band_valid]
-        self.analysis_plot.setLabel("left", "临界频带功率 [dB]")
+        if spectrum_freq.size and spectrum_freq.size == spectrum_power.size:
+            spectrum_valid = (
+                np.isfinite(spectrum_freq)
+                & np.isfinite(spectrum_power)
+                & (spectrum_freq >= f_lo_hz)
+                & (spectrum_freq <= f_hi_hz)
+            )
+        else:
+            spectrum_valid = np.zeros(0, dtype=bool)
+        upper_label = "线性功率谱 [dB]"
+        if spectrum_freq.size and np.any(spectrum_valid):
+            sx, sy = _decimate_peak_envelope(
+                spectrum_freq[spectrum_valid] / 1000.0,
+                spectrum_power[spectrum_valid],
+                max_pts,
+            )
+            self.analysis_plot.plot(sx, sy, pen=mkPen(color=(51, 196, 77), width=2), name="线性功率谱")
+            finite_upper = spectrum_power[spectrum_valid]
+        else:
+            band_power = np.asarray(res.band_power_db, dtype=float)
+            band_valid = np.isfinite(band_power) & (freq >= f_lo_hz) & (freq <= f_hi_hz)
+            bx, by = _decimate_peak_envelope(f_khz[band_valid], band_power[band_valid], max_pts)
+            self.analysis_plot.plot(bx, by, pen=mkPen(color=(51, 196, 77), width=2), name="临界频带功率")
+            finite_upper = band_power[band_valid]
+            upper_label = "临界频带功率 [dB]"
+        self.analysis_plot.setLabel("left", upper_label)
         self.analysis_plot.showGrid(x=True, y=True)
         self.analysis_plot.setTitle("线性功率谱 + PR值分布曲线", size="12px", color="k")
 

--- a/ui/ui_analysis_config/__init__.py
+++ b/ui/ui_analysis_config/__init__.py
@@ -1,0 +1,2 @@
+"""ui.ui_analysis_config package."""
+

--- a/ui/ui_analysis_config/pr_config_dialog.py
+++ b/ui/ui_analysis_config/pr_config_dialog.py
@@ -1,0 +1,347 @@
+"""突出比 (PR / Prominence Ratio) 分析配置对话框。
+
+需求书《笔记本电脑风扇噪音核心测试要求书》要点：
+- PR 模块适配 ECMA-74 Annex D，默认按 ECMA/ECMA-418-1 标准临界带计算 PR，
+  15% 固定比例带宽保留为图面划分线和兼容对比模式。
+  （PR 为带功率比值，需求书 4.4.3 把 PR 模块幅度标度写为 dB 而非 dB(A)；计权为隐藏高级项。）
+- 临界带功率积分与 PR 频谱共用同一段 FFT 频谱，临界带宽与 FFT 参数天然同步
+  （对应 3.3"确认临界带宽与 FFT 参数同步"，截图本配置界面即可留存）。
+
+`PRConfigWindow` 与 SPL/FBA 等同级，通过 `operation_sequence.create_config_dialog` 路由，
+保存的配置由 `ProminenceRatioParams.from_config()` 读取。
+"""
+
+import re
+from typing import List, Optional
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QIcon
+from PyQt5.QtWidgets import QDialog, QHBoxLayout, QVBoxLayout, QGridLayout, QSizePolicy, QWidget
+
+from ui.custom_ui_widget.popuputils import PopupUtils
+from ui.custom_ui_widget.widgets import (
+    PushButton,
+    ComboBox,
+    Label,
+    GroupBox,
+    SpinBox,
+    DoubleSpinBox,
+    CheckBox,
+    MessageBox,
+)
+
+
+# 临界带定义：UI 文本 ↔ 配置值
+MODE_LABELS = [
+    ("ECMA 标准临界带", "ecma"),
+    ("固定比例带宽", "customer_15pct"),
+]
+
+# 需求书默认三段 PR 限值 [f_lo, f_hi, limit_db]
+DEFAULT_FAN_PR_LIMITS = [[100, 2000, 4], [2000, 5000, 2], [5000, 20000, 4]]
+
+
+def default_pr_config() -> dict:
+    """PR 顶层默认配置（代码内可靠默认源，不依赖被 gitignore 的 JSON）。
+
+    与需求书校核口径一致：ECMA-74 Annex D / ECMA-418-1 标准临界带
+    + 线性(不计权) + 20Hz 高通；15% 固定比例仅作显示划分线/兼容模式。
+    （weighting=auto→线性(Z)，为隐藏高级项，界面不暴露。）
+    """
+    return {
+        "analysis_channel": 0,
+        "critical_band_mode": "ecma",
+        "standard": "ecma74_annexD",
+        "mode_profile": "ecma2022",
+        "f_min": 100,
+        "f_max": 20000,
+        "window": "hann",
+        "window_samples": 65536,
+        "overlap_ratio": 0.75,
+        "target_resolution_hz": 1.0,
+        "weighting": "auto",
+        "customer_band_ratio": 0.15,
+        "highpass_hz": 20.0,
+        "dc_removal": "mean",
+        "bpf_enabled": False,
+        "blade_count": 0,
+        "rpm": 0,
+        "bpf_tolerance_percent": 5.0,
+        # 需求书 1.4 第7条 / 4.3：谐波分量一律不纳入判定，固定 False，不开放 UI 配置。
+        "include_harmonics_in_customer_judgement": False,
+        "limit_checked": True,
+        "fan_pr_limits": [list(b) for b in DEFAULT_FAN_PR_LIMITS],
+    }
+
+
+class PRConfigWindow(QDialog):
+    """突出比 (PR) 分析配置窗口。"""
+
+    def __init__(self, config_manager, model_type, available_channels: Optional[List[int]] = None):
+        super().__init__()
+        self.config_manager = config_manager
+        self.model_type_str = "".join(re.findall(r"[A-Za-z]", str(model_type))) or "PR"
+        self.show_channel_selector = available_channels is not None
+        self.available_channels = self._normalize_available_channels(available_channels)
+
+        full_config = self.config_manager.load_config()
+        saved = full_config.get(model_type, {}) if isinstance(full_config, dict) else {}
+        # 以默认配置兜底，保证旧配置/缺字段也能完整加载
+        self.load_config = {**default_pr_config(), **(saved or {})}
+
+        self.init_ui()
+
+    @staticmethod
+    def _normalize_available_channels(available_channels):
+        try:
+            channels = sorted({int(ch) for ch in (available_channels or [])})
+        except Exception:
+            channels = []
+        return channels or [0]
+
+    # ------------------------------------------------------------------
+    # UI 构建
+    # ------------------------------------------------------------------
+    def init_ui(self):
+        self.setWindowFlag(Qt.WindowCloseButtonHint, False)
+        self.setWindowFlag(Qt.WindowContextHelpButtonHint, False)
+        self.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
+        self.setWindowTitle("PR (突出比) 分析配置")
+        self.setMinimumSize(640, 700)
+        self.resize(640, 700)
+
+        main_layout = QVBoxLayout()
+        main_layout.setSpacing(12)
+        main_layout.setContentsMargins(18, 18, 18, 18)
+
+        if self.show_channel_selector:
+            main_layout.addLayout(self._create_channel_layout())
+
+        main_layout.addWidget(self._create_mode_group())
+        main_layout.addWidget(self._create_fft_group())
+        main_layout.addWidget(self._create_limit_group())
+
+        main_layout.addStretch(1)
+        main_layout.addLayout(self.create_btn())
+        self.setLayout(main_layout)
+
+        self._on_mode_changed()
+
+    def _create_channel_layout(self):
+        layout = QHBoxLayout()
+        layout.addWidget(Label("通道:"))
+        self.channel_combo_box = ComboBox()
+        for ch in self.available_channels:
+            self.channel_combo_box.addItem(f"In{int(ch) + 1}", int(ch))
+        saved_channel = self.load_config.get("analysis_channel", None)
+        if saved_channel is None or int(saved_channel) not in self.available_channels:
+            saved_channel = int(self.available_channels[0])
+        idx = self.channel_combo_box.findData(int(saved_channel))
+        self.channel_combo_box.setCurrentIndex(idx if idx >= 0 else 0)
+        layout.addWidget(self.channel_combo_box, 1)
+        return layout
+
+    def _create_mode_group(self):
+        group = GroupBox("临界带定义 / 频率范围")
+        layout = QVBoxLayout()
+
+        row_mode = QHBoxLayout()
+        row_mode.addWidget(Label("临界带定义:"))
+        self.mode_combo = ComboBox()
+        for text, _val in MODE_LABELS:
+            self.mode_combo.addItem(text)
+        saved_mode = str(self.load_config.get("critical_band_mode", "ecma"))
+        mode_idx = next((i for i, (_t, v) in enumerate(MODE_LABELS) if v == saved_mode), 0)
+        self.mode_combo.setCurrentIndex(mode_idx)
+        self.mode_combo.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        self.mode_combo.setMinimumWidth(200)
+        self.mode_combo.currentIndexChanged.connect(self._on_mode_changed)
+        row_mode.addWidget(self.mode_combo, 1)
+
+        # 固定带宽比例与“临界带定义”同一行（仅固定比例带宽模式可见）；百分比显示（如 15 %）
+        self.band_ratio_spin = DoubleSpinBox()
+        self.band_ratio_spin.setRange(5, 50)
+        self.band_ratio_spin.setDecimals(0)
+        self.band_ratio_spin.setSingleStep(1)
+        self.band_ratio_spin.setSuffix(" %")
+        self.band_ratio_spin.setValue(round(float(self.load_config.get("customer_band_ratio", 0.15)) * 100))
+        self.ratio_container = QWidget()
+        row_ratio = QHBoxLayout(self.ratio_container)
+        row_ratio.setContentsMargins(12, 0, 0, 0)
+        row_ratio.addWidget(Label("固定带宽比例:"))
+        row_ratio.addWidget(self.band_ratio_spin)
+        row_mode.addWidget(self.ratio_container)
+        layout.addLayout(row_mode)
+
+        row_range = QHBoxLayout()
+        row_range.addWidget(Label("频率下限:"))
+        self.f_min_spin = DoubleSpinBox()
+        self.f_min_spin.setRange(1, 20000)
+        self.f_min_spin.setDecimals(0)
+        self.f_min_spin.setValue(float(self.load_config.get("f_min", 100)))
+        self.f_min_spin.setSuffix(" Hz")
+        row_range.addWidget(self.f_min_spin)
+        row_range.addSpacing(16)
+        row_range.addWidget(Label("频率上限:"))
+        self.f_max_spin = DoubleSpinBox()
+        self.f_max_spin.setRange(100, 96000)
+        self.f_max_spin.setDecimals(0)
+        self.f_max_spin.setValue(float(self.load_config.get("f_max", 20000)))
+        self.f_max_spin.setSuffix(" Hz")
+        row_range.addWidget(self.f_max_spin)
+        layout.addLayout(row_range)
+
+        group.setLayout(layout)
+        return group
+
+    def _create_fft_group(self):
+        group = GroupBox("FFT 参数")
+        layout = QGridLayout()
+
+        layout.addWidget(Label("窗函数:"), 0, 0)
+        self.window_combo = ComboBox()
+        self.window_combo.addItems(["hann", "hamming", "blackman"])
+        widx = self.window_combo.findText(str(self.load_config.get("window", "hann")))
+        self.window_combo.setCurrentIndex(widx if widx >= 0 else 0)
+        layout.addWidget(self.window_combo, 0, 1)
+
+        layout.addWidget(Label("窗长 (点):"), 1, 0)
+        self.window_samples_combo = ComboBox()
+        for n in (8192, 16384, 32768, 65536, 131072):
+            self.window_samples_combo.addItem(str(n), n)
+        nidx = self.window_samples_combo.findData(int(self.load_config.get("window_samples", 65536)))
+        self.window_samples_combo.setCurrentIndex(nidx if nidx >= 0 else 3)
+        layout.addWidget(self.window_samples_combo, 1, 1)
+
+        layout.addWidget(Label("重叠率:"), 2, 0)
+        self.overlap_spin = DoubleSpinBox()
+        self.overlap_spin.setRange(0.0, 0.95)
+        self.overlap_spin.setDecimals(2)
+        self.overlap_spin.setSingleStep(0.05)
+        self.overlap_spin.setValue(float(self.load_config.get("overlap_ratio", 0.75)))
+        layout.addWidget(self.overlap_spin, 2, 1)
+
+        saved_hp = float(self.load_config.get("highpass_hz", 20.0))
+        self.highpass_check = CheckBox(" 高通去直流")
+        self.highpass_check.setChecked(saved_hp > 0)
+        layout.addWidget(self.highpass_check, 3, 0)
+        self.highpass_spin = DoubleSpinBox()
+        self.highpass_spin.setRange(1.0, 200.0)
+        self.highpass_spin.setDecimals(0)
+        self.highpass_spin.setValue(saved_hp if saved_hp > 0 else 20.0)
+        self.highpass_spin.setSuffix(" Hz")
+        self.highpass_spin.setEnabled(saved_hp > 0)
+        self.highpass_check.stateChanged.connect(
+            lambda *_: self.highpass_spin.setEnabled(self.highpass_check.isChecked())
+        )
+        layout.addWidget(self.highpass_spin, 3, 1)
+
+        group.setLayout(layout)
+        return group
+
+    def _create_limit_group(self):
+        group = GroupBox("PR 限值对比")
+        layout = QVBoxLayout()
+
+        self.limit_check = CheckBox(" 启用 PR 限值对比")
+        self.limit_check.setChecked(bool(self.load_config.get("limit_checked", True)))
+        layout.addWidget(self.limit_check)
+
+        saved_limits = self.load_config.get("fan_pr_limits") or DEFAULT_FAN_PR_LIMITS
+        header = QHBoxLayout()
+        header.addWidget(Label("频率下限 (Hz)"))
+        header.addWidget(Label("频率上限 (Hz)"))
+        header.addWidget(Label("PR 限值 (dB)"))
+        layout.addLayout(header)
+
+        self.limit_rows = []
+        for band in saved_limits:
+            row = QHBoxLayout()
+            lo = DoubleSpinBox(); lo.setRange(1, 96000); lo.setDecimals(0); lo.setValue(float(band[0]))
+            hi = DoubleSpinBox(); hi.setRange(1, 96000); hi.setDecimals(0); hi.setValue(float(band[1]))
+            lim = DoubleSpinBox(); lim.setRange(0, 60); lim.setDecimals(1); lim.setValue(float(band[2]))
+            row.addWidget(lo); row.addWidget(hi); row.addWidget(lim)
+            layout.addLayout(row)
+            self.limit_rows.append((lo, hi, lim))
+
+        group.setLayout(layout)
+        return group
+
+    # ------------------------------------------------------------------
+    # 模式切换
+    # ------------------------------------------------------------------
+    def _current_mode(self) -> str:
+        idx = self.mode_combo.currentIndex()
+        return MODE_LABELS[idx][1] if 0 <= idx < len(MODE_LABELS) else "ecma"
+
+    def _on_mode_changed(self, *_args):
+        """固定比例带宽才需要比例输入；ECMA 临界带由公式确定，隐藏比例框。"""
+        if hasattr(self, "ratio_container"):
+            self.ratio_container.setVisible(self._current_mode() == "customer_15pct")
+
+    # ------------------------------------------------------------------
+    # 按钮 / 配置导出
+    # ------------------------------------------------------------------
+    def create_btn(self):
+        btn_layout = QHBoxLayout()
+        default_btn = PushButton(" 设为默认 ")
+        default_btn.clicked.connect(self.on_default_btn_clicked)
+        ok_btn = PushButton(" 确  认 ")
+        ok_btn.clicked.connect(self.on_click_ok_btn)
+        btn_layout.addStretch()
+        btn_layout.addWidget(default_btn)
+        btn_layout.addSpacing(10)
+        btn_layout.addWidget(ok_btn)
+        return btn_layout
+
+    def _collect_fan_pr_limits(self):
+        limits = []
+        for lo, hi, lim in self.limit_rows:
+            limits.append([int(lo.value()), int(hi.value()), float(lim.value())])
+        return limits
+
+    def _validate(self) -> bool:
+        if float(self.f_max_spin.value()) <= float(self.f_min_spin.value()):
+            MessageBox.warning(self, "提示", "频率上限必须大于下限。")
+            return False
+        for lo, hi, _lim in self.limit_rows:
+            if float(hi.value()) <= float(lo.value()):
+                MessageBox.warning(self, "提示", "PR 限值频段的结束频率必须大于起始频率。")
+                return False
+        return True
+
+    def get_default_config(self):
+        config = dict(default_pr_config())
+        config.update({
+            "critical_band_mode": self._current_mode(),
+            "customer_band_ratio": float(self.band_ratio_spin.value()) / 100.0,
+            "f_min": int(self.f_min_spin.value()),
+            "f_max": int(self.f_max_spin.value()),
+            "window": self.window_combo.currentText(),
+            "window_samples": int(self.window_samples_combo.currentData() or 65536),
+            "overlap_ratio": float(self.overlap_spin.value()),
+            "target_resolution_hz": float(self.load_config.get("target_resolution_hz", 1.0)),
+            "highpass_hz": float(self.highpass_spin.value()) if self.highpass_check.isChecked() else 0.0,
+            "limit_checked": bool(self.limit_check.isChecked()),
+            "fan_pr_limits": self._collect_fan_pr_limits(),
+        })
+        # 计权为隐藏高级项：界面不暴露，默认 auto→线性(Z)；如配置里显式写了 A/C 则保留。
+        config["weighting"] = str(self.load_config.get("weighting", "auto"))
+        if self.show_channel_selector and hasattr(self, "channel_combo_box"):
+            config["analysis_channel"] = int(self.channel_combo_box.currentData())
+        else:
+            config["analysis_channel"] = int(self.load_config.get("analysis_channel", 0) or 0)
+        return config
+
+    def on_default_btn_clicked(self):
+        if not self._validate():
+            return
+        config_data = self.get_default_config()
+        save_flag = self.config_manager.save_default_config(self.model_type_str, config_data)
+        PopupUtils().save_popup(self, success_flag=save_flag)
+
+    def on_click_ok_btn(self):
+        if not self._validate():
+            return
+        self.accept()
+        return self.get_default_config()


### PR DESCRIPTION
## Summary

- Add Prominence Ratio (PR) analysis module based on ECMA-74 Annex D / ECMA-418-1 standard
- Implement dual-track visualization (critical band power + PR curve) with band annotations and limit lines
- Integrate PR into existing analysis sequence, config dialog, and Excel export pipeline

## Changes

- `base/core_algorithm/response/ecma_critical_band.py`: ECMA critical band pure functions (Zwicker bandwidth, adjacent band quadratic fitting, low-frequency correction, prominence threshold)
- `base/core_algorithm/response/prominence_ratio_analyzer.py`: PR algorithm orchestration (FFT/Welch PSD, weighted band power integration, tone detection, same-band grouping, customer 4/2/4 dB OK/NG decision)
- `ui/signal_analysis_window.py`: ProminenceRatioAnalysis widget with dual-track plot, info card annotations, 15%% divider lines, view-freeze batch rendering
- `ui/ui_analysis_config/pr_config_dialog.py`: PR configuration dialog (critical band mode, FFT params, frequency range, DC removal, PR limit comparison)
- `ui/operation_sequence.py`: Add PR to analysis list, config dialog routing, default config fallback
- `ui/sequence/sequence_widget.py`: Add calculate_pr() dispatch and OK/NG support
- `base/excel_result_exporter.py`: Add PR curve export and unit support

## Test Plan

- [ ] PR analysis produces correct dual-track plot with band annotations
- [ ] Config dialog opens and saves parameters correctly
- [ ] Excel export includes PR curve data
- [ ] OK/NG aggregation works with PR limit comparison enabled

Made with [Cursor](https://cursor.com)