### PR TITLE
refactor(ui): add analysis config normalization helpers

### DIFF
--- a/ui/ui_analysis_config/config_normalization.py
+++ b/ui/ui_analysis_config/config_normalization.py
@@ -1,0 +1,171 @@
+"""Compatibility helpers for analysis configuration dialogs.
+
+The analysis configuration UI keeps legacy persisted keys stable while newer
+dialogs and shared widgets use clearer internal concept names.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+
+WEIGHTING_OPTIONS = ("Z", "A", "B", "C", "D")
+WEIGHTING_DISPLAY_LABELS = {
+    "Z": "Z（None）",
+    "A": "A",
+    "B": "B",
+    "C": "C",
+    "D": "D",
+}
+
+OCTAVE_SMOOTHING_OPTIONS = (0, 1, 3, 6, 12, 24, 48)
+
+CONFIG_CONCEPTS = {
+    "analysis_channel": {
+        "meaning": "Input channel selected for this analysis item.",
+        "legacy_keys": ("analysis_channel",),
+    },
+    "weighting": {
+        "meaning": "Acoustic weighting curve.",
+        "legacy_keys": ("weighting",),
+    },
+    "frequency_smoothing": {
+        "meaning": "Frequency-domain octave smoothing.",
+        "legacy_keys": ("octave_smoothing", "smooth_checked"),
+    },
+    "time_smoothing": {
+        "meaning": "Time-domain or point-domain smoothing for event detection.",
+        "legacy_keys": (
+            "smooth_checked",
+            "smooth_enabled",
+            "smooth_unit",
+            "smooth_time_sec",
+            "smooth_points",
+            "smooth_algo",
+        ),
+    },
+    "threshold_curve": {
+        "meaning": "CSV upper/lower curve threshold.",
+        "legacy_keys": ("limit_checked", "limit_data"),
+    },
+    "reference_threshold": {
+        "meaning": "Reference-spectrum dB offset threshold.",
+        "legacy_keys": ("enable_threshold_judgment", "lower_offset_db", "upper_offset_db"),
+    },
+    "golden_sample": {
+        "meaning": "Comparison against a golden baseline result.",
+        "legacy_keys": ("golden_sample_checked", "golden_sample_result_path"),
+    },
+    "harmonic_selection": {
+        "meaning": "Selected harmonic orders.",
+        "legacy_keys": ("selected_labels", "all_checked"),
+    },
+}
+
+
+def _to_int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _to_float(value: Any, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def normalize_weighting(value: Any, default: str = "Z") -> str:
+    """Return a canonical weighting value: Z, A, B, C, or D."""
+    normalized_default = str(default or "Z").strip().upper()
+    if normalized_default in ("NONE", "Z（NONE）"):
+        normalized_default = "Z"
+    if normalized_default not in WEIGHTING_OPTIONS:
+        normalized_default = "Z"
+
+    if value in (None, ""):
+        return normalized_default
+
+    normalized = str(value).strip().upper()
+    if normalized in ("NONE", "Z（NONE）"):
+        return "Z"
+    return normalized if normalized in WEIGHTING_OPTIONS else normalized_default
+
+
+def weighting_to_display_label(value: Any, default: str = "Z") -> str:
+    """Return the dialog label for a weighting value."""
+    return WEIGHTING_DISPLAY_LABELS[normalize_weighting(value, default=default)]
+
+
+def normalize_octave_smoothing(
+    cfg: Mapping[str, Any] | None,
+    default: int = 0,
+    legacy_true_default: int = 6,
+) -> int:
+    """Return a supported octave smoothing fraction from legacy config keys."""
+    config = cfg or {}
+    normalized_default = _to_int(default, 0)
+    if normalized_default not in OCTAVE_SMOOTHING_OPTIONS:
+        normalized_default = 0
+
+    if "octave_smoothing" in config:
+        value = _to_int(config.get("octave_smoothing"), normalized_default)
+        return value if value in OCTAVE_SMOOTHING_OPTIONS else normalized_default
+
+    if bool(config.get("smooth_checked", False)):
+        value = _to_int(legacy_true_default, 6)
+        return value if value in OCTAVE_SMOOTHING_OPTIONS else 6
+
+    return normalized_default
+
+
+def normalize_time_smoothing(
+    cfg: Mapping[str, Any] | None,
+    defaults: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return a stable internal shape for time or point smoothing settings."""
+    config = cfg or {}
+    fallback = {
+        "enabled": False,
+        "unit": "time",
+        "time_sec": 0.02,
+        "points": 0,
+        "algo": 1,
+    }
+    fallback.update(defaults or {})
+
+    unit = str(config.get("smooth_unit", fallback["unit"]) or fallback["unit"]).strip().lower()
+    if unit not in ("time", "points"):
+        unit = str(fallback["unit"] or "time").strip().lower()
+    if unit not in ("time", "points"):
+        unit = "time"
+
+    return {
+        "enabled": bool(config.get("smooth_enabled", config.get("smooth_checked", fallback["enabled"]))),
+        "unit": unit,
+        "time_sec": _to_float(config.get("smooth_time_sec", fallback["time_sec"]), float(fallback["time_sec"])),
+        "points": _to_int(config.get("smooth_points", fallback["points"]), int(fallback["points"])),
+        "algo": _to_int(config.get("smooth_algo", fallback["algo"]), int(fallback["algo"])),
+    }
+
+
+def normalize_analysis_channel(
+    cfg: Mapping[str, Any] | None,
+    available_channels: Iterable[Any] | None,
+) -> int:
+    """Return a valid analysis channel, falling back to the first available one."""
+    channels = []
+    for ch in available_channels or []:
+        try:
+            channels.append(int(ch))
+        except (TypeError, ValueError):
+            continue
+    channels = sorted(set(channels))
+    if not channels:
+        channels = [0]
+
+    selected = _to_int((cfg or {}).get("analysis_channel", channels[0]), channels[0])
+    return selected if selected in channels else channels[0]

--- a/ui/ui_analysis_config/fba_config_dialog.py
+++ b/ui/ui_analysis_config/fba_config_dialog.py
@@ -8,6 +8,7 @@ from consts.running_consts import DEFAULT_DIR
 from ui.custom_ui_widget.popuputils import PopupUtils
 
 # 确保这里导入的是你项目中正确的 ThresholdConfigWidget 路径
+from ui.ui_analysis_config.config_normalization import weighting_to_display_label
 from ui.ui_analysis_config.threshold_config_widget import ThresholdConfigWidget
 from ui.custom_ui_widget.widgets import PushButton, ComboBox, Label, GroupBox, DoubleSpinBox, PlainTextEdit, MessageBox
 from ui.ui_src import ui_resources
@@ -215,10 +216,7 @@ class FbaConfigWindow(QDialog):
         self.strategy_combo.setCurrentIndex(idx if idx >= 0 else 0)
 
     def _init_weighting_combo(self):
-        val = self.load_config.get("weighting", "A")
-        # 兼容旧配置中的 None
-        if val in ("None", "Z"):
-            val = "Z（None）"
+        val = weighting_to_display_label(self.load_config.get("weighting", "A"), default="A")
         idx = self.weighting_combo.findText(val)
         # 默认选 A (索引通常是 1，取决于 addItems 的顺序)
         self.weighting_combo.setCurrentIndex(idx if idx >= 0 else 1)

--- a/ui/ui_analysis_config/fr_config_dialog.py
+++ b/ui/ui_analysis_config/fr_config_dialog.py
@@ -8,6 +8,7 @@ from PyQt5.QtWidgets import QDialog, QHBoxLayout, QVBoxLayout
 
 from consts.running_consts import DEFAULT_DIR
 from ui.custom_ui_widget.popuputils import PopupUtils
+from ui.ui_analysis_config.config_normalization import normalize_octave_smoothing
 from ui.ui_analysis_config.threshold_config_widget import ThresholdConfigWidget
 from ui.custom_ui_widget.widgets import CheckBox, ComboBox, Label, PushButton
 from ui.ui_src import ui_resources
@@ -47,11 +48,7 @@ class FrConfigWindow(QDialog):
         self.smooth_combo_box = ComboBox()
         self.smooth_combo_box.addItems(list(self.OCTAVE_SMOOTHING_LABELS.keys()))
 
-        selected_oct = self.load_config.get("octave_smoothing", None)
-        if selected_oct is None:
-            # Backward-compatible: legacy boolean smooth_checked -> default to 1/6 Oct
-            selected_oct = 6 if self.load_config.get("smooth_checked", False) else 0
-        selected_oct = int(selected_oct)
+        selected_oct = normalize_octave_smoothing(self.load_config, default=0)
         selected_label = next(
             (k for k, v in self.OCTAVE_SMOOTHING_LABELS.items() if v == selected_oct),
             "不平滑",

--- a/ui/ui_analysis_config/spl_config_dialog.py
+++ b/ui/ui_analysis_config/spl_config_dialog.py
@@ -12,6 +12,7 @@ from PyQt5.QtWidgets import QDialog, QHBoxLayout, QVBoxLayout
 from consts.running_consts import DEFAULT_DIR
 from ui.custom_ui_widget.popuputils import PopupUtils
 from ui.custom_ui_widget.widgets import CheckBox, GroupBox, Label, PushButton, ComboBox, RadioButton
+from ui.ui_analysis_config.config_normalization import normalize_octave_smoothing, weighting_to_display_label
 from ui.ui_analysis_config.threshold_config_widget import ThresholdConfigWidget
 from ui.ui_src import ui_resources
 
@@ -103,10 +104,7 @@ class SplConfigWindow(QDialog):
             # SPLF: octave smoothing dropdown (frequency-domain)
             self.smooth_combo_box = ComboBox()
             self.smooth_combo_box.addItems(list(self.OCTAVE_SMOOTHING_LABELS.keys()))
-            selected_oct = self.load_config.get("octave_smoothing", None)
-            if selected_oct is None:
-                selected_oct = 6 if self.load_config.get("smooth_checked", False) else 0
-            selected_oct = int(selected_oct)
+            selected_oct = normalize_octave_smoothing(self.load_config, default=0)
             selected_label = next(
                 (k for k, v in self.OCTAVE_SMOOTHING_LABELS.items() if v == selected_oct),
                 "不平滑",
@@ -128,9 +126,7 @@ class SplConfigWindow(QDialog):
         weighting_label = Label("计权方式:")
         self.weighting_combo = ComboBox()
         self.weighting_combo.addItems(["Z（None）", "A", "B", "C", "D"])
-        weighting_value = self.load_config.get("weighting", "Z（None）")
-        if weighting_value in ["None", "Z"]:
-            weighting_value = "Z（None）"
+        weighting_value = weighting_to_display_label(self.load_config.get("weighting", "Z"))
         index = self.weighting_combo.findText(weighting_value)
         if index >= 0:
             self.weighting_combo.setCurrentIndex(index)

--- a/unit_test/ui/test_analysis_config_normalization.py
+++ b/unit_test/ui/test_analysis_config_normalization.py
@@ -1,0 +1,114 @@
+import pytest
+
+from ui.ui_analysis_config.config_normalization import (
+    CONFIG_CONCEPTS,
+    normalize_analysis_channel,
+    normalize_octave_smoothing,
+    normalize_time_smoothing,
+    normalize_weighting,
+    weighting_to_display_label,
+)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, "Z"),
+        ("", "Z"),
+        ("None", "Z"),
+        ("Z（None）", "Z"),
+        ("z", "Z"),
+        ("A", "A"),
+        ("b", "B"),
+        ("bad", "Z"),
+    ],
+)
+def test_normalize_weighting_returns_canonical_value(value, expected):
+    assert normalize_weighting(value) == expected
+
+
+def test_normalize_weighting_honors_valid_default():
+    assert normalize_weighting("bad", default="A") == "A"
+
+
+def test_weighting_to_display_label_uses_legacy_none_label():
+    assert weighting_to_display_label("None") == "Z（None）"
+    assert weighting_to_display_label("C") == "C"
+
+
+def test_normalize_octave_smoothing_prefers_explicit_key():
+    cfg = {"octave_smoothing": 3, "smooth_checked": True}
+
+    assert normalize_octave_smoothing(cfg) == 3
+
+
+def test_normalize_octave_smoothing_supports_legacy_smooth_checked():
+    assert normalize_octave_smoothing({"smooth_checked": True}) == 6
+    assert normalize_octave_smoothing({"smooth_checked": False}) == 0
+
+
+def test_normalize_octave_smoothing_rejects_unsupported_values():
+    assert normalize_octave_smoothing({"octave_smoothing": 5}, default=0) == 0
+    assert normalize_octave_smoothing({"octave_smoothing": "bad"}, default=3) == 3
+
+
+def test_normalize_time_smoothing_returns_stable_internal_shape():
+    cfg = {
+        "smooth_enabled": True,
+        "smooth_unit": "points",
+        "smooth_time_sec": "0.125",
+        "smooth_points": "32",
+        "smooth_algo": "3",
+    }
+
+    assert normalize_time_smoothing(cfg) == {
+        "enabled": True,
+        "unit": "points",
+        "time_sec": 0.125,
+        "points": 32,
+        "algo": 3,
+    }
+
+
+def test_normalize_time_smoothing_accepts_legacy_smooth_checked():
+    normalized = normalize_time_smoothing({"smooth_checked": True})
+
+    assert normalized["enabled"] is True
+    assert normalized["unit"] == "time"
+
+
+def test_normalize_analysis_channel_uses_selected_available_channel():
+    assert normalize_analysis_channel({"analysis_channel": "2"}, [0, 2, 4]) == 2
+
+
+@pytest.mark.parametrize(
+    ("cfg", "available_channels", "expected"),
+    [
+        ({"analysis_channel": "bad"}, [3, 5], 3),
+        ({"analysis_channel": 4}, [0, 1], 0),
+        ({}, [2, 1], 1),
+        ({"analysis_channel": 5}, ["bad", 5], 5),
+        ({"analysis_channel": 5}, ["bad"], 0),
+        ({"analysis_channel": 9}, [], 0),
+        (None, None, 0),
+    ],
+)
+def test_normalize_analysis_channel_falls_back_safely(cfg, available_channels, expected):
+    assert normalize_analysis_channel(cfg, available_channels) == expected
+
+
+def test_config_concepts_document_step_one_taxonomy():
+    expected_concepts = {
+        "analysis_channel",
+        "weighting",
+        "frequency_smoothing",
+        "time_smoothing",
+        "threshold_curve",
+        "reference_threshold",
+        "golden_sample",
+        "harmonic_selection",
+    }
+
+    assert expected_concepts.issubset(CONFIG_CONCEPTS)
+    assert "octave_smoothing" in CONFIG_CONCEPTS["frequency_smoothing"]["legacy_keys"]
+    assert "smooth_enabled" in CONFIG_CONCEPTS["time_smoothing"]["legacy_keys"]


### PR DESCRIPTION
## Summary

- Add a shared analysis config normalization module for Step 1 taxonomy and compatibility rules.
- Normalize legacy weighting, octave smoothing, time smoothing, and analysis channel values without changing persisted dialog output keys.
- Reuse the helpers in SPL, FR, and FBA dialog loading paths.
- Add focused tests for compatibility behavior and taxonomy coverage.

## Related Issue

Closes #736

## Changes

- `ui/ui_analysis_config/config_normalization.py`: Added taxonomy constants and normalization helpers.
- `ui/ui_analysis_config/spl_config_dialog.py`: Uses helpers for SPLF smoothing and weighting display loading.
- `ui/ui_analysis_config/fr_config_dialog.py`: Uses helper for octave smoothing loading.
- `ui/ui_analysis_config/fba_config_dialog.py`: Uses helper for weighting display loading.
- `unit_test/ui/test_analysis_config_normalization.py`: Added unit coverage for compatibility rules.

## Test Plan

- [x] `python -m pytest unit_test/ui/test_analysis_config_normalization.py`
- [x] `python -m py_compile ui/ui_analysis_config/config_normalization.py ui/ui_analysis_config/spl_config_dialog.py ui/ui_analysis_config/fr_config_dialog.py ui/ui_analysis_config/fba_config_dialog.py unit_test/ui/test_analysis_config_normalization.py`
- [ ] `python -m pytest unit_test/ui/test_signal_analysis_channel.py` was attempted but timed out during collection in this environment.
- [ ] `python -m pytest unit_test/ui/test_sequence_channel_calibration.py` was attempted but collection failed because `concurrent_log_handler` is not installed in this environment.

## Checklist

- [x] Code follows the existing project style.
- [x] Persisted config keys remain unchanged.
- [x] `plan.md` and other local planning files are not included.