### PR TITLE
refactor(analysis-config): add shared UI widgets

### DIFF
--- a/ui/ui_analysis_config/ai_config_dialog.py
+++ b/ui/ui_analysis_config/ai_config_dialog.py
@@ -1,71 +1,40 @@
 from typing import List, Optional
 
-from PyQt5.QtCore import Qt, QTimer
-from PyQt5.QtGui import QIcon
-from PyQt5.QtWidgets import QDialog, QHBoxLayout, QVBoxLayout, QSizePolicy
+from PyQt5.QtCore import QTimer
+from PyQt5.QtWidgets import QHBoxLayout, QVBoxLayout, QSizePolicy
 
 from base.training_model_management import TrainingModelManagement
 from consts import error_code
 from consts.running_consts import DEFAULT_DIR
 from ui.custom_ui_widget.popuputils import PopupUtils
-from ui.custom_ui_widget.widgets import PushButton, ComboBox, Label, GroupBox, MessageBox
+from ui.custom_ui_widget.widgets import ComboBox, Label, GroupBox, MessageBox
+from ui.ui_analysis_config.common_widgets import AnalysisConfigDialogBase, ChannelSelectorWidget
 from ui.ui_src import ui_resources
 
 
-class AIConfigWindow(QDialog):
+class AIConfigWindow(AnalysisConfigDialogBase):
     def __init__(self, config_manager, model_type, signal_len=None, available_channels: Optional[List[int]] = None):
-        super().__init__()
+        super().__init__(disable_close_button=True)
         self.signal_len = signal_len
         self.config_manager = config_manager
         self.model_list = self.load_model_name_from_db()
         self.load_config = self.config_manager.load_config().get(model_type, {})
         self.show_channel_selector = available_channels is not None
-        self.available_channels = self._normalize_available_channels(available_channels)
+        self.available_channels = available_channels
         self.init_ui()
 
-    @staticmethod
-    def _normalize_available_channels(available_channels):
-        channels = []
-        try:
-            channels = sorted({int(ch) for ch in (available_channels or [])})
-        except Exception:
-            channels = []
-        if not channels:
-            channels = [0]
-        return channels
-
     def init_ui(self):
-        self.setWindowFlag(Qt.WindowCloseButtonHint, False)
-        self.setWindowFlag(Qt.WindowContextHelpButtonHint, False)
-        self.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
         self.setMinimumSize(200, 300)
         layout = QVBoxLayout()
         if self.show_channel_selector:
-            layout.addLayout(self.create_channel_layout())
+            self.channel_selector = ChannelSelectorWidget(self.load_config, self.available_channels, self)
+            layout.addWidget(self.channel_selector)
         model_box = self.create_model_layout()
         btn_layout = self.create_btn()
         layout.addWidget(model_box)
         layout.addStretch()
         layout.addLayout(btn_layout)
         self.setLayout(layout)
-
-    def create_channel_layout(self):
-        channel_label = Label("通道:")
-        self.channel_combo_box = ComboBox(self)
-        for ch in self.available_channels:
-            self.channel_combo_box.addItem(f"In{int(ch) + 1}", int(ch))
-
-        saved_channel = self.load_config.get("analysis_channel", None)
-        if saved_channel is None or int(saved_channel) not in self.available_channels:
-            saved_channel = int(self.available_channels[0])
-        idx = self.channel_combo_box.findData(int(saved_channel))
-        self.channel_combo_box.setCurrentIndex(idx if idx >= 0 else 0)
-
-        channel_layout = QHBoxLayout()
-        channel_layout.addWidget(channel_label)
-        channel_layout.addWidget(self.channel_combo_box)
-        channel_layout.setSpacing(10)
-        return channel_layout
 
     def cheack_model_list(self):
         if self.analyse_model_combo_box.count() == 0:
@@ -105,21 +74,13 @@ class AIConfigWindow(QDialog):
         return model_list
 
     def create_btn(self):
-        btn_layout = QHBoxLayout()
-        default_btn = PushButton(" 设为默认 ")
-        default_btn.clicked.connect(self.on_default_btn_clicked)
-        ok_btn = PushButton(" 确  认 ")
-        ok_btn.clicked.connect(self.on_click_ok_btn)
-        btn_layout.addWidget(default_btn)
-        btn_layout.addStretch()
-        btn_layout.addWidget(ok_btn)
-        return btn_layout
+        return self.create_standard_button_layout(self.on_default_btn_clicked, self.on_click_ok_btn)
 
     def get_default_config(self):
         default_config = {
             "analyse_model_name": self.analyse_model_combo_box.currentText(),
-            "analysis_channel": int(self.channel_combo_box.currentData())
-            if self.show_channel_selector and hasattr(self, "channel_combo_box")
+            "analysis_channel": self.channel_selector.current_channel()
+            if self.show_channel_selector and hasattr(self, "channel_selector")
             else int(self.load_config.get("analysis_channel", 0) or 0),
         }
         return default_config

--- a/ui/ui_analysis_config/common_widgets.py
+++ b/ui/ui_analysis_config/common_widgets.py
@@ -1,0 +1,389 @@
+"""Shared widgets for analysis configuration dialogs."""
+
+from __future__ import annotations
+
+from functools import partial
+from typing import Any
+
+from PyQt5.QtCore import Qt, pyqtSignal
+from PyQt5.QtGui import QIcon
+from PyQt5.QtWidgets import (
+    QButtonGroup,
+    QDialog,
+    QHBoxLayout,
+    QScrollArea,
+    QSizePolicy,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ui.custom_ui_widget.popuputils import PopupUtils
+from ui.custom_ui_widget.widgets import CheckBox, ComboBox, DoubleSpinBox, Label, PushButton, RadioButton, SpinBox
+from ui.ui_analysis_config.config_normalization import (
+    OCTAVE_SMOOTHING_OPTIONS,
+    WEIGHTING_OPTIONS,
+    normalize_analysis_channel,
+    normalize_octave_smoothing,
+    normalize_time_smoothing,
+    normalize_weighting,
+    weighting_to_display_label,
+)
+from ui.ui_src import ui_resources
+
+
+OCTAVE_SMOOTHING_LABELS = {
+    0: "不平滑",
+    1: "1/1 Oct",
+    3: "1/3 Oct",
+    6: "1/6 Oct",
+    12: "1/12 Oct",
+    24: "1/24 Oct",
+    48: "1/48 Oct",
+}
+
+
+class AnalysisConfigDialogBase(QDialog):
+    """Base dialog helpers for analysis configuration windows."""
+
+    def __init__(self, *args, disable_close_button: bool = False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.apply_standard_window_flags(disable_close_button=disable_close_button)
+
+    def apply_standard_window_flags(self, disable_close_button: bool = True) -> None:
+        if disable_close_button:
+            self.setWindowFlag(Qt.WindowCloseButtonHint, False)
+        self.setWindowFlag(Qt.WindowContextHelpButtonHint, False)
+        self.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
+
+    def create_standard_button_layout(self, default_callback, ok_callback) -> QHBoxLayout:
+        btn_layout = QHBoxLayout()
+        default_btn = PushButton(" 设为默认 ")
+        default_btn.clicked.connect(default_callback)
+        ok_btn = PushButton(" 确  认 ")
+        ok_btn.clicked.connect(ok_callback)
+        btn_layout.addWidget(default_btn)
+        btn_layout.addStretch()
+        btn_layout.addWidget(ok_btn)
+        return btn_layout
+
+    def show_default_save_popup(self, success_flag: bool) -> None:
+        PopupUtils().save_popup(self, success_flag=success_flag)
+
+
+class ChannelSelectorWidget(QWidget):
+    """Channel selector that preserves the legacy analysis_channel key."""
+
+    def __init__(self, cfg: dict[str, Any] | None = None, available_channels=None, parent=None):
+        super().__init__(parent)
+        self.available_channels = self._normalize_available_channels(available_channels)
+        self.combo_box = ComboBox(self)
+        for ch in self.available_channels:
+            self.combo_box.addItem(f"In{int(ch) + 1}", int(ch))
+
+        selected = normalize_analysis_channel(cfg, self.available_channels)
+        selected_idx = self.combo_box.findData(selected)
+        self.combo_box.setCurrentIndex(selected_idx if selected_idx >= 0 else 0)
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(Label("通道:"))
+        layout.addWidget(self.combo_box)
+        layout.addStretch()
+
+    @staticmethod
+    def _normalize_available_channels(available_channels) -> list[int]:
+        channels = []
+        for ch in available_channels or []:
+            try:
+                channels.append(int(ch))
+            except (TypeError, ValueError):
+                continue
+        channels = sorted(set(channels))
+        return channels or [0]
+
+    def current_channel(self) -> int:
+        return int(self.combo_box.currentData())
+
+    def get_config(self) -> dict[str, int]:
+        return {"analysis_channel": self.current_channel()}
+
+
+class WeightingSelectorWidget(QWidget):
+    """Weighting selector that displays Z as Z(None) but saves canonical values."""
+
+    def __init__(
+        self,
+        cfg: dict[str, Any] | None = None,
+        allowed_options: tuple[str, ...] | list[str] = WEIGHTING_OPTIONS,
+        default: str = "Z",
+        parent=None,
+    ):
+        super().__init__(parent)
+        self.allowed_options = tuple(normalize_weighting(option) for option in allowed_options)
+        if not self.allowed_options:
+            self.allowed_options = ("Z",)
+        normalized_default = normalize_weighting(default)
+        if normalized_default not in self.allowed_options:
+            normalized_default = self.allowed_options[0]
+
+        self.combo_box = ComboBox(self)
+        for option in self.allowed_options:
+            self.combo_box.addItem(weighting_to_display_label(option), option)
+
+        selected = normalize_weighting((cfg or {}).get("weighting"), default=normalized_default)
+        if selected not in self.allowed_options:
+            selected = normalized_default
+        selected_idx = self.combo_box.findData(selected)
+        self.combo_box.setCurrentIndex(selected_idx if selected_idx >= 0 else 0)
+        self.combo_box.setSizePolicy(QSizePolicy.Maximum, QSizePolicy.Fixed)
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(Label("计权方式:"))
+        layout.addWidget(self.combo_box)
+        layout.addStretch()
+
+    def current_weighting(self) -> str:
+        return normalize_weighting(self.combo_box.currentData())
+
+    def get_config(self) -> dict[str, str]:
+        return {"weighting": self.current_weighting()}
+
+
+class OctaveSmoothingSelectorWidget(QWidget):
+    """Frequency-domain octave smoothing selector."""
+
+    def __init__(
+        self,
+        cfg: dict[str, Any] | None = None,
+        allowed_options: tuple[int, ...] | list[int] = OCTAVE_SMOOTHING_OPTIONS,
+        default: int = 0,
+        legacy_true_default: int = 6,
+        parent=None,
+    ):
+        super().__init__(parent)
+        self.allowed_options = tuple(option for option in allowed_options if option in OCTAVE_SMOOTHING_OPTIONS)
+        if not self.allowed_options:
+            self.allowed_options = (0,)
+        if default not in self.allowed_options:
+            default = self.allowed_options[0]
+
+        self.combo_box = ComboBox(self)
+        for option in self.allowed_options:
+            self.combo_box.addItem(OCTAVE_SMOOTHING_LABELS[option], option)
+
+        selected = normalize_octave_smoothing(cfg, default=default, legacy_true_default=legacy_true_default)
+        if selected not in self.allowed_options:
+            selected = default
+        selected_idx = self.combo_box.findData(selected)
+        self.combo_box.setCurrentIndex(selected_idx if selected_idx >= 0 else 0)
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(Label("平滑"))
+        layout.addWidget(self.combo_box)
+        layout.addStretch()
+
+    def current_octave_smoothing(self) -> int:
+        return int(self.combo_box.currentData())
+
+    def get_config(self) -> dict[str, int]:
+        return {"octave_smoothing": self.current_octave_smoothing()}
+
+
+class TimeSmoothingWidget(QWidget):
+    """Time or point smoothing control for event-detection style dialogs."""
+
+    def __init__(
+        self,
+        cfg: dict[str, Any] | None = None,
+        defaults: dict[str, Any] | None = None,
+        show_algorithm: bool = True,
+        parent=None,
+    ):
+        super().__init__(parent)
+        self.show_algorithm = show_algorithm
+        smoothing = normalize_time_smoothing(cfg, defaults)
+
+        self.enabled_checkbox = CheckBox("平滑")
+        self.enabled_checkbox.setChecked(smoothing["enabled"])
+
+        self.unit_combo = ComboBox(self)
+        self.unit_combo.addItem("时间(秒)", "time")
+        self.unit_combo.addItem("格点数", "points")
+        unit_idx = self.unit_combo.findData(smoothing["unit"])
+        self.unit_combo.setCurrentIndex(unit_idx if unit_idx >= 0 else 0)
+        self.unit_combo.currentIndexChanged.connect(self._update_unit_visibility)
+
+        self.time_spin = DoubleSpinBox(self)
+        self.time_spin.setRange(0.00, 999.00)
+        self.time_spin.setDecimals(4)
+        self.time_spin.setSingleStep(0.01)
+        self.time_spin.setValue(float(smoothing["time_sec"]))
+
+        self.points_spin = SpinBox(self)
+        self.points_spin.setRange(1, 99999)
+        self.points_spin.setValue(max(1, int(smoothing["points"])))
+
+        main_row = QHBoxLayout()
+        main_row.addWidget(self.enabled_checkbox)
+        main_row.addStretch()
+        main_row.addWidget(Label("单位:"))
+        main_row.addWidget(self.unit_combo)
+        main_row.addWidget(self.time_spin)
+        main_row.addWidget(self.points_spin)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addLayout(main_row)
+
+        self.algo_group = None
+        if show_algorithm:
+            self.algo_group = QButtonGroup(self)
+            algo_row = QHBoxLayout()
+            algo_row.addStretch()
+            algo_row.addWidget(Label("平滑算法:"))
+            algo_buttons = (
+                (RadioButton("平均"), 1),
+                (RadioButton("Golay"), 2),
+                (RadioButton("Gaussian"), 3),
+            )
+            for button, value in algo_buttons:
+                self.algo_group.addButton(button, value)
+                algo_row.addWidget(button)
+                if int(smoothing["algo"]) == value:
+                    button.setChecked(True)
+            if self.algo_group.checkedId() < 0:
+                self.algo_group.button(1).setChecked(True)
+            layout.addLayout(algo_row)
+
+        self._update_unit_visibility()
+
+    def _update_unit_visibility(self) -> None:
+        is_time = self.unit_combo.currentData() == "time"
+        self.time_spin.setVisible(is_time)
+        self.points_spin.setVisible(not is_time)
+
+    def get_config(self) -> dict[str, Any]:
+        config = {
+            "smooth_enabled": self.enabled_checkbox.isChecked(),
+            "smooth_unit": str(self.unit_combo.currentData()),
+            "smooth_time_sec": float(self.time_spin.value()),
+            "smooth_points": int(self.points_spin.value()),
+        }
+        if self.show_algorithm:
+            config["smooth_algo"] = int(self.algo_group.checkedId() or 1)
+        return config
+
+
+class GoldenSampleWidget(CheckBox):
+    """Golden sample checkbox that preserves golden_sample_checked."""
+
+    def __init__(self, cfg: dict[str, Any] | None = None, parent=None):
+        super().__init__("使用黄金样本", parent)
+        self.setChecked(bool((cfg or {}).get("golden_sample_checked", False)))
+
+    def is_checked(self) -> bool:
+        return self.isChecked()
+
+    def get_config(self) -> dict[str, bool]:
+        return {"golden_sample_checked": self.is_checked()}
+
+
+class HarmonicSelectorWidget(QWidget):
+    """Scrollable harmonic order selector with optional all-selected state."""
+
+    selected_labels_changed = pyqtSignal()
+
+    def __init__(self, cfg: dict[str, Any] | None = None, start_order: int = 2, end_order: int = 35, parent=None):
+        super().__init__(parent)
+        self.start_order = int(start_order)
+        self.end_order = int(end_order)
+        if self.end_order < self.start_order:
+            self.start_order, self.end_order = self.end_order, self.start_order
+
+        self._selected_labels = self._load_selected_labels(cfg)
+        self.scroll_area = QScrollArea(self)
+        self.scroll_area.setFixedSize(120, 150)
+        self.scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+
+        box_container = QWidget()
+        self.box_layout = QVBoxLayout()
+        for order in self._all_orders():
+            label = Label("  " + str(order))
+            label.setMinimumWidth(90)
+            label.setMinimumHeight(25)
+            label.setAlignment(Qt.AlignLeft)
+            label.mousePressEvent = partial(self._on_label_click, label)
+            if order in self._selected_labels:
+                label.setText("\u2713" + str(order))
+            self.box_layout.addWidget(label)
+        box_container.setLayout(self.box_layout)
+        self.scroll_area.setWidget(box_container)
+
+        self.select_all_check = CheckBox("全选")
+        self.select_all_check.setChecked(bool((cfg or {}).get("all_checked", False)))
+        self.select_all_check.stateChanged.connect(self._on_select_all_changed)
+        if self.select_all_check.isChecked():
+            self._selected_labels = self._all_orders()
+            self._sync_labels()
+            self.scroll_area.setDisabled(True)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self.scroll_area)
+        layout.addStretch()
+        layout.addWidget(self.select_all_check)
+
+    def _all_orders(self) -> list[int]:
+        return list(range(self.start_order, self.end_order + 1))
+
+    def _load_selected_labels(self, cfg: dict[str, Any] | None) -> list[int]:
+        selected = []
+        for value in (cfg or {}).get("selected_labels", []):
+            try:
+                order = int(value)
+            except (TypeError, ValueError):
+                continue
+            if self.start_order <= order <= self.end_order:
+                selected.append(order)
+        return sorted(set(selected))
+
+    def _on_select_all_changed(self, state) -> None:
+        if state == Qt.Checked:
+            self.scroll_area.setDisabled(True)
+            self._selected_labels = self._all_orders()
+        else:
+            self.scroll_area.setDisabled(False)
+            self._selected_labels = []
+        self._sync_labels()
+        self.selected_labels_changed.emit()
+
+    def _on_label_click(self, label, event) -> None:
+        order = int("".join(filter(str.isdigit, label.text())))
+        if order in self._selected_labels:
+            self._selected_labels.remove(order)
+        else:
+            self._selected_labels.append(order)
+            self._selected_labels.sort()
+        self._sync_labels()
+        self.selected_labels_changed.emit()
+
+    def _sync_labels(self) -> None:
+        selected = set(self._selected_labels)
+        for i in range(self.box_layout.count()):
+            label = self.box_layout.itemAt(i).widget()
+            order = int("".join(filter(str.isdigit, label.text())))
+            label.setText(("\u2713" if order in selected else "  ") + str(order))
+
+    def selected_labels(self) -> list[int]:
+        return list(self._selected_labels)
+
+    def all_checked(self) -> bool:
+        return self.select_all_check.isChecked()
+
+    def get_config(self) -> dict[str, Any]:
+        return {
+            "selected_labels": self.selected_labels(),
+            "all_checked": self.all_checked(),
+        }

--- a/ui/ui_analysis_config/lp_config_dialog.py
+++ b/ui/ui_analysis_config/lp_config_dialog.py
@@ -1,53 +1,27 @@
 from typing import List, Optional
 
 from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QIcon
-from PyQt5.QtWidgets import QDialog, QHBoxLayout, QVBoxLayout
+from PyQt5.QtWidgets import QHBoxLayout, QVBoxLayout
 
 from consts.running_consts import DEFAULT_DIR
 from ui.custom_ui_widget.popuputils import PopupUtils
-from ui.custom_ui_widget.widgets import GroupBox, Label, PushButton, SpinBox, ComboBox
+from ui.custom_ui_widget.widgets import GroupBox, Label, SpinBox
+from ui.ui_analysis_config.common_widgets import AnalysisConfigDialogBase, ChannelSelectorWidget
 from ui.ui_src import ui_resources
 
 
-class LPConfigWindow(QDialog):
+class LPConfigWindow(AnalysisConfigDialogBase):
     def __init__(self, config_manager, model_type, available_channels: Optional[List[int]] = None):
         super().__init__()
         self.config_manager = config_manager
         self.load_config = self.config_manager.load_config().get(model_type, {})
         self.show_channel_selector = available_channels is not None
-        self.available_channels = self._normalize_available_channels(available_channels)
+        self.available_channels = available_channels
 
         self.init_ui()
 
-    @staticmethod
-    def _normalize_available_channels(available_channels):
-        channels = []
-        try:
-            channels = sorted({int(ch) for ch in (available_channels or [])})
-        except Exception:
-            channels = []
-        if not channels:
-            channels = [0]
-        return channels
-
-    def _create_channel_layout(self):
-        channel_layout = QHBoxLayout()
-        channel_layout.addWidget(Label("通道:"))
-        self.channel_combo_box = ComboBox()
-        for ch in self.available_channels:
-            self.channel_combo_box.addItem(f"In{int(ch) + 1}", int(ch))
-        saved_channel = self.load_config.get("analysis_channel", None)
-        if saved_channel is None or int(saved_channel) not in self.available_channels:
-            saved_channel = int(self.available_channels[0])
-        idx = self.channel_combo_box.findData(int(saved_channel))
-        self.channel_combo_box.setCurrentIndex(idx if idx >= 0 else 0)
-        channel_layout.addWidget(self.channel_combo_box)
-        return channel_layout
-
     def init_ui(self):
         self.setMinimumSize(350, 350)
-        self.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
         layout = QVBoxLayout()
         lp_config_box = self.create_lp_config_box()
         btn_layout = self.create_btn_layout()
@@ -60,7 +34,8 @@ class LPConfigWindow(QDialog):
         lp_config_box = GroupBox("松散颗粒参数配置")
         lp_config_box_layout = QVBoxLayout()
         if self.show_channel_selector:
-            lp_config_box_layout.addLayout(self._create_channel_layout())
+            self.channel_selector = ChannelSelectorWidget(self.load_config, self.available_channels, self)
+            lp_config_box_layout.addWidget(self.channel_selector)
             lp_config_box_layout.addStretch()
         trigger_threshold_layout = self.create_trigger_threshold_layout()
         comfirm_threshold_layout = self.create_confirm_threshold_layout()
@@ -161,16 +136,7 @@ class LPConfigWindow(QDialog):
         return stimulus_max_frequency_layout
 
     def create_btn_layout(self):
-        btn_layout = QHBoxLayout()
-        default_btn = PushButton("设为默认")
-        ok_btn = PushButton(" 确  定 ")
-        default_btn.clicked.connect(self.on_click_default_btn)
-        ok_btn.clicked.connect(self.on_click_ok_btn)
-        btn_layout.addWidget(default_btn)
-        btn_layout.addStretch()
-        btn_layout.addWidget(ok_btn)
-
-        return btn_layout
+        return self.create_standard_button_layout(self.on_click_default_btn, self.on_click_ok_btn)
 
     def get_default_config(self):
         default_config = {
@@ -180,8 +146,8 @@ class LPConfigWindow(QDialog):
             "max_check_duration": self.max_check_duration_spinbox.value(),
             "loose_particle_num": self.loose_particle_num_spinbox.value(),
             "cutoff_freq": self.stimulus_max_frequency_spinbox.value(),
-            "analysis_channel": int(self.channel_combo_box.currentData())
-            if self.show_channel_selector and hasattr(self, "channel_combo_box")
+            "analysis_channel": self.channel_selector.current_channel()
+            if self.show_channel_selector and hasattr(self, "channel_selector")
             else int(self.load_config.get("analysis_channel", 0) or 0),
         }
         return default_config

--- a/ui/ui_analysis_config/spec_config_dialog.py
+++ b/ui/ui_analysis_config/spec_config_dialog.py
@@ -1,59 +1,31 @@
 from typing import List, Optional
 
 from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QIcon
-from PyQt5.QtWidgets import QDialog, QHBoxLayout, QVBoxLayout
+from PyQt5.QtWidgets import QHBoxLayout, QVBoxLayout
 
 from consts.running_consts import DEFAULT_DIR
 from ui.custom_ui_widget.popuputils import PopupUtils
-from ui.custom_ui_widget.widgets import CheckBox, GroupBox, Label, PushButton, ComboBox, SpinBox, MessageBox
+from ui.custom_ui_widget.widgets import CheckBox, GroupBox, Label, ComboBox, SpinBox, MessageBox
+from ui.ui_analysis_config.common_widgets import AnalysisConfigDialogBase, ChannelSelectorWidget
 from ui.ui_src import ui_resources
 
 
-class SpecConfigWindow(QDialog):
+class SpecConfigWindow(AnalysisConfigDialogBase):
     def __init__(self, config_manager, model_type, available_channels: Optional[List[int]] = None):
-        super().__init__()
+        super().__init__(disable_close_button=True)
         self.config_manager = config_manager
         self.load_config = self.config_manager.load_config().get(model_type, {})
         self.show_channel_selector = available_channels is not None
-        self.available_channels = self._normalize_available_channels(available_channels)
+        self.available_channels = available_channels
         self.init_ui()
 
-    @staticmethod
-    def _normalize_available_channels(available_channels):
-        channels = []
-        try:
-            channels = sorted({int(ch) for ch in (available_channels or [])})
-        except Exception:
-            channels = []
-        if not channels:
-            channels = [0]
-        return channels
-
-    def _create_channel_layout(self):
-        channel_layout = QHBoxLayout()
-        channel_layout.addWidget(Label("通道:"))
-        self.channel_combo_box = ComboBox()
-        for ch in self.available_channels:
-            self.channel_combo_box.addItem(f"In{int(ch) + 1}", int(ch))
-        saved_channel = self.load_config.get("analysis_channel", None)
-        if saved_channel is None or int(saved_channel) not in self.available_channels:
-            saved_channel = int(self.available_channels[0])
-        idx = self.channel_combo_box.findData(int(saved_channel))
-        self.channel_combo_box.setCurrentIndex(idx if idx >= 0 else 0)
-        channel_layout.addWidget(self.channel_combo_box)
-        channel_layout.addStretch()
-        return channel_layout
-
     def init_ui(self):
-        self.setWindowFlag(Qt.WindowCloseButtonHint, False)
-        self.setWindowFlag(Qt.WindowContextHelpButtonHint, False)
-        self.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
         self.setMinimumSize(350, 350)
         self.resize(350, 420)
         layout = QVBoxLayout()
         if self.show_channel_selector:
-            layout.addLayout(self._create_channel_layout())
+            self.channel_selector = ChannelSelectorWidget(self.load_config, self.available_channels, self)
+            layout.addWidget(self.channel_selector)
         spec_param_group_box = GroupBox("频谱图参数配置")
         param_layout = self.create_spec_param()
         spec_param_group_box.setLayout(param_layout)
@@ -164,15 +136,7 @@ class SpecConfigWindow(QDialog):
         return param_layout
 
     def create_btn(self):
-        btn_layout = QHBoxLayout()
-        default_btn = PushButton(" 设为默认 ")
-        default_btn.clicked.connect(self.on_default_btn_clicked)
-        ok_btn = PushButton(" 确  认 ")
-        ok_btn.clicked.connect(self.on_click_ok_btn)
-        btn_layout.addWidget(default_btn)
-        btn_layout.addStretch()
-        btn_layout.addWidget(ok_btn)
-        return btn_layout
+        return self.create_standard_button_layout(self.on_default_btn_clicked, self.on_click_ok_btn)
 
     def on_custom_limit_checkbox_changed(self, state):
         if state == Qt.Checked:
@@ -190,8 +154,8 @@ class SpecConfigWindow(QDialog):
             "top_limit": self.top_limit_spinbox.value(),
             "bottom_limit": self.bottom_limit_spinbox.value(),
             "custom_limit": self.custom_limit_checkbox.isChecked(),
-            "analysis_channel": int(self.channel_combo_box.currentData())
-            if self.show_channel_selector and hasattr(self, "channel_combo_box")
+            "analysis_channel": self.channel_selector.current_channel()
+            if self.show_channel_selector and hasattr(self, "channel_selector")
             else int(self.load_config.get("analysis_channel", 0) or 0),
         }
         if default_config["custom_limit"] and default_config["top_limit"] <= default_config["bottom_limit"]:

--- a/unit_test/ui/test_analysis_config_common_widgets.py
+++ b/unit_test/ui/test_analysis_config_common_widgets.py
@@ -1,0 +1,136 @@
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QApplication
+
+from ui.ui_analysis_config.common_widgets import (
+    ChannelSelectorWidget,
+    GoldenSampleWidget,
+    HarmonicSelectorWidget,
+    OctaveSmoothingSelectorWidget,
+    TimeSmoothingWidget,
+    WeightingSelectorWidget,
+)
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return QApplication.instance() or QApplication([])
+
+
+def test_channel_selector_uses_available_channel(qapp):
+    widget = ChannelSelectorWidget({"analysis_channel": "2"}, [0, 2, 4])
+
+    assert widget.current_channel() == 2
+    assert widget.get_config() == {"analysis_channel": 2}
+
+
+@pytest.mark.parametrize(
+    ("cfg", "available_channels", "expected"),
+    [
+        ({"analysis_channel": "bad"}, [3, 5], 3),
+        ({"analysis_channel": 4}, [0, 1], 0),
+        ({}, [], 0),
+        (None, None, 0),
+    ],
+)
+def test_channel_selector_falls_back_safely(qapp, cfg, available_channels, expected):
+    widget = ChannelSelectorWidget(cfg, available_channels)
+
+    assert widget.current_channel() == expected
+
+
+def test_weighting_selector_saves_z_for_none_display(qapp):
+    widget = WeightingSelectorWidget({"weighting": "Z（None）"}, allowed_options=("Z", "A", "C"), default="A")
+
+    assert widget.combo_box.currentText() == "Z（None）"
+    assert widget.current_weighting() == "Z"
+    assert widget.get_config() == {"weighting": "Z"}
+
+
+def test_weighting_selector_respects_allowed_options(qapp):
+    widget = WeightingSelectorWidget({"weighting": "B"}, allowed_options=("Z", "A", "C"), default="A")
+
+    assert widget.current_weighting() == "A"
+
+
+def test_octave_smoothing_selector_reads_explicit_key(qapp):
+    widget = OctaveSmoothingSelectorWidget({"octave_smoothing": 3})
+
+    assert widget.current_octave_smoothing() == 3
+    assert widget.get_config() == {"octave_smoothing": 3}
+
+
+def test_octave_smoothing_selector_reads_legacy_smooth_checked(qapp):
+    widget = OctaveSmoothingSelectorWidget({"smooth_checked": True})
+
+    assert widget.current_octave_smoothing() == 6
+
+
+def test_octave_smoothing_selector_supports_option_subset(qapp):
+    widget = OctaveSmoothingSelectorWidget({"octave_smoothing": 12}, allowed_options=(0, 3, 6), default=0)
+
+    assert widget.current_octave_smoothing() == 0
+
+
+def test_time_smoothing_widget_outputs_legacy_keys(qapp):
+    widget = TimeSmoothingWidget(
+        {
+            "smooth_enabled": True,
+            "smooth_unit": "points",
+            "smooth_time_sec": 0.125,
+            "smooth_points": 32,
+            "smooth_algo": 3,
+        }
+    )
+
+    assert widget.get_config() == {
+        "smooth_enabled": True,
+        "smooth_unit": "points",
+        "smooth_time_sec": 0.125,
+        "smooth_points": 32,
+        "smooth_algo": 3,
+    }
+    assert widget.time_spin.isHidden() is True
+    assert widget.points_spin.isHidden() is False
+
+
+def test_time_smoothing_widget_can_hide_algorithm(qapp):
+    widget = TimeSmoothingWidget({"smooth_enabled": True}, show_algorithm=False)
+
+    assert "smooth_algo" not in widget.get_config()
+
+
+def test_golden_sample_widget_outputs_legacy_key(qapp):
+    widget = GoldenSampleWidget({"golden_sample_checked": True})
+
+    assert widget.is_checked() is True
+    assert widget.get_config() == {"golden_sample_checked": True}
+
+
+def test_harmonic_selector_filters_to_range(qapp):
+    widget = HarmonicSelectorWidget({"selected_labels": [1, 2, "3", 40]}, start_order=2, end_order=35)
+
+    assert widget.selected_labels() == [2, 3]
+    assert widget.get_config() == {"selected_labels": [2, 3], "all_checked": False}
+
+
+def test_harmonic_selector_all_checked_selects_range(qapp):
+    widget = HarmonicSelectorWidget({"selected_labels": [10], "all_checked": True}, start_order=10, end_order=12)
+
+    assert widget.selected_labels() == [10, 11, 12]
+    assert widget.all_checked() is True
+    assert widget.scroll_area.isEnabled() is False
+
+
+def test_harmonic_selector_toggle_label_updates_selection(qapp):
+    widget = HarmonicSelectorWidget({"selected_labels": [2]}, start_order=2, end_order=3)
+    first_label = widget.box_layout.itemAt(0).widget()
+
+    first_label.mousePressEvent(None)
+
+    assert widget.selected_labels() == []
+    assert first_label.text().startswith("  ")

--- a/unit_test/ui/test_analysis_config_dialog_migration.py
+++ b/unit_test/ui/test_analysis_config_dialog_migration.py
@@ -1,0 +1,115 @@
+import os
+import sys
+import types
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+from PyQt5.QtWidgets import QApplication
+
+from consts import error_code
+
+
+class FakeConfigManager:
+    def __init__(self, config):
+        self.config = config
+        self.saved = []
+
+    def load_config(self):
+        return self.config
+
+    def save_default_config(self, model_type, config_data):
+        self.saved.append((model_type, config_data))
+        return True
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return QApplication.instance() or QApplication([])
+
+
+def test_ai_dialog_uses_shared_channel_selector_without_changing_config(qapp, monkeypatch):
+    class FakeTrainingModelManagement:
+        def get_all_model_name_from_db(self):
+            return error_code.OK, [("model_a", "1024 samples")]
+
+    monkeypatch.setitem(
+        sys.modules,
+        "base.training_model_management",
+        types.SimpleNamespace(TrainingModelManagement=FakeTrainingModelManagement),
+    )
+    from ui.ui_analysis_config import ai_config_dialog
+
+    monkeypatch.setattr(ai_config_dialog, "TrainingModelManagement", FakeTrainingModelManagement)
+    config_manager = FakeConfigManager({"AI": {"analyse_model_name": "model_a", "analysis_channel": 2}})
+
+    window = ai_config_dialog.AIConfigWindow(config_manager, "AI", available_channels=[0, 2])
+
+    assert window.get_default_config() == {
+        "analyse_model_name": "model_a",
+        "analysis_channel": 2,
+    }
+
+
+def test_lp_dialog_preserves_saved_keys_after_channel_migration(qapp):
+    from ui.ui_analysis_config.lp_config_dialog import LPConfigWindow
+
+    config_manager = FakeConfigManager(
+        {
+            "LP": {
+                "trigger_threshold": 12,
+                "hysterests_threshold": 3,
+                "min_check_duration": 20,
+                "max_check_duration": 80,
+                "loose_particle_num": 2,
+                "cutoff_freq": 15000,
+                "analysis_channel": 1,
+            }
+        }
+    )
+
+    window = LPConfigWindow(config_manager, "LP", available_channels=[0, 1])
+
+    assert window.get_default_config() == {
+        "trigger_threshold": 12,
+        "hysterests_threshold": 3,
+        "min_check_duration": 20,
+        "max_check_duration": 80,
+        "loose_particle_num": 2,
+        "cutoff_freq": 15000,
+        "analysis_channel": 1,
+    }
+
+
+def test_spec_dialog_preserves_saved_keys_after_channel_migration(qapp):
+    from ui.ui_analysis_config.spec_config_dialog import SpecConfigWindow
+
+    config_manager = FakeConfigManager(
+        {
+            "Spec": {
+                "n_fft": 1024,
+                "hop_length": 128,
+                "window_func": "hamming",
+                "color_map": "magma",
+                "freq_scale_type": "log",
+                "top_limit": 75,
+                "bottom_limit": 35,
+                "custom_limit": True,
+                "analysis_channel": 3,
+            }
+        }
+    )
+
+    window = SpecConfigWindow(config_manager, "Spec", available_channels=[1, 3])
+
+    assert window.get_default_config() == {
+        "n_fft": 1024,
+        "hop_length": 128,
+        "window_func": "hamming",
+        "color_map": "magma",
+        "freq_scale_type": "log",
+        "top_limit": 75,
+        "bottom_limit": 35,
+        "custom_limit": True,
+        "analysis_channel": 3,
+    }


### PR DESCRIPTION
## Summary

- Added shared analysis configuration UI widgets for common dialog controls.
- Migrated AI, LP, and Spec dialogs to the shared channel selector and standard button layout.
- Added Qt unit tests for shared widgets and low-risk dialog migration compatibility.

## Related Issues

Closes #739
Closes #740

## Changes

- `ui/ui_analysis_config/common_widgets.py`: Added reusable dialog base, channel, weighting, smoothing, golden sample, and harmonic selector widgets.
- `ui/ui_analysis_config/ai_config_dialog.py`: Reused the shared channel selector and standard buttons.
- `ui/ui_analysis_config/lp_config_dialog.py`: Reused the shared channel selector and standard buttons.
- `ui/ui_analysis_config/spec_config_dialog.py`: Reused the shared channel selector and standard buttons.
- `unit_test/ui/test_analysis_config_common_widgets.py`: Added coverage for shared widget config compatibility.
- `unit_test/ui/test_analysis_config_dialog_migration.py`: Added compatibility tests for AI, LP, and Spec config output.

## Test Plan

- [x] `python -m pytest unit_test/ui/test_analysis_config_normalization.py unit_test/ui/test_analysis_config_common_widgets.py unit_test/ui/test_analysis_config_dialog_migration.py -q`
- [x] `python -m py_compile ui/ui_analysis_config/common_widgets.py ui/ui_analysis_config/ai_config_dialog.py ui/ui_analysis_config/lp_config_dialog.py ui/ui_analysis_config/spec_config_dialog.py unit_test/ui/test_analysis_config_common_widgets.py unit_test/ui/test_analysis_config_dialog_migration.py`
- [x] Manual smoke test for AI, LP, and Spec dialogs

## Checklist

- [x] Code follows existing project style
- [x] Legacy config keys are preserved
- [x] Runtime analysis behavior is unchanged
- [x] `plan.md` is not included