### PR TITLE
feat(ui): complete analysis config defaults

### DIFF
--- a/ui/operation_sequence.py
+++ b/ui/operation_sequence.py
@@ -1274,7 +1274,7 @@ class OptionList(ListView):
             self.default_logger.error(f"Failed to load the default config file. {data}")
             return
 
-        default_of_type = data.get(type, {})
+        default_of_type = copy.deepcopy(data.get(type, {}))
         self.config[0].analysis_list[list_item_text] = default_of_type
         self.config[0].analysis_list[list_item_text]["type"] = type
 

--- a/ui/ui_analysis_config/common_widgets.py
+++ b/ui/ui_analysis_config/common_widgets.py
@@ -199,10 +199,12 @@ class TimeSmoothingWidget(QWidget):
         cfg: dict[str, Any] | None = None,
         defaults: dict[str, Any] | None = None,
         show_algorithm: bool = True,
+        min_points: int = 1,
         parent=None,
     ):
         super().__init__(parent)
         self.show_algorithm = show_algorithm
+        self.min_points = int(min_points)
         smoothing = normalize_time_smoothing(cfg, defaults)
 
         self.enabled_checkbox = CheckBox("平滑")
@@ -222,8 +224,8 @@ class TimeSmoothingWidget(QWidget):
         self.time_spin.setValue(float(smoothing["time_sec"]))
 
         self.points_spin = SpinBox(self)
-        self.points_spin.setRange(1, 99999)
-        self.points_spin.setValue(max(1, int(smoothing["points"])))
+        self.points_spin.setRange(self.min_points, 99999)
+        self.points_spin.setValue(max(self.min_points, int(smoothing["points"])))
 
         main_row = QHBoxLayout()
         main_row.addWidget(self.enabled_checkbox)

--- a/ui/ui_analysis_config/fba_config_dialog.py
+++ b/ui/ui_analysis_config/fba_config_dialog.py
@@ -1,20 +1,22 @@
 import re
 from typing import List, Optional
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QIcon
-from PyQt5.QtWidgets import QDialog, QHBoxLayout, QVBoxLayout, QSizePolicy, QWidget
+from PyQt5.QtWidgets import QHBoxLayout, QVBoxLayout, QSizePolicy, QWidget
 
 from consts.running_consts import DEFAULT_DIR
 from ui.custom_ui_widget.popuputils import PopupUtils
 
 # 确保这里导入的是你项目中正确的 ThresholdConfigWidget 路径
-from ui.ui_analysis_config.config_normalization import weighting_to_display_label
+from ui.ui_analysis_config.common_widgets import (
+    AnalysisConfigDialogBase,
+    ChannelSelectorWidget,
+    WeightingSelectorWidget,
+)
 from ui.ui_analysis_config.threshold_config_widget import ThresholdConfigWidget
-from ui.custom_ui_widget.widgets import PushButton, ComboBox, Label, GroupBox, DoubleSpinBox, PlainTextEdit, MessageBox
+from ui.custom_ui_widget.widgets import ComboBox, Label, GroupBox, DoubleSpinBox, PlainTextEdit, MessageBox
 from ui.ui_src import ui_resources
 
 
-class FbaConfigWindow(QDialog):
+class FbaConfigWindow(AnalysisConfigDialogBase):
     """
     FBA 频段能量分析配置窗口 (修复布局版)
     """
@@ -30,12 +32,12 @@ class FbaConfigWindow(QDialog):
     ]
 
     def __init__(self, config_manager, model_type, available_channels: Optional[List[int]] = None):
-        super().__init__()
+        super().__init__(disable_close_button=True)
         self.config_manager = config_manager
         # 提取模型类型中的字母部分，例如 "FBA"
         self.model_type_str = "".join(re.findall(r"[A-Za-z]", str(model_type))) or "FBA"
         self.show_channel_selector = available_channels is not None
-        self.available_channels = self._normalize_available_channels(available_channels)
+        self.available_channels = available_channels
 
         # 加载配置
         full_config = self.config_manager.load_config()
@@ -43,36 +45,8 @@ class FbaConfigWindow(QDialog):
 
         self.init_ui()
 
-    @staticmethod
-    def _normalize_available_channels(available_channels):
-        channels = []
-        try:
-            channels = sorted({int(ch) for ch in (available_channels or [])})
-        except Exception:
-            channels = []
-        if not channels:
-            channels = [0]
-        return channels
-
-    def _create_channel_layout(self):
-        channel_layout = QHBoxLayout()
-        channel_layout.addWidget(Label("通道:"))
-        self.channel_combo_box = ComboBox()
-        for ch in self.available_channels:
-            self.channel_combo_box.addItem(f"In{int(ch) + 1}", int(ch))
-        saved_channel = self.load_config.get("analysis_channel", None)
-        if saved_channel is None or int(saved_channel) not in self.available_channels:
-            saved_channel = int(self.available_channels[0])
-        idx = self.channel_combo_box.findData(int(saved_channel))
-        self.channel_combo_box.setCurrentIndex(idx if idx >= 0 else 0)
-        channel_layout.addWidget(self.channel_combo_box, 1)
-        return channel_layout
-
     def init_ui(self):
         # --- 窗口基本设置 ---
-        self.setWindowFlag(Qt.WindowCloseButtonHint, False)
-        self.setWindowFlag(Qt.WindowContextHelpButtonHint, False)
-        self.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
         self.setWindowTitle("FBA 分析配置")
         # 该对话框主要是纵向排布；过大的默认宽度会让界面“显得很宽”
         # 同时避免默认高度过大把“阈值展示区域”撑得太高
@@ -85,7 +59,8 @@ class FbaConfigWindow(QDialog):
         main_layout.setContentsMargins(20, 20, 20, 20)
 
         if self.show_channel_selector:
-            main_layout.addLayout(self._create_channel_layout())
+            self.channel_selector = ChannelSelectorWidget(self.load_config, self.available_channels, self)
+            main_layout.addWidget(self.channel_selector)
 
         # =========================================================
         # 1. 频段划分策略 (GroupBox)
@@ -161,26 +136,13 @@ class FbaConfigWindow(QDialog):
         range_group.setLayout(range_layout)
         main_layout.addWidget(range_group)
 
-        # =========================================================
-        # 3. 计权方式 (水平布局) - 关键修复点
-        # =========================================================
-        weight_layout = QHBoxLayout()
-
-        weight_label = Label("计权方式:")
-        weight_layout.addWidget(weight_label)
-
-        self.weighting_combo = ComboBox()
-        self.weighting_combo.addItems(["Z（None）", "A", "C"])
-        self._init_weighting_combo()
-        # 避免下拉框“参与抢占”横向空间导致对话框默认宽度变大
-        self.weighting_combo.setSizePolicy(QSizePolicy.Maximum, QSizePolicy.Fixed)
-        weight_layout.addWidget(self.weighting_combo)
-
-        # 加一个弹簧，让它靠左显示，不要拉得太长
-        weight_layout.addStretch()
-
-        # 将这一行加入主布局
-        main_layout.addLayout(weight_layout)
+        self.weighting_selector = WeightingSelectorWidget(
+            self.load_config,
+            allowed_options=("Z", "A", "C"),
+            default="A",
+            parent=self,
+        )
+        main_layout.addWidget(self.weighting_selector)
 
         # =========================================================
         # 4. 阈值配置组件 (ThresholdConfigWidget)
@@ -215,12 +177,6 @@ class FbaConfigWindow(QDialog):
         idx = self.strategy_combo.findText(val)
         self.strategy_combo.setCurrentIndex(idx if idx >= 0 else 0)
 
-    def _init_weighting_combo(self):
-        val = weighting_to_display_label(self.load_config.get("weighting", "A"), default="A")
-        idx = self.weighting_combo.findText(val)
-        # 默认选 A (索引通常是 1，取决于 addItems 的顺序)
-        self.weighting_combo.setCurrentIndex(idx if idx >= 0 else 1)
-
     def _on_strategy_changed(self, text):
         """根据选择的策略，显隐对应的参数控件"""
         is_equal = text == "等宽"
@@ -230,17 +186,7 @@ class FbaConfigWindow(QDialog):
         self.custom_widget.setVisible(is_custom)
 
     def create_btn(self):
-        btn_layout = QHBoxLayout()
-        default_btn = PushButton(" 设为默认 ")
-        default_btn.clicked.connect(self.on_default_btn_clicked)
-        ok_btn = PushButton(" 确  认 ")
-        ok_btn.clicked.connect(self.on_click_ok_btn)
-
-        btn_layout.addStretch()
-        btn_layout.addWidget(default_btn)
-        btn_layout.addSpacing(10)
-        btn_layout.addWidget(ok_btn)
-        return btn_layout
+        return self.create_standard_button_layout(self.on_default_btn_clicked, self.on_click_ok_btn)
 
     # -----------------------------------------------------------
     # 以下逻辑方法保持原有不变
@@ -303,15 +249,14 @@ class FbaConfigWindow(QDialog):
             "f_min": int(self.f_min_spin.value()),
             "f_max": int(self.f_max_spin.value()),
             "bandwidth": int(self.bandwidth_spin.value()),
-            "analysis_channel": int(self.channel_combo_box.currentData())
-            if self.show_channel_selector and hasattr(self, "channel_combo_box")
+            "analysis_channel": self.channel_selector.current_channel()
+            if self.show_channel_selector and hasattr(self, "channel_selector")
             else int(self.load_config.get("analysis_channel", 0) or 0),
         }
         if self.strategy_combo.currentText() == "自定义":
             config["custom_bands_text"] = self.custom_bands_edit.toPlainText()
 
-        weighting_value = self.weighting_combo.currentText()
-        config["weighting"] = "Z" if weighting_value == "Z（None）" else weighting_value
+        config.update(self.weighting_selector.get_config())
 
         # 获取阈值组件的配置
         config.update(self.threshold_widget.get_config())

--- a/ui/ui_analysis_config/fr_config_dialog.py
+++ b/ui/ui_analysis_config/fr_config_dialog.py
@@ -2,62 +2,38 @@
 FR (Frequency Response) 分析配置对话框
 """
 
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QIcon
-from PyQt5.QtWidgets import QDialog, QHBoxLayout, QVBoxLayout
+from PyQt5.QtWidgets import QVBoxLayout
 
 from consts.running_consts import DEFAULT_DIR
 from ui.custom_ui_widget.popuputils import PopupUtils
-from ui.ui_analysis_config.config_normalization import normalize_octave_smoothing
+from ui.ui_analysis_config.common_widgets import (
+    AnalysisConfigDialogBase,
+    GoldenSampleWidget,
+    OctaveSmoothingSelectorWidget,
+)
 from ui.ui_analysis_config.threshold_config_widget import ThresholdConfigWidget
-from ui.custom_ui_widget.widgets import CheckBox, ComboBox, Label, PushButton
 from ui.ui_src import ui_resources
 
 
-class FrConfigWindow(QDialog):
+class FrConfigWindow(AnalysisConfigDialogBase):
     """FR 频率响应分析配置对话框"""
 
-    OCTAVE_SMOOTHING_LABELS = {
-        "不平滑": 0,
-        "1/1 Oct": 1,
-        "1/3 Oct": 3,
-        "1/6 Oct": 6,
-        "1/12 Oct": 12,
-        "1/24 Oct": 24,
-        "1/48 Oct": 48,
-    }
-
     def __init__(self, config_manager, model_type):
-        super().__init__()
+        super().__init__(disable_close_button=True)
         self.config_manager = config_manager
         self.model_type = model_type
         self.load_config = self.config_manager.load_config().get(model_type, {})
         self.init_ui()
 
     def init_ui(self):
-        self.setWindowFlag(Qt.WindowCloseButtonHint, False)
-        self.setWindowFlag(Qt.WindowContextHelpButtonHint, False)
-        self.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
         # 默认高度偏小会把阈值绘图区域压缩得很矮
         self.setMinimumSize(380, 420)
         self.resize(380, 450)
 
         layout = QVBoxLayout()
 
-        # Octave smoothing
-        self.smooth_combo_box = ComboBox()
-        self.smooth_combo_box.addItems(list(self.OCTAVE_SMOOTHING_LABELS.keys()))
-
-        selected_oct = normalize_octave_smoothing(self.load_config, default=0)
-        selected_label = next(
-            (k for k, v in self.OCTAVE_SMOOTHING_LABELS.items() if v == selected_oct),
-            "不平滑",
-        )
-        self.smooth_combo_box.setCurrentText(selected_label)
-
-        # Golden sample checkbox (placed above threshold widget)
-        self.golden_chk_box = CheckBox("使用黄金样本")
-        self.golden_chk_box.setChecked(self.load_config.get("golden_sample_checked", False))
+        self.smoothing_selector = OctaveSmoothingSelectorWidget(self.load_config, parent=self)
+        self.golden_chk_box = GoldenSampleWidget(self.load_config, self)
 
         # 使用通用阈值配置组件
         self.threshold_widget = ThresholdConfigWidget(
@@ -68,8 +44,7 @@ class FrConfigWindow(QDialog):
 
         btn_layout = self.create_btn()
 
-        layout.addWidget(Label("平滑"))
-        layout.addWidget(self.smooth_combo_box)
+        layout.addWidget(self.smoothing_selector)
         layout.addWidget(self.golden_chk_box)
         layout.addWidget(self.threshold_widget)
         layout.addStretch()
@@ -77,23 +52,13 @@ class FrConfigWindow(QDialog):
         self.setLayout(layout)
 
     def create_btn(self):
-        btn_layout = QHBoxLayout()
-        default_btn = PushButton(" 设为默认 ")
-        default_btn.clicked.connect(self.on_default_btn_clicked)
-        ok_btn = PushButton(" 确  认 ")
-        ok_btn.clicked.connect(self.on_click_ok_btn)
-        btn_layout.addWidget(default_btn)
-        btn_layout.addStretch()
-        btn_layout.addWidget(ok_btn)
-        return btn_layout
+        return self.create_standard_button_layout(self.on_default_btn_clicked, self.on_click_ok_btn)
 
     def get_default_config(self):
         """获取配置数据"""
-        smooth_label = self.smooth_combo_box.currentText()
-        config = {
-            "octave_smoothing": int(self.OCTAVE_SMOOTHING_LABELS.get(smooth_label, 0)),
-            "golden_sample_checked": self.golden_chk_box.isChecked(),
-        }
+        config = {}
+        config.update(self.smoothing_selector.get_config())
+        config.update(self.golden_chk_box.get_config())
         config.update(self.threshold_widget.get_config())
         return config
 

--- a/ui/ui_analysis_config/hd_config_dialog.py
+++ b/ui/ui_analysis_config/hd_config_dialog.py
@@ -2,44 +2,28 @@
 HD (Harmonic Distortion / THD) 分析配置对话框
 """
 
-from functools import partial
-
-from PyQt5.QtCore import Qt, pyqtSignal
-from PyQt5.QtGui import QIcon
-from PyQt5.QtWidgets import (
-    QDialog,
-    QHBoxLayout,
-    QVBoxLayout,
-    QSizePolicy,
-    QScrollArea,
-    QWidget,
-)
+from PyQt5.QtWidgets import QVBoxLayout
 
 from consts.running_consts import DEFAULT_DIR
 from ui.custom_ui_widget.popuputils import PopupUtils
+from ui.ui_analysis_config.common_widgets import AnalysisConfigDialogBase, GoldenSampleWidget, HarmonicSelectorWidget
 from ui.ui_analysis_config.threshold_config_widget import ThresholdConfigWidget
-from ui.custom_ui_widget.widgets import CheckBox, GroupBox, Label, PushButton, MessageBox
+from ui.custom_ui_widget.widgets import GroupBox, MessageBox
 from ui.ui_src import ui_resources
 
 
-class HdConfigWindow(QDialog):
+class HdConfigWindow(AnalysisConfigDialogBase):
     """谐波失真 (THD) 分析配置对话框"""
 
-    selected_labels_changed = pyqtSignal()
-
     def __init__(self, config_manager, model_type):
-        super().__init__()
+        super().__init__(disable_close_button=True)
         self.config_manager = config_manager
         self.model_type = model_type
         self.load_config = self.config_manager.load_config().get(model_type, {})
-        self.selected_labels = self.load_config.get("selected_labels", [])
         self.init_ui()
 
     def init_ui(self):
         self.setObjectName("HdConfigWindow")
-        self.setWindowFlag(Qt.WindowCloseButtonHint, False)
-        self.setWindowFlag(Qt.WindowContextHelpButtonHint, False)
-        self.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
         self.setMinimumSize(320, 480)
         self.resize(380, 620)
 
@@ -47,19 +31,13 @@ class HdConfigWindow(QDialog):
 
         # 谐波选择组
         harmonic_group_box = GroupBox("谐波失真")
-        harmonic_group_box.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)
-        harmonic_slider_layout = self.create_harmonic_slider_layout()
+        harmonic_slider_layout = QVBoxLayout()
         harmonic_slider_layout.setSpacing(12)
-        self.select_all_check = CheckBox("全选")
-        self.select_all_check.setChecked(self.load_config.get("all_checked", False))
-        self.select_all_check.stateChanged.connect(self.on_select_all_changed)
-        harmonic_slider_layout.addStretch()
-        harmonic_slider_layout.addWidget(self.select_all_check)
+        self.harmonic_selector = HarmonicSelectorWidget(self.load_config, start_order=2, end_order=35, parent=self)
+        harmonic_slider_layout.addWidget(self.harmonic_selector)
         harmonic_group_box.setLayout(harmonic_slider_layout)
 
-        # Golden sample checkbox (placed above threshold widget)
-        self.golden_chk_box = CheckBox("使用黄金样本")
-        self.golden_chk_box.setChecked(self.load_config.get("golden_sample_checked", False))
+        self.golden_chk_box = GoldenSampleWidget(self.load_config, self)
 
         # 阈值配置组件
         self.threshold_widget = ThresholdConfigWidget(
@@ -77,81 +55,14 @@ class HdConfigWindow(QDialog):
         layout.addLayout(btn_layout)
         self.setLayout(layout)
 
-    def create_harmonic_slider_layout(self):
-        harmonic_slider_layout = QVBoxLayout()
-        self.scroll_area = QScrollArea()
-        self.scroll_area.setFixedSize(120, 150)
-        self.scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
-        box_container = QWidget()
-        self.box_layout = QVBoxLayout()
-        for i in range(2, 36):
-            label = Label("  " + str(i))
-            label.setFixedSize(90, 25)
-            label.setAlignment(Qt.AlignLeft)
-            label.mousePressEvent = partial(self.on_label_click, label)
-            if i in self.selected_labels:
-                label.setText("\u2713" + label.text().strip())
-            self.box_layout.addWidget(label)
-        if self.load_config.get("all_checked"):
-            self.scroll_area.setDisabled(True)
-        box_container.setLayout(self.box_layout)
-        self.scroll_area.setWidget(box_container)
-        harmonic_slider_layout.addWidget(self.scroll_area)
-        harmonic_slider_layout.addStretch()
-        return harmonic_slider_layout
-
-    def on_select_all_changed(self, state):
-        self.get_default_config()
-        if state == Qt.Checked:
-            self.scroll_area.setDisabled(True)
-            self.selected_labels = list(range(2, 36))
-            for i in range(self.box_layout.count()):
-                label = self.box_layout.itemAt(i).widget()
-                text = label.text().strip()
-                if not text.startswith("\u2713"):
-                    label.setText("\u2713" + text)
-        else:
-            self.scroll_area.setDisabled(False)
-            self.selected_labels = []
-            for i in range(self.box_layout.count()):
-                label = self.box_layout.itemAt(i).widget()
-                text = label.text().strip()
-                if text.startswith("\u2713"):
-                    label.setText("  " + text[1:])
-        self.selected_labels_changed.emit()
-
-    def on_label_click(self, label, event):
-        checked_box = "\u2713"
-        cleaned_label = "".join(filter(str.isdigit, label.text()))
-        label_value = int(cleaned_label)
-        if label_value in self.selected_labels:
-            self.selected_labels.remove(label_value)
-            self.selected_labels.sort()
-            label.setText(label.text().replace(checked_box, "").lstrip())
-            label.setText("  " + label.text().replace(checked_box, ""))
-        else:
-            self.selected_labels.append(label_value)
-            label.setText(checked_box + label.text().strip())
-        self.selected_labels_changed.emit()
-
     def create_btn(self):
-        btn_layout = QHBoxLayout()
-        default_btn = PushButton(" 设为默认 ")
-        default_btn.clicked.connect(self.on_default_btn_clicked)
-        ok_btn = PushButton(" 确  认 ")
-        ok_btn.clicked.connect(self.on_click_ok_btn)
-        btn_layout.addWidget(default_btn)
-        btn_layout.addStretch()
-        btn_layout.addWidget(ok_btn)
-        return btn_layout
+        return self.create_standard_button_layout(self.on_default_btn_clicked, self.on_click_ok_btn)
 
     def get_default_config(self):
         """获取配置数据"""
-        config = {
-            "selected_labels": self.selected_labels,
-            "all_checked": self.select_all_check.isChecked(),
-            "golden_sample_checked": self.golden_chk_box.isChecked(),
-        }
+        config = {}
+        config.update(self.harmonic_selector.get_config())
+        config.update(self.golden_chk_box.get_config())
         config.update(self.threshold_widget.get_config())
         return config
 
@@ -163,7 +74,7 @@ class HdConfigWindow(QDialog):
         PopupUtils().save_popup(self, success_flag=save_flag)
 
     def on_click_ok_btn(self):
-        if not self.selected_labels:
+        if not self.harmonic_selector.selected_labels():
             MessageBox.warning(self, "设置警告", "请选择谐波失真阶数")
         else:
             config_data = self.get_default_config()

--- a/ui/ui_analysis_config/pattern_match_config_dialog.py
+++ b/ui/ui_analysis_config/pattern_match_config_dialog.py
@@ -2,7 +2,7 @@ import os
 import numpy as np
 
 from PyQt5.QtCore import Qt, QEvent
-from PyQt5.QtGui import QIcon, QStandardItem, QIntValidator, QDoubleValidator
+from PyQt5.QtGui import QStandardItem, QIntValidator, QDoubleValidator
 from PyQt5.QtWidgets import (
     QDialog,
     QHBoxLayout,
@@ -32,12 +32,13 @@ from ui.custom_ui_widget.widgets import (
     CheckBox,
     MessageBox,
 )
+from ui.ui_analysis_config.common_widgets import AnalysisConfigDialogBase
 from ui.ui_src import ui_resources
 
 
-class PatternMatchConfigWindow(QDialog):
+class PatternMatchConfigWindow(AnalysisConfigDialogBase):
     def __init__(self, config_manager, model_type):
-        super().__init__()
+        super().__init__(disable_close_button=False)
         self.config_manager = config_manager
         _, self.feature_registry = self.load_features_param_config()
         self.load_config = self.config_manager.load_config().get(model_type, {})
@@ -64,8 +65,6 @@ class PatternMatchConfigWindow(QDialog):
     def init_ui(self):
         self.setObjectName("PatternMatchConfigWindow")
         self.setWindowTitle("模式匹配参数配置")
-        self.setWindowFlag(Qt.WindowContextHelpButtonHint, False)
-        self.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
         self.setMinimumSize(800, 750)
         self.resize(800, 750)
         self.main_layout = QVBoxLayout(self)
@@ -208,15 +207,7 @@ class PatternMatchConfigWindow(QDialog):
         return group
 
     def create_btn_layout(self):
-        layout = QHBoxLayout()
-        ok_btn = PushButton(" 确  认 ")
-        ok_btn.clicked.connect(self.on_click_ok_btn)
-        default_btn = PushButton("设为默认")
-        default_btn.clicked.connect(self.on_click_default_btn)
-        layout.addWidget(default_btn)
-        layout.addStretch()
-        layout.addWidget(ok_btn)
-        return layout
+        return self.create_standard_button_layout(self.on_click_default_btn, self.on_click_ok_btn)
 
     def on_click_extract_btn(self):
         dlg = AudioClipExtractionDialog(save_clip=True, dialog_title="选择模板片段")

--- a/ui/ui_analysis_config/pd_config_dialog.py
+++ b/ui/ui_analysis_config/pd_config_dialog.py
@@ -1,6 +1,5 @@
 from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QIcon
-from PyQt5.QtWidgets import QDialog, QHBoxLayout, QVBoxLayout, QButtonGroup
+from PyQt5.QtWidgets import QHBoxLayout, QVBoxLayout
 
 from consts.running_consts import DEFAULT_DIR
 from ui.custom_ui_widget.popuputils import PopupUtils
@@ -12,24 +11,21 @@ from ui.custom_ui_widget.widgets import (
     LineEdit,
     SpinBox,
     DoubleSpinBox,
-    RadioButton,
     CheckBox,
 )
+from ui.ui_analysis_config.common_widgets import AnalysisConfigDialogBase, TimeSmoothingWidget
 from ui.ui_src import ui_resources
 
 
-class PDConfigWindow(QDialog):
+class PDConfigWindow(AnalysisConfigDialogBase):
     def __init__(self, config_manager, model_type):
-        super().__init__()
+        super().__init__(disable_close_button=True)
         self.config_manager = config_manager
         self.load_config = self.config_manager.load_config().get(model_type, {})
 
         self.init_ui()
 
     def init_ui(self):
-        self.setWindowFlag(Qt.WindowCloseButtonHint, False)
-        self.setWindowFlag(Qt.WindowContextHelpButtonHint, False)
-        self.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
         self.setMinimumSize(940, 520)
         self.resize(1000, 560)
 
@@ -102,55 +98,17 @@ class PDConfigWindow(QDialog):
         self.spin_filter_order.valueChanged.connect(lambda _: self.get_default_config())
         row_filter_order.addWidget(self.spin_filter_order)
 
-        # smooth (two rows: main parameters + algorithm)
-        row_smooth_main = QHBoxLayout()
-        self.chk_smooth = CheckBox("平滑")
-        self.chk_smooth.setChecked(self.load_config.get("smooth_enabled", False))
-        self.chk_smooth.stateChanged.connect(self.get_default_config)
-        row_smooth_main.addWidget(self.chk_smooth)
-        row_smooth_main.addStretch()
-        row_smooth_main.addWidget(Label("单位:"))
-        self.combo_smooth_unit = ComboBox()
-        self.combo_smooth_unit.addItems(["时间(秒)", "格点数"])
-        self.combo_smooth_unit.setCurrentIndex(0 if self.load_config.get("smooth_unit", "time") == "time" else 1)
-        self.combo_smooth_unit.currentIndexChanged.connect(
-            lambda _: (self._update_smooth_unit_enabled(), self.get_default_config())
+        self.smoothing_widget = TimeSmoothingWidget(
+            self.load_config,
+            defaults={"enabled": False, "unit": "time", "time_sec": 0.02, "points": 0, "algo": 1},
+            min_points=0,
+            parent=self,
         )
-        row_smooth_main.addWidget(self.combo_smooth_unit)
-        self.spin_smooth_time = DoubleSpinBox()
-        self.spin_smooth_time.setRange(0.00, 999.00)
-        self.spin_smooth_time.setDecimals(4)
-        self.spin_smooth_time.setSingleStep(0.01)
-        self.spin_smooth_time.setValue(float(self.load_config.get("smooth_time_sec", 0.02)))
-        self.spin_smooth_time.valueChanged.connect(lambda _: self.get_default_config())
-        row_smooth_main.addWidget(self.spin_smooth_time)
-        self.spin_smooth_points = SpinBox()
-        self.spin_smooth_points.setRange(1, 99999)
-        self.spin_smooth_points.setValue(int(self.load_config.get("smooth_points", 0)))
-        self.spin_smooth_points.valueChanged.connect(lambda _: self.get_default_config())
-        row_smooth_main.addWidget(self.spin_smooth_points)
-
-        row_smooth_algo = QHBoxLayout()
-        row_smooth_algo.addStretch()
-        row_smooth_algo.addWidget(Label("平滑算法:"))
-        self.group_smooth_algo = QButtonGroup(self)
-        self.rb_algo1 = RadioButton("平均")
-        self.rb_algo2 = RadioButton("Golay")
-        self.rb_algo3 = RadioButton("Gaussian")
-        row_smooth_algo.addWidget(self.rb_algo1)
-        row_smooth_algo.addWidget(self.rb_algo2)
-        row_smooth_algo.addWidget(self.rb_algo3)
-        self.group_smooth_algo.addButton(self.rb_algo1, 1)
-        self.group_smooth_algo.addButton(self.rb_algo2, 2)
-        self.group_smooth_algo.addButton(self.rb_algo3, 3)
-        algo_saved = int(self.load_config.get("smooth_algo", 1))
-        if algo_saved == 2:
-            self.rb_algo2.setChecked(True)
-        elif algo_saved == 3:
-            self.rb_algo3.setChecked(True)
-        else:
-            self.rb_algo1.setChecked(True)
-        self.group_smooth_algo.buttonClicked.connect(lambda _: self.get_default_config())
+        self.smoothing_widget.enabled_checkbox.stateChanged.connect(self.get_default_config)
+        self.smoothing_widget.unit_combo.currentIndexChanged.connect(lambda _: self.get_default_config())
+        self.smoothing_widget.time_spin.valueChanged.connect(lambda _: self.get_default_config())
+        self.smoothing_widget.points_spin.valueChanged.connect(lambda _: self.get_default_config())
+        self.smoothing_widget.algo_group.buttonClicked.connect(lambda _: self.get_default_config())
 
         # SPL calculation window length (no check box, default enabled; support time/grid point number)
         row_splwin = QHBoxLayout()
@@ -183,13 +141,11 @@ class PDConfigWindow(QDialog):
         vbox.addLayout(row_filter_order)
         # place the SPL calculation window length between the filter and smooth
         vbox.addLayout(row_splwin)
-        vbox.addLayout(row_smooth_main)
-        vbox.addLayout(row_smooth_algo)
+        vbox.addWidget(self.smoothing_widget)
         vbox.setSpacing(8)
         vbox.setContentsMargins(10, 12, 10, 12)
         group_box.setLayout(vbox)
         # initialize the display state
-        self._update_smooth_unit_enabled()
         self._update_spl_window_unit_enabled()
         return group_box
 
@@ -441,15 +397,7 @@ class PDConfigWindow(QDialog):
         self.adjustSize()
 
     def create_btn_layout(self):
-        btn_layout = QHBoxLayout()
-        default_btn = PushButton(" 设为默认 ")
-        ok_btn = PushButton(" 确  认 ")
-        default_btn.clicked.connect(self.on_click_default_btn)
-        ok_btn.clicked.connect(self.on_click_ok_btn)
-        btn_layout.addWidget(default_btn)
-        btn_layout.addStretch()
-        btn_layout.addWidget(ok_btn)
-        return btn_layout
+        return self.create_standard_button_layout(self.on_click_default_btn, self.on_click_ok_btn)
 
     def get_default_config(self):
         default_config = {
@@ -457,10 +405,6 @@ class PDConfigWindow(QDialog):
             "filter_enabled": self.chk_filter.isChecked(),
             "filter_ranges": self.edit_filter_ranges.text().strip(),
             "filter_type": "bandpass" if self.combo_filter_type.currentIndex() == 0 else "bandstop",
-            "smooth_enabled": self.chk_smooth.isChecked(),
-            "smooth_unit": "time" if self.combo_smooth_unit.currentIndex() == 0 else "points",
-            "smooth_time_sec": float(self.spin_smooth_time.value()),
-            "smooth_points": int(self.spin_smooth_points.value()),
             # based parameter
             "peak_count_enabled": self.chk_peak_count.isChecked(),
             "peak_count": int(self.spin_peak_count.value()),
@@ -483,7 +427,6 @@ class PDConfigWindow(QDialog):
             # advanced mode
             "advanced_mode": bool(getattr(self, "advanced_visible", False)),
             "filter_order": int(self.spin_filter_order.value()),
-            "smooth_algo": int(self.group_smooth_algo.checkedId() or 1),
             "convex_unit": (
                 "audio"
                 if self.combo_convex_unit.currentIndex() == 0
@@ -498,6 +441,7 @@ class PDConfigWindow(QDialog):
             "test_peak_op": self.combo_test_peak_op.currentText(),
             "test_peak_value": int(self.spin_test_peak_value.value()),
         }
+        default_config.update(self.smoothing_widget.get_config())
         return default_config
 
     def _update_duration_ref_unit(self):

--- a/ui/ui_analysis_config/perceptual_rb_config_dialog.py
+++ b/ui/ui_analysis_config/perceptual_rb_config_dialog.py
@@ -6,16 +6,17 @@ PRB 使用固定谐波范围 (2阶-35阶) 结合 SoundCheck/Listen (SC) 心理�
 """
 
 from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QIcon
-from PyQt5.QtWidgets import QDialog, QHBoxLayout, QVBoxLayout
+from PyQt5.QtWidgets import QVBoxLayout
 
 from consts.running_consts import DEFAULT_DIR
 from ui.custom_ui_widget.popuputils import PopupUtils
+from ui.ui_analysis_config.common_widgets import AnalysisConfigDialogBase, GoldenSampleWidget
 from ui.ui_analysis_config.threshold_config_widget import ThresholdConfigWidget
-from ui.custom_ui_widget.widgets import GroupBox, Label, PushButton, ComboBox, CheckBox
+from ui.custom_ui_widget.widgets import GroupBox, Label, ComboBox
 from ui.ui_src import ui_resources
 
-class PerceptualRbConfigWindow(QDialog):
+
+class PerceptualRbConfigWindow(AnalysisConfigDialogBase):
     """
     Perceptual Rub & Buzz (PRB) 分析配置对话框
 
@@ -24,16 +25,13 @@ class PerceptualRbConfigWindow(QDialog):
     """
 
     def __init__(self, config_manager, model_type):
-        super().__init__()
+        super().__init__(disable_close_button=True)
         self.config_manager = config_manager
         self.model_type = model_type
         self.load_config = self.config_manager.load_config().get(model_type, {}) if self.config_manager else {}
         self.init_ui()
 
     def init_ui(self):
-        self.setWindowFlag(Qt.WindowCloseButtonHint, False)
-        self.setWindowFlag(Qt.WindowContextHelpButtonHint, False)
-        self.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
         # 默认高度偏小会把阈值绘图区域压缩得很矮
         self.setMinimumSize(380, 420)
         self.resize(400, 480)
@@ -69,9 +67,7 @@ class PerceptualRbConfigWindow(QDialog):
         group_layout.addWidget(self.sc_metric_combo)
         group.setLayout(group_layout)
 
-        # Golden sample checkbox (placed above threshold widget)
-        self.golden_chk_box = CheckBox("使用黄金样本")
-        self.golden_chk_box.setChecked(self.load_config.get("golden_sample_checked", False))
+        self.golden_chk_box = GoldenSampleWidget(self.load_config, self)
 
         # 阈值配置组件
         self.threshold_widget = ThresholdConfigWidget(
@@ -80,21 +76,11 @@ class PerceptualRbConfigWindow(QDialog):
             model_type=self.model_type,
         )
 
-        # 按钮布局
-        btn_layout = QHBoxLayout()
-        default_btn = PushButton(" 设为默认 ")
-        default_btn.clicked.connect(self.on_default_btn_clicked)
-        ok_btn = PushButton(" 确  认 ")
-        ok_btn.clicked.connect(self.on_click_ok_btn)
-        btn_layout.addWidget(default_btn)
-        btn_layout.addStretch()
-        btn_layout.addWidget(ok_btn)
-
         root_layout.addWidget(group)
         root_layout.addWidget(self.golden_chk_box)
         root_layout.addWidget(self.threshold_widget)
         root_layout.addStretch()
-        root_layout.addLayout(btn_layout)
+        root_layout.addLayout(self.create_standard_button_layout(self.on_default_btn_clicked, self.on_click_ok_btn))
         self.setLayout(root_layout)
 
 
@@ -113,7 +99,7 @@ class PerceptualRbConfigWindow(QDialog):
         masking_config["sc_metric"] = metric
 
         config = {"prb_method": "sc", "masking_config": masking_config}
-        config["golden_sample_checked"] = self.golden_chk_box.isChecked()
+        config.update(self.golden_chk_box.get_config())
         config.update(self.threshold_widget.get_config())
         return config
 

--- a/ui/ui_analysis_config/pipeline_pd_pm_config.py
+++ b/ui/ui_analysis_config/pipeline_pd_pm_config.py
@@ -1,5 +1,4 @@
 from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import QDialog, QHBoxLayout, QVBoxLayout
 
 from consts.running_consts import DEFAULT_DIR
@@ -14,10 +13,11 @@ from ui.ui_analysis_config.rb_config_dialog import RbConfigWindow
 from ui.ui_analysis_config.spec_config_dialog import SpecConfigWindow
 from ui.ui_analysis_config.spl_config_dialog import SplConfigWindow
 from ui.custom_ui_widget.widgets import GroupBox, Label, PushButton, CheckBox, SpinBox, MessageBox
+from ui.ui_analysis_config.common_widgets import AnalysisConfigDialogBase
 from ui.ui_src import ui_resources
 
 
-class PipelineConfigWindow(QDialog):
+class PipelineConfigWindow(AnalysisConfigDialogBase):
     """
     pipeline configuration window (for inheritance)
 
@@ -27,7 +27,7 @@ class PipelineConfigWindow(QDialog):
     """
 
     def __init__(self, config_manager, model_type):
-        super().__init__()
+        super().__init__(disable_close_button=True)
         self.config_manager = config_manager
         self.model_type = model_type
         # full configuration dictionary (analysis_list)
@@ -39,9 +39,6 @@ class PipelineConfigWindow(QDialog):
         self._hydrate_from_saved()
 
     def init_ui(self):
-        self.setWindowFlag(Qt.WindowCloseButtonHint, False)
-        self.setWindowFlag(Qt.WindowContextHelpButtonHint, False)
-        self.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
         self.setMinimumSize(720, 360)
         self.resize(760, 380)
 
@@ -213,6 +210,7 @@ class PipelineConfigWindow(QDialog):
             self.config_manager.config = {}
         local_cfg = self.head_local_config if slot == "head" else self.tail_local_config
         if isinstance(local_cfg, dict) and local_cfg:
+            # Temporary child configs stay scoped to this pipeline and are not top-level analysis items.
             # 使用副本，避免子窗体原地修改带来意外引用问题
             try:
                 self.config_manager.config[temp_name] = dict(local_cfg)

--- a/ui/ui_analysis_config/rb_config_dialog.py
+++ b/ui/ui_analysis_config/rb_config_dialog.py
@@ -4,50 +4,32 @@ RB (Rub & Buzz) 分析配置对话框
 Rub & Buzz 使用高阶谐波失真 (10阶-35阶) 来检测扬声器的摩擦和蜂鸣问题。
 """
 
-from functools import partial
-
-from PyQt5.QtCore import Qt, pyqtSignal
-from PyQt5.QtGui import QIcon
-from PyQt5.QtWidgets import (
-    QDialog,
-    QHBoxLayout,
-    QVBoxLayout,
-    QSizePolicy,
-    QScrollArea,
-    QWidget,
-)
+from PyQt5.QtWidgets import QVBoxLayout
 
 from consts.running_consts import DEFAULT_DIR
 from ui.custom_ui_widget.popuputils import PopupUtils
-from ui.custom_ui_widget.widgets import CheckBox, GroupBox, Label, PushButton, MessageBox
+from ui.custom_ui_widget.widgets import GroupBox, MessageBox
+from ui.ui_analysis_config.common_widgets import AnalysisConfigDialogBase, GoldenSampleWidget, HarmonicSelectorWidget
 from ui.ui_analysis_config.threshold_config_widget import ThresholdConfigWidget
 from ui.ui_src import ui_resources
 
 
-class RbConfigWindow(QDialog):
+class RbConfigWindow(AnalysisConfigDialogBase):
     """
     Rub & Buzz 分析配置对话框
 
     允许选择 10阶-35阶 谐波进行分析，并支持阈值曲线配置。
     """
 
-    selected_labels_changed = pyqtSignal()
-
     def __init__(self, config_manager, model_type):
-        super().__init__()
+        super().__init__(disable_close_button=True)
         self.config_manager = config_manager
         self.model_type = model_type
         self.load_config = self.config_manager.load_config().get(model_type, {})
-        # Filter harmonics to valid range (10-35)
-        loaded_labels = self.load_config.get("selected_labels", [])
-        self.selected_labels = [h for h in loaded_labels if 10 <= h <= 35]
         self.init_ui()
 
     def init_ui(self):
         self.setObjectName("RbConfigWindow")
-        self.setWindowFlag(Qt.WindowCloseButtonHint, False)
-        self.setWindowFlag(Qt.WindowContextHelpButtonHint, False)
-        self.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
         self.setMinimumSize(320, 480)
         self.resize(380, 620)
 
@@ -56,19 +38,13 @@ class RbConfigWindow(QDialog):
         # 谐波选择组
         harmonic_group_box = GroupBox("Rub & Buzz")
         harmonic_group_box.setObjectName("harmonic_group_box")
-        harmonic_group_box.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)
-        harmonic_slider_layout = self.create_harmonic_slider_layout()
+        harmonic_slider_layout = QVBoxLayout()
         harmonic_slider_layout.setSpacing(12)
-        self.select_all_check = CheckBox("全选")
-        self.select_all_check.setChecked(self.load_config.get("all_checked", False))
-        self.select_all_check.stateChanged.connect(self.on_select_all_changed)
-        harmonic_slider_layout.addStretch()
-        harmonic_slider_layout.addWidget(self.select_all_check)
+        self.harmonic_selector = HarmonicSelectorWidget(self.load_config, start_order=10, end_order=35, parent=self)
+        harmonic_slider_layout.addWidget(self.harmonic_selector)
         harmonic_group_box.setLayout(harmonic_slider_layout)
 
-        # Golden sample checkbox (placed above threshold widget)
-        self.golden_chk_box = CheckBox("使用黄金样本")
-        self.golden_chk_box.setChecked(self.load_config.get("golden_sample_checked", False))
+        self.golden_chk_box = GoldenSampleWidget(self.load_config, self)
 
         # 阈值配置组件
         self.threshold_widget = ThresholdConfigWidget(
@@ -86,84 +62,14 @@ class RbConfigWindow(QDialog):
         layout.addLayout(btn_layout)
         self.setLayout(layout)
 
-    def create_harmonic_slider_layout(self):
-        """创建谐波选择布局，范围 10-35"""
-        harmonic_slider_layout = QVBoxLayout()
-        self.scroll_area = QScrollArea()
-        self.scroll_area.setFixedSize(120, 150)
-        self.scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
-        box_container = QWidget()
-        self.box_layout = QVBoxLayout()
-        # Rub & Buzz: harmonics 10-35 (26 harmonics total)
-        for i in range(10, 36):
-            label = Label("  " + str(i))
-            label.setMinimumWidth(90)
-            label.setMinimumHeight(25)
-            label.setAlignment(Qt.AlignLeft)
-            label.mousePressEvent = partial(self.on_label_click, label)
-            if i in self.selected_labels:
-                label.setText("\u2713" + label.text().strip())
-            self.box_layout.addWidget(label)
-        if self.load_config.get("all_checked"):
-            self.scroll_area.setDisabled(True)
-        box_container.setLayout(self.box_layout)
-        self.scroll_area.setWidget(box_container)
-        harmonic_slider_layout.addWidget(self.scroll_area)
-        harmonic_slider_layout.addStretch()
-        return harmonic_slider_layout
-
-    def on_select_all_changed(self, state):
-        self.get_default_config()
-        if state == Qt.Checked:
-            self.scroll_area.setDisabled(True)
-            # Select all rub&buzz harmonics (10-35)
-            self.selected_labels = list(range(10, 36))
-            for i in range(self.box_layout.count()):
-                label = self.box_layout.itemAt(i).widget()
-                text = label.text().strip()
-                if not text.startswith("\u2713"):
-                    label.setText("\u2713" + text)
-        else:
-            self.scroll_area.setDisabled(False)
-            self.selected_labels = []
-            for i in range(self.box_layout.count()):
-                label = self.box_layout.itemAt(i).widget()
-                text = label.text().strip()
-                if text.startswith("\u2713"):
-                    label.setText("  " + text[1:])
-        self.selected_labels_changed.emit()
-
-    def on_label_click(self, label, event):
-        checked_box = "\u2713"
-        cleaned_label = "".join(filter(str.isdigit, label.text()))
-        label_value = int(cleaned_label)
-        if label_value in self.selected_labels:
-            self.selected_labels.remove(label_value)
-            self.selected_labels.sort()
-            label.setText("  " + label.text().replace(checked_box, "").strip())
-        else:
-            self.selected_labels.append(label_value)
-            label.setText(checked_box + label.text().strip())
-        self.selected_labels_changed.emit()
-
     def create_btn(self):
-        btn_layout = QHBoxLayout()
-        default_btn = PushButton(" 设为默认 ")
-        default_btn.clicked.connect(self.on_default_btn_clicked)
-        ok_btn = PushButton(" 确  认 ")
-        ok_btn.clicked.connect(self.on_click_ok_btn)
-        btn_layout.addWidget(default_btn)
-        btn_layout.addStretch()
-        btn_layout.addWidget(ok_btn)
-        return btn_layout
+        return self.create_standard_button_layout(self.on_default_btn_clicked, self.on_click_ok_btn)
 
     def get_default_config(self):
         """获取配置数据"""
-        config = {
-            "selected_labels": self.selected_labels,
-            "all_checked": self.select_all_check.isChecked(),
-            "golden_sample_checked": self.golden_chk_box.isChecked(),
-        }
+        config = {}
+        config.update(self.harmonic_selector.get_config())
+        config.update(self.golden_chk_box.get_config())
         config.update(self.threshold_widget.get_config())
         return config
 
@@ -175,7 +81,7 @@ class RbConfigWindow(QDialog):
         PopupUtils().save_popup(self, success_flag=save_flag)
 
     def on_click_ok_btn(self):
-        if not self.selected_labels:
+        if not self.harmonic_selector.selected_labels():
             MessageBox.warning(self, "设置警告", "请选择Rub & Buzz阶数")
         else:
             config_data = self.get_default_config()

--- a/ui/ui_analysis_config/reference_spectrum_config_dialog.py
+++ b/ui/ui_analysis_config/reference_spectrum_config_dialog.py
@@ -11,9 +11,7 @@ from typing import List, Optional
 
 import numpy as np
 from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import (
-    QDialog,
     QFileDialog,
     QHBoxLayout,
     QVBoxLayout,
@@ -43,20 +41,16 @@ from ui.custom_ui_widget.widgets import (
     LineEdit,
     SpinBox,
 )
+from ui.ui_analysis_config.common_widgets import AnalysisConfigDialogBase, OctaveSmoothingSelectorWidget
 
 
-class ReferenceSpectrumConfigWindow(QDialog):
+class ReferenceSpectrumConfigWindow(AnalysisConfigDialogBase):
     WINDOW_OPTIONS = ["hann", "hamming", "blackman"]
     NPERSEG_OPTIONS = ["1024", "2048", "4096", "8192"]
     OVERLAP_OPTIONS = [("25%", 0.25), ("50%", 0.5), ("75%", 0.75)]
-    SMOOTHING_OPTIONS = [
-        ("不平滑", 0),
-        ("1/3 Oct", 3),
-        ("1/6 Oct", 6),
-    ]
 
     def __init__(self, config_manager, model_type, available_channels: Optional[List[int]] = None):
-        super().__init__()
+        super().__init__(disable_close_button=True)
         self.config_manager = config_manager
         self.model_type = model_type
         self.available_channels = list(available_channels or [])
@@ -71,9 +65,6 @@ class ReferenceSpectrumConfigWindow(QDialog):
         self._bind_initial_values()
 
     def init_ui(self):
-        self.setWindowFlag(Qt.WindowCloseButtonHint, False)
-        self.setWindowFlag(Qt.WindowContextHelpButtonHint, False)
-        self.setWindowIcon(QIcon(DEFAULT_DIR + "ui/ui_pic/logo_pic/ting.ico"))
         self.setMinimumSize(520, 680)
         self.resize(560, 720)
 
@@ -233,18 +224,18 @@ class ReferenceSpectrumConfigWindow(QDialog):
         self.overlap_combo_box.currentIndexChanged.connect(self._on_generation_relevant_value_changed)
         overlap_row.addWidget(self.overlap_combo_box)
 
-        smoothing_row = QHBoxLayout()
-        smoothing_row.addWidget(Label("平滑"))
-        self.smoothing_combo_box = ComboBox()
-        for text, value in self.SMOOTHING_OPTIONS:
-            self.smoothing_combo_box.addItem(text, int(value))
-        self.smoothing_combo_box.currentIndexChanged.connect(self._on_generation_relevant_value_changed)
-        smoothing_row.addWidget(self.smoothing_combo_box)
+        self.smoothing_selector = OctaveSmoothingSelectorWidget(
+            {"octave_smoothing": self.load_config.get("smoothing", 0)},
+            allowed_options=(0, 3, 6),
+            default=0,
+            parent=self,
+        )
+        self.smoothing_selector.combo_box.currentIndexChanged.connect(self._on_generation_relevant_value_changed)
 
         advanced_layout.addLayout(window_row)
         advanced_layout.addLayout(nperseg_row)
         advanced_layout.addLayout(overlap_row)
-        advanced_layout.addLayout(smoothing_row)
+        advanced_layout.addWidget(self.smoothing_selector)
         self.advanced_container.setLayout(advanced_layout)
         self.advanced_container.setVisible(False)
 
@@ -253,14 +244,9 @@ class ReferenceSpectrumConfigWindow(QDialog):
         return group
 
     def create_btn(self):
-        btn_layout = QHBoxLayout()
-        self.default_btn = PushButton(" 设为默认 ")
-        self.default_btn.clicked.connect(self.on_default_btn_clicked)
-        self.ok_btn = PushButton(" 确  认 ")
-        self.ok_btn.clicked.connect(self.on_click_ok_btn)
-        btn_layout.addWidget(self.default_btn)
-        btn_layout.addStretch()
-        btn_layout.addWidget(self.ok_btn)
+        btn_layout = self.create_standard_button_layout(self.on_default_btn_clicked, self.on_click_ok_btn)
+        self.default_btn = btn_layout.itemAt(0).widget()
+        self.ok_btn = btn_layout.itemAt(2).widget()
         return btn_layout
 
     def _bind_initial_values(self):
@@ -284,9 +270,6 @@ class ReferenceSpectrumConfigWindow(QDialog):
         overlap_value = float(cfg.get("overlap_ratio", 0.5))
         overlap_index = self.overlap_combo_box.findData(overlap_value)
         self.overlap_combo_box.setCurrentIndex(overlap_index if overlap_index >= 0 else 1)
-        smoothing_value = int(cfg.get("smoothing", 0))
-        smoothing_index = self.smoothing_combo_box.findData(smoothing_value)
-        self.smoothing_combo_box.setCurrentIndex(smoothing_index if smoothing_index >= 0 else 0)
         self.show_advanced_checkbox.setChecked(self._has_non_default_advanced_params(cfg))
 
         if source_path:
@@ -338,7 +321,7 @@ class ReferenceSpectrumConfigWindow(QDialog):
             window=self.window_combo_box.currentText(),
             nperseg=int(self.nperseg_combo_box.currentText()),
             overlap_ratio=float(self.overlap_combo_box.currentData()),
-            smoothing=int(self.smoothing_combo_box.currentData()),
+            smoothing=self.smoothing_selector.current_octave_smoothing(),
         )
 
     def _probe_audio_file(self, file_path: str):
@@ -561,7 +544,7 @@ class ReferenceSpectrumConfigWindow(QDialog):
             "window": self.window_combo_box.currentText(),
             "nperseg": int(self.nperseg_combo_box.currentText()),
             "overlap_ratio": float(self.overlap_combo_box.currentData()),
-            "smoothing": int(self.smoothing_combo_box.currentData()),
+            "smoothing": self.smoothing_selector.current_octave_smoothing(),
         }
         return config
 

--- a/ui/ui_analysis_config/spl_config_dialog.py
+++ b/ui/ui_analysis_config/spl_config_dialog.py
@@ -5,70 +5,35 @@ SPL (Sound Pressure Level) 分析配置对话框
 import re
 from typing import List, Optional
 
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QIcon
-from PyQt5.QtWidgets import QDialog, QHBoxLayout, QVBoxLayout
+from PyQt5.QtWidgets import QVBoxLayout
 
 from consts.running_consts import DEFAULT_DIR
 from ui.custom_ui_widget.popuputils import PopupUtils
-from ui.custom_ui_widget.widgets import CheckBox, GroupBox, Label, PushButton, ComboBox, RadioButton
-from ui.ui_analysis_config.config_normalization import normalize_octave_smoothing, weighting_to_display_label
+from ui.custom_ui_widget.widgets import CheckBox, GroupBox, RadioButton
+from ui.ui_analysis_config.common_widgets import (
+    AnalysisConfigDialogBase,
+    ChannelSelectorWidget,
+    GoldenSampleWidget,
+    OctaveSmoothingSelectorWidget,
+    WeightingSelectorWidget,
+)
 from ui.ui_analysis_config.threshold_config_widget import ThresholdConfigWidget
 from ui.ui_src import ui_resources
 
 
-class SplConfigWindow(QDialog):
+class SplConfigWindow(AnalysisConfigDialogBase):
     """SPL 分析配置对话框"""
 
-    OCTAVE_SMOOTHING_LABELS = {
-        "不平滑": 0,
-        "1/1 Oct": 1,
-        "1/3 Oct": 3,
-        "1/6 Oct": 6,
-        "1/12 Oct": 12,
-        "1/24 Oct": 24,
-        "1/48 Oct": 48,
-    }
-
     def __init__(self, config_manager, model_type, available_channels: Optional[List[int]] = None):
-        super().__init__()
+        super().__init__(disable_close_button=True)
         self.config_manager = config_manager
         self.load_config = self.config_manager.load_config().get(model_type, {})
         self.model_type = "".join(re.findall(r"[A-Za-z]", str(model_type))) or "SPL"
         self.show_channel_selector = available_channels is not None
-        self.available_channels = self._normalize_available_channels(available_channels)
+        self.available_channels = available_channels
         self.init_ui()
 
-    @staticmethod
-    def _normalize_available_channels(available_channels):
-        channels = []
-        try:
-            channels = sorted({int(ch) for ch in (available_channels or [])})
-        except Exception:
-            channels = []
-        if not channels:
-            channels = [0]
-        return channels
-
-    def _create_channel_layout(self):
-        channel_layout = QHBoxLayout()
-        channel_layout.addWidget(Label("通道:"))
-        self.channel_combo_box = ComboBox()
-        for ch in self.available_channels:
-            self.channel_combo_box.addItem(f"In{int(ch) + 1}", int(ch))
-        saved_channel = self.load_config.get("analysis_channel", None)
-        if saved_channel is None or int(saved_channel) not in self.available_channels:
-            saved_channel = int(self.available_channels[0])
-        idx = self.channel_combo_box.findData(int(saved_channel))
-        self.channel_combo_box.setCurrentIndex(idx if idx >= 0 else 0)
-        channel_layout.addWidget(self.channel_combo_box)
-        channel_layout.addStretch()
-        return channel_layout
-
     def init_ui(self):
-        self.setWindowFlag(Qt.WindowCloseButtonHint, False)
-        self.setWindowFlag(Qt.WindowContextHelpButtonHint, False)
-        self.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
         # 默认高度偏小会把阈值绘图区域压缩得很矮，导致“显示不完整”的观感
         height = 570 if self.model_type == "SPLF" else 430
         self.setMinimumSize(380, height)
@@ -101,21 +66,12 @@ class SplConfigWindow(QDialog):
             mode_layout.addWidget(self.radio_total)
             self.splf_mode_group_box.setLayout(mode_layout)
 
-            # SPLF: octave smoothing dropdown (frequency-domain)
-            self.smooth_combo_box = ComboBox()
-            self.smooth_combo_box.addItems(list(self.OCTAVE_SMOOTHING_LABELS.keys()))
-            selected_oct = normalize_octave_smoothing(self.load_config, default=0)
-            selected_label = next(
-                (k for k, v in self.OCTAVE_SMOOTHING_LABELS.items() if v == selected_oct),
-                "不平滑",
-            )
-            self.smooth_combo_box.setCurrentText(selected_label)
+            self.smoothing_selector = OctaveSmoothingSelectorWidget(self.load_config, parent=self)
 
         # SPLF only: golden sample checkbox (placed above threshold widget)
         self.golden_chk_box = None
         if self.model_type == "SPLF":
-            self.golden_chk_box = CheckBox("使用黄金样本")
-            self.golden_chk_box.setChecked(self.load_config.get("golden_sample_checked", False))
+            self.golden_chk_box = GoldenSampleWidget(self.load_config, self)
 
         self.threshold_widget = ThresholdConfigWidget(
             parent=self,
@@ -123,33 +79,17 @@ class SplConfigWindow(QDialog):
             model_type=self.model_type,
         )
 
-        weighting_label = Label("计权方式:")
-        self.weighting_combo = ComboBox()
-        self.weighting_combo.addItems(["Z（None）", "A", "B", "C", "D"])
-        weighting_value = weighting_to_display_label(self.load_config.get("weighting", "Z"))
-        index = self.weighting_combo.findText(weighting_value)
-        if index >= 0:
-            self.weighting_combo.setCurrentIndex(index)
-        else:
-            self.weighting_combo.setCurrentIndex(0)
-
-        threshold_weighting_layout = QHBoxLayout()
-        threshold_weighting_layout.addWidget(weighting_label)
-        threshold_weighting_layout.addWidget(self.weighting_combo)
-        threshold_weighting_layout.addStretch()
+        self.weighting_selector = WeightingSelectorWidget(self.load_config, parent=self)
 
         btn_layout = self.create_btn()
 
         if self.show_channel_selector:
-            layout.addLayout(self._create_channel_layout())
-        layout.addLayout(threshold_weighting_layout)
+            self.channel_selector = ChannelSelectorWidget(self.load_config, self.available_channels, self)
+            layout.addWidget(self.channel_selector)
+        layout.addWidget(self.weighting_selector)
         if self.splf_mode_group_box is not None:
             layout.addWidget(self.splf_mode_group_box)
-
-            smooth_layout = QHBoxLayout()
-            smooth_layout.addWidget(Label("平滑"))
-            smooth_layout.addWidget(self.smooth_combo_box)
-            layout.addLayout(smooth_layout)
+            layout.addWidget(self.smoothing_selector)
         elif self.smooth_chk_box is not None:
             layout.addWidget(self.smooth_chk_box)
         if self.golden_chk_box is not None:
@@ -161,15 +101,7 @@ class SplConfigWindow(QDialog):
         self.setLayout(layout)
 
     def create_btn(self):
-        btn_layout = QHBoxLayout()
-        default_btn = PushButton(" 设为默认 ")
-        default_btn.clicked.connect(self.on_default_btn_clicked)
-        ok_btn = PushButton(" 确  认 ")
-        ok_btn.clicked.connect(self.on_click_ok_btn)
-        btn_layout.addWidget(default_btn)
-        btn_layout.addStretch()
-        btn_layout.addWidget(ok_btn)
-        return btn_layout
+        return self.create_standard_button_layout(self.on_default_btn_clicked, self.on_click_ok_btn)
 
     def get_default_config(self):
         """获取配置数据"""
@@ -181,18 +113,13 @@ class SplConfigWindow(QDialog):
             if hasattr(self, "radio_total") and self.radio_total.isChecked():
                 calc_mode = "total"
             config["splf_calc_mode"] = calc_mode
-            smooth_label = self.smooth_combo_box.currentText()
-            config["octave_smoothing"] = int(self.OCTAVE_SMOOTHING_LABELS.get(smooth_label, 0))
+            config.update(self.smoothing_selector.get_config())
             if self.golden_chk_box is not None:
-                config["golden_sample_checked"] = self.golden_chk_box.isChecked()
+                config.update(self.golden_chk_box.get_config())
         config.update(self.threshold_widget.get_config())
-        weighting_value = self.weighting_combo.currentText()
-        if weighting_value == "Z（None）":
-            config["weighting"] = "Z"
-        else:
-            config["weighting"] = weighting_value
-        if self.show_channel_selector and hasattr(self, "channel_combo_box"):
-            config["analysis_channel"] = int(self.channel_combo_box.currentData())
+        config.update(self.weighting_selector.get_config())
+        if self.show_channel_selector and hasattr(self, "channel_selector"):
+            config.update(self.channel_selector.get_config())
         else:
             config["analysis_channel"] = int(self.load_config.get("analysis_channel", 0) or 0)
         return config

--- a/ui/ui_config/analysis_default_config.json
+++ b/ui/ui_config/analysis_default_config.json
@@ -1,0 +1,235 @@
+{
+    "SPL": {
+        "smooth_checked": true,
+        "limit_checked": false,
+        "limit_data": null,
+        "weighting": "Z",
+        "analysis_channel": 0
+    },
+    "SPLF": {
+        "splf_calc_mode": "fundamental",
+        "octave_smoothing": 0,
+        "golden_sample_checked": false,
+        "limit_checked": false,
+        "limit_data": null,
+        "weighting": "Z",
+        "analysis_channel": 0
+    },
+    "Spec": {
+        "n_fft": 2048,
+        "hop_length": 256,
+        "window_func": "hann",
+        "color_map": "viridis",
+        "freq_scale_type": "linear",
+        "top_limit": 70,
+        "bottom_limit": 50,
+        "custom_limit": false,
+        "analysis_channel": 0
+    },
+    "RSC": {
+        "reference_source_path": "",
+        "reference_data_path": "",
+        "reference_data_state": "not_generated",
+        "reference_data_last_generated_at": null,
+        "use_custom_band": false,
+        "start_freq_hz": 500,
+        "end_freq_hz": 8000,
+        "highlight_analysis_band": true,
+        "enable_threshold_judgment": true,
+        "lower_offset_db": -3.0,
+        "upper_offset_db": 3.0,
+        "channel_labels": {},
+        "window": "hann",
+        "nperseg": 4096,
+        "overlap_ratio": 0.5,
+        "smoothing": 0
+    },
+    "FR": {
+        "octave_smoothing": 0,
+        "golden_sample_checked": false,
+        "limit_checked": false,
+        "limit_data": null
+    },
+    "FBA": {
+        "band_strategy": "1/3 倍频程",
+        "f_min": 20,
+        "f_max": 20000,
+        "bandwidth": 100,
+        "weighting": "A",
+        "analysis_channel": 0,
+        "limit_checked": false,
+        "limit_data": null
+    },
+    "HD": {
+        "selected_labels": [
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10
+        ],
+        "all_checked": false,
+        "golden_sample_checked": false,
+        "limit_checked": false,
+        "limit_data": null
+    },
+    "RB": {
+        "selected_labels": [
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23,
+            24,
+            25
+        ],
+        "all_checked": false,
+        "golden_sample_checked": false,
+        "limit_checked": false,
+        "limit_data": null
+    },
+    "PRB": {
+        "prb_method": "sc",
+        "masking_config": {
+            "sc_metric": "totalnl_x_ehs"
+        },
+        "golden_sample_checked": false,
+        "limit_checked": false,
+        "limit_data": null
+    },
+    "LP": {
+        "trigger_threshold": 22,
+        "hysterests_threshold": 3,
+        "min_check_duration": 2,
+        "max_check_duration": 20,
+        "loose_particle_num": 3,
+        "cutoff_freq": 2007,
+        "analysis_channel": 0
+    },
+    "PD": {
+        "filter_enabled": false,
+        "filter_ranges": "",
+        "filter_type": "bandpass",
+        "filter_order": 4,
+        "smooth_enabled": false,
+        "smooth_unit": "time",
+        "smooth_time_sec": 0.02,
+        "smooth_points": 0,
+        "smooth_algo": 1,
+        "spl_window_unit": "time",
+        "spl_window_time_sec": 0.05,
+        "spl_window_points": 0,
+        "peak_count_enabled": true,
+        "peak_count": 3,
+        "peak_size_enabled": true,
+        "peak_size_unit": "db",
+        "peak_min_value": 100.0,
+        "peak_slope_enabled": false,
+        "peak_slope_unit": "db",
+        "peak_min_slope": 100.0,
+        "nms_enabled": false,
+        "nms_unit": "time",
+        "nms_time_sec": 0.5,
+        "nms_points": 0,
+        "duration_enabled": false,
+        "duration_min": 0.0,
+        "duration_max": 0.0,
+        "advanced_mode": false,
+        "convex_unit": "audio",
+        "convex_audio_ratio": 1.0,
+        "convex_points": 1024,
+        "convex_time_sec": 0.0,
+        "duration_ref_unit": "peak",
+        "duration_ref_value": 0.5,
+        "test_peak_op": "≥",
+        "test_peak_value": 3
+    },
+    "PM": {
+        "pattern_list": [],
+        "sample_rate": 44100,
+        "feature_type": "mfcc",
+        "feature_params": {
+            "n_fft": 256,
+            "hop_length": 64,
+            "n_mels": 128,
+            "n_mfcc": 20
+        },
+        "apply_filter": false,
+        "filter_range_hz": [
+            0,
+            4000
+        ],
+        "algorithm": "dtw",
+        "similarity_metric": "cosine",
+        "threshold_strategy": "fixed_threshold",
+        "threshold_value": 0.85
+    },
+    "ED": {
+        "type": "ED",
+        "head": {
+            "type": "PD",
+            "config": {}
+        },
+        "tail": {
+            "type": "PM",
+            "config": {}
+        },
+        "auto_equal_length": false,
+        "left_grid": 0,
+        "right_grid": 0,
+        "pass_condition": {
+            "n1": 1,
+            "n2": 1
+        }
+    },
+    "AI": {
+        "analyse_model_name": "",
+        "analysis_channel": 0
+    },
+    "Excel": {
+        "enabled": true,
+        "save_dir": null,
+        "file_base": "analysis_results",
+        "add_date": true,
+        "add_model_dir": false,
+        "lock_files": true,
+        "date_format": "%Y%m%d",
+        "max_points": 2000,
+        "save_items": [],
+        "save_mes_enabled": false,
+        "mes_file_base": "D:/dataMES",
+        "mes_file_name": "Results"
+    },
+    "FFT": {
+        "n_fft": 4096,
+        "window": "hann",
+        "overlap_ratio": 0.5,
+        "weighting": "Z",
+        "x_axis_scale": "log",
+        "focus_range_enabled": true,
+        "focus_min_hz": 100,
+        "focus_max_hz": 20000,
+        "baseline_file_path": "",
+        "baseline_display_mode": "overlay",
+        "baseline_smooth_third_octave": false,
+        "dominant_tone_enabled": false,
+        "dominant_tone_intervals_text": "",
+        "dominant_tone_min_prominence_db": 3.0,
+        "dominant_tone_use_display_curve": true,
+        "limit_checked": false,
+        "limit_data": null
+    }
+}

--- a/unit_test/ui/test_analysis_config_defaults.py
+++ b/unit_test/ui/test_analysis_config_defaults.py
@@ -1,0 +1,126 @@
+import ast
+import json
+from pathlib import Path
+
+
+DEFAULT_CONFIG_PATH = Path("ui/ui_config/analysis_default_config.json")
+OPERATION_SEQUENCE_PATH = Path("ui/operation_sequence.py")
+
+EXPOSED_ANALYSIS_TYPES = {
+    "SPL",
+    "SPLF",
+    "Spec",
+    "RSC",
+    "FR",
+    "FBA",
+    "HD",
+    "RB",
+    "PRB",
+    "LP",
+    "PD",
+    "PM",
+    "ED",
+    "AI",
+    "Excel",
+}
+
+
+def load_defaults():
+    with DEFAULT_CONFIG_PATH.open("r", encoding="utf-8") as file:
+        return json.load(file)
+
+
+def test_every_exposed_analysis_type_has_default_config():
+    defaults = load_defaults()
+
+    assert EXPOSED_ANALYSIS_TYPES.issubset(defaults)
+    for analysis_type in EXPOSED_ANALYSIS_TYPES:
+        assert isinstance(defaults[analysis_type], dict), analysis_type
+
+
+def test_fft_default_is_preserved_as_legacy_or_future_item():
+    defaults = load_defaults()
+
+    assert "FFT" in defaults
+    assert defaults["FFT"]["n_fft"] == 4096
+    assert defaults["FFT"]["limit_checked"] is False
+    assert defaults["FFT"]["limit_data"] is None
+
+
+def test_curve_and_distortion_defaults_keep_legacy_threshold_and_golden_keys():
+    defaults = load_defaults()
+
+    for analysis_type in ("SPL", "SPLF", "FR", "FBA", "HD", "RB", "PRB"):
+        assert defaults[analysis_type]["limit_checked"] is False
+        assert "limit_data" in defaults[analysis_type]
+
+    for analysis_type in ("SPLF", "FR", "HD", "RB", "PRB"):
+        assert defaults[analysis_type]["golden_sample_checked"] is False
+
+
+def test_channel_defaults_are_present_for_channel_aware_dialogs():
+    defaults = load_defaults()
+
+    for analysis_type in ("SPL", "SPLF", "Spec", "FBA", "LP", "AI"):
+        assert defaults[analysis_type]["analysis_channel"] == 0
+
+
+def test_special_dialog_defaults_include_required_legacy_keys():
+    defaults = load_defaults()
+
+    assert defaults["RSC"]["smoothing"] == 0
+    assert "octave_smoothing" not in defaults["RSC"]
+    assert defaults["RSC"]["enable_threshold_judgment"] is True
+    assert defaults["RSC"]["channel_labels"] == {}
+
+    pd_defaults = defaults["PD"]
+    for key in (
+        "smooth_enabled",
+        "smooth_unit",
+        "smooth_time_sec",
+        "smooth_points",
+        "smooth_algo",
+        "spl_window_unit",
+        "nms_unit",
+        "advanced_mode",
+        "test_peak_op",
+    ):
+        assert key in pd_defaults
+
+    ed_defaults = defaults["ED"]
+    assert ed_defaults["head"] == {"type": "PD", "config": {}}
+    assert ed_defaults["tail"] == {"type": "PM", "config": {}}
+    assert ed_defaults["pass_condition"] == {"n1": 1, "n2": 1}
+
+    excel_defaults = defaults["Excel"]
+    assert excel_defaults["save_items"] == []
+    assert excel_defaults["save_dir"] is None
+    assert excel_defaults["file_base"] == "analysis_results"
+
+
+def test_pattern_match_default_does_not_depend_on_local_template_file():
+    defaults = load_defaults()
+
+    assert defaults["PM"]["pattern_list"] == []
+    assert "pattern_save_path" not in defaults["PM"]
+    assert "pattern_duration_sec" not in defaults["PM"]
+
+
+def test_get_item_default_config_deep_copies_default_before_adding_type():
+    tree = ast.parse(OPERATION_SEQUENCE_PATH.read_text(encoding="utf-8"))
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "get_item_default_config":
+            calls = [
+                call
+                for call in ast.walk(node)
+                if isinstance(call, ast.Call)
+                and isinstance(call.func, ast.Attribute)
+                and call.func.attr == "deepcopy"
+                and isinstance(call.func.value, ast.Name)
+                and call.func.value.id == "copy"
+            ]
+            assert calls, "get_item_default_config must deep-copy defaults before adding type"
+            return
+
+    raise AssertionError("get_item_default_config was not found")

--- a/unit_test/ui/test_analysis_config_dialog_migration.py
+++ b/unit_test/ui/test_analysis_config_dialog_migration.py
@@ -5,7 +5,8 @@ import types
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 import pytest
-from PyQt5.QtWidgets import QApplication
+from PyQt5.QtGui import QStandardItemModel
+from PyQt5.QtWidgets import QApplication, QTableView
 
 from consts import error_code
 
@@ -21,6 +22,63 @@ class FakeConfigManager:
     def save_default_config(self, model_type, config_data):
         self.saved.append((model_type, config_data))
         return True
+
+
+def stub_pattern_match_import_dependencies(monkeypatch):
+    class FakeLoadUiConfig:
+        @staticmethod
+        def load_data_from_json(_file_path):
+            return 0, {}
+
+    class FakeFileOps:
+        @staticmethod
+        def get_relative_path(file_path, _base_path):
+            return file_path
+
+    class FakeDataView(QTableView):
+        def __init__(self, rows, columns, _data):
+            super().__init__()
+            self._model = QStandardItemModel(rows, columns)
+            self.setModel(self._model)
+
+        def set_h_header(self, labels):
+            self._model.setHorizontalHeaderLabels(labels)
+
+    class FakeAudioClipExtractionDialog:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def on_exec(self):
+            return None, None, None
+
+    class FakeGenericFeatureParamsDialog:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def exec_(self):
+            return 0
+
+        def get_params(self):
+            return {}
+
+    monkeypatch.setitem(sys.modules, "base.load_config", types.SimpleNamespace(LoadUiConfig=FakeLoadUiConfig))
+    monkeypatch.setitem(sys.modules, "base.file_ops", types.SimpleNamespace(FileOps=FakeFileOps))
+    monkeypatch.setitem(sys.modules, "base.load_audio", types.SimpleNamespace(load_audio_simple=lambda *_: ([], None)))
+    monkeypatch.setitem(
+        sys.modules,
+        "ui.custom_ui_widget.custom_table_widget",
+        types.SimpleNamespace(DataView=FakeDataView),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "ui.custom_ui_widget.audio_clip_extraction_dialog",
+        types.SimpleNamespace(AudioClipExtractionDialog=FakeAudioClipExtractionDialog),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "ui.generic_feature_params_dialog",
+        types.SimpleNamespace(GenericFeatureParamsDialog=FakeGenericFeatureParamsDialog),
+    )
 
 
 @pytest.fixture(scope="module")
@@ -112,4 +170,334 @@ def test_spec_dialog_preserves_saved_keys_after_channel_migration(qapp):
         "bottom_limit": 35,
         "custom_limit": True,
         "analysis_channel": 3,
+    }
+
+
+def test_spl_dialog_preserves_saved_keys_after_shared_control_migration(qapp):
+    from ui.ui_analysis_config.spl_config_dialog import SplConfigWindow
+
+    config_manager = FakeConfigManager(
+        {
+            "SPL": {
+                "smooth_checked": True,
+                "limit_checked": False,
+                "limit_data": None,
+                "weighting": "C",
+                "analysis_channel": 2,
+            }
+        }
+    )
+
+    window = SplConfigWindow(config_manager, "SPL", available_channels=[0, 2])
+
+    assert window.get_default_config() == {
+        "smooth_checked": True,
+        "limit_checked": False,
+        "limit_data": None,
+        "weighting": "C",
+        "analysis_channel": 2,
+    }
+
+
+def test_splf_dialog_preserves_saved_keys_after_shared_control_migration(qapp):
+    from ui.ui_analysis_config.spl_config_dialog import SplConfigWindow
+
+    config_manager = FakeConfigManager(
+        {
+            "SPLF": {
+                "splf_calc_mode": "total",
+                "octave_smoothing": 3,
+                "golden_sample_checked": True,
+                "limit_checked": False,
+                "limit_data": None,
+                "weighting": "Z（None）",
+                "analysis_channel": 1,
+            }
+        }
+    )
+
+    window = SplConfigWindow(config_manager, "SPLF", available_channels=[0, 1])
+
+    assert window.get_default_config() == {
+        "splf_calc_mode": "total",
+        "octave_smoothing": 3,
+        "golden_sample_checked": True,
+        "limit_checked": False,
+        "limit_data": None,
+        "weighting": "Z",
+        "analysis_channel": 1,
+    }
+
+
+def test_fr_dialog_uses_shared_octave_smoothing_legacy_fallback(qapp):
+    from ui.ui_analysis_config.fr_config_dialog import FrConfigWindow
+
+    config_manager = FakeConfigManager(
+        {
+            "FR": {
+                "smooth_checked": True,
+                "golden_sample_checked": True,
+                "limit_checked": False,
+                "limit_data": None,
+            }
+        }
+    )
+
+    window = FrConfigWindow(config_manager, "FR")
+
+    assert window.get_default_config() == {
+        "octave_smoothing": 6,
+        "golden_sample_checked": True,
+        "limit_checked": False,
+        "limit_data": None,
+    }
+
+
+def test_fba_dialog_preserves_saved_keys_after_shared_control_migration(qapp):
+    from ui.ui_analysis_config.fba_config_dialog import FbaConfigWindow
+
+    config_manager = FakeConfigManager(
+        {
+            "FBA": {
+                "band_strategy": "1/3 倍频程",
+                "f_min": 50,
+                "f_max": 16000,
+                "bandwidth": 200,
+                "weighting": "Z（None）",
+                "analysis_channel": 3,
+                "limit_checked": False,
+                "limit_data": None,
+            }
+        }
+    )
+
+    window = FbaConfigWindow(config_manager, "FBA", available_channels=[1, 3])
+
+    assert window.get_default_config() == {
+        "band_strategy": "1/3 倍频程",
+        "f_min": 50,
+        "f_max": 16000,
+        "bandwidth": 200,
+        "analysis_channel": 3,
+        "weighting": "Z",
+        "limit_checked": False,
+        "limit_data": None,
+    }
+
+
+def test_hd_dialog_uses_shared_harmonic_and_golden_widgets(qapp):
+    from ui.ui_analysis_config.hd_config_dialog import HdConfigWindow
+
+    config_manager = FakeConfigManager(
+        {
+            "HD": {
+                "selected_labels": [2, "3", 40],
+                "all_checked": False,
+                "golden_sample_checked": True,
+                "limit_checked": False,
+                "limit_data": None,
+            }
+        }
+    )
+
+    window = HdConfigWindow(config_manager, "HD")
+
+    assert window.get_default_config() == {
+        "selected_labels": [2, 3],
+        "all_checked": False,
+        "golden_sample_checked": True,
+        "limit_checked": False,
+        "limit_data": None,
+    }
+
+
+def test_rb_dialog_filters_harmonics_to_rub_buzz_range(qapp):
+    from ui.ui_analysis_config.rb_config_dialog import RbConfigWindow
+
+    config_manager = FakeConfigManager(
+        {
+            "RB": {
+                "selected_labels": [2, 10, "12", 40],
+                "all_checked": False,
+                "golden_sample_checked": False,
+                "limit_checked": False,
+                "limit_data": None,
+            }
+        }
+    )
+
+    window = RbConfigWindow(config_manager, "RB")
+
+    assert window.get_default_config() == {
+        "selected_labels": [10, 12],
+        "all_checked": False,
+        "golden_sample_checked": False,
+        "limit_checked": False,
+        "limit_data": None,
+    }
+
+
+def test_prb_dialog_preserves_metric_fallback_and_golden_sample(qapp):
+    from ui.ui_analysis_config.perceptual_rb_config_dialog import PerceptualRbConfigWindow
+
+    config_manager = FakeConfigManager(
+        {
+            "PRB": {
+                "masking_config": {"sc_metric": "totalnl_phons", "keep": "value"},
+                "golden_sample_checked": True,
+                "limit_checked": False,
+                "limit_data": None,
+            }
+        }
+    )
+
+    window = PerceptualRbConfigWindow(config_manager, "PRB")
+    config = window.get_default_config()
+
+    assert config["prb_method"] == "sc"
+    assert config["masking_config"] == {"sc_metric": "totalnl_x_ehs", "keep": "value"}
+    assert config["golden_sample_checked"] is True
+    assert config["limit_checked"] is False
+    assert config["limit_data"] is None
+
+
+def test_rsc_dialog_keeps_smoothing_key_after_shared_selector_migration(qapp, monkeypatch):
+    from ui.ui_analysis_config import reference_spectrum_config_dialog as rsc_dialog
+
+    monkeypatch.setattr(rsc_dialog, "get_reference_data_state", lambda **_: "not_generated")
+    config_manager = FakeConfigManager(
+        {
+            "RSC": {
+                "reference_source_path": "",
+                "reference_data_path": "",
+                "use_custom_band": False,
+                "start_freq_hz": 100,
+                "end_freq_hz": 1000,
+                "highlight_analysis_band": False,
+                "enable_threshold_judgment": True,
+                "lower_offset_db": -2.0,
+                "upper_offset_db": 2.0,
+                "channel_labels": {},
+                "window": "hann",
+                "nperseg": 4096,
+                "overlap_ratio": 0.5,
+                "smoothing": 3,
+            }
+        }
+    )
+
+    window = rsc_dialog.ReferenceSpectrumConfigWindow(config_manager, "RSC")
+    config = window.get_default_config()
+
+    assert config["smoothing"] == 3
+    assert "octave_smoothing" not in config
+    assert config["enable_threshold_judgment"] is True
+    assert config["lower_offset_db"] == -2.0
+    assert config["upper_offset_db"] == 2.0
+
+
+def test_pd_dialog_preserves_time_smoothing_keys_after_widget_migration(qapp):
+    from ui.ui_analysis_config.pd_config_dialog import PDConfigWindow
+
+    config_manager = FakeConfigManager(
+        {
+            "PD": {
+                "smooth_enabled": True,
+                "smooth_unit": "points",
+                "smooth_time_sec": 0.125,
+                "smooth_points": 0,
+                "smooth_algo": 3,
+            }
+        }
+    )
+
+    window = PDConfigWindow(config_manager, "PD")
+    config = window.get_default_config()
+
+    assert config["smooth_enabled"] is True
+    assert config["smooth_unit"] == "points"
+    assert config["smooth_time_sec"] == 0.125
+    assert config["smooth_points"] == 0
+    assert config["smooth_algo"] == 3
+
+
+def test_pm_dialog_preserves_fixed_threshold_config_after_button_migration(qapp, monkeypatch):
+    stub_pattern_match_import_dependencies(monkeypatch)
+    from ui.ui_analysis_config import pattern_match_config_dialog as pm_dialog
+
+    monkeypatch.setattr(
+        pm_dialog.PatternMatchConfigWindow,
+        "load_features_param_config",
+        staticmethod(
+            lambda: (
+                True,
+                {
+                    "mfcc": {
+                        "display_name": "MFCC",
+                        "params": {"n_mfcc": {"default": 13}},
+                    }
+                },
+            )
+        ),
+    )
+    config_manager = FakeConfigManager(
+        {
+            "PM": {
+                "pattern_list": [],
+                "sample_rate": 48000,
+                "feature_type": "mfcc",
+                "feature_params": {"n_mfcc": 20},
+                "apply_filter": True,
+                "filter_range_hz": [100, 5000],
+                "similarity_metric": "cosine",
+                "threshold_strategy": "fixed_threshold",
+                "threshold_value": 0.75,
+            }
+        }
+    )
+
+    window = pm_dialog.PatternMatchConfigWindow(config_manager, "PM")
+
+    assert window.get_config() == {
+        "pattern_list": [],
+        "sample_rate": 48000,
+        "feature_type": "mfcc",
+        "feature_params": {"n_mfcc": 20},
+        "apply_filter": True,
+        "filter_range_hz": (100, 5000),
+        "algorithm": "dtw",
+        "similarity_metric": "cosine",
+        "threshold_strategy": "fixed_threshold",
+        "threshold_value": 0.75,
+    }
+
+
+def test_pipeline_pd_pm_dialog_preserves_nested_config_after_base_migration(qapp, monkeypatch):
+    stub_pattern_match_import_dependencies(monkeypatch)
+    from ui.ui_analysis_config.pipeline_pd_pm_config import PipelinePdPmConfigWindow
+
+    config_manager = FakeConfigManager(
+        {
+            "ED": {
+                "type": "ED",
+                "head": {"type": "PD", "config": {"peak_count": 2}},
+                "tail": {"type": "PM", "config": {"threshold_value": 0.8}},
+                "auto_equal_length": False,
+                "left_grid": 10,
+                "right_grid": 20,
+                "pass_condition": {"n1": 2, "n2": 5},
+            }
+        }
+    )
+
+    window = PipelinePdPmConfigWindow(config_manager, "ED")
+
+    assert window.get_default_config() == {
+        "type": "ED",
+        "head": {"type": "PD", "config": {"peak_count": 2}},
+        "tail": {"type": "PM", "config": {"threshold_value": 0.8}},
+        "auto_equal_length": False,
+        "left_grid": 10,
+        "right_grid": 20,
+        "pass_condition": {"n1": 2, "n2": 5},
     }


### PR DESCRIPTION
## Summary

- Added complete conservative defaults for exposed analysis configuration items.
- Deep-copied default analysis configs when adding operation sequence entries.
- Added unit test coverage for analysis default config contracts.

## Changes

- `ui/operation_sequence.py`: Uses deep-copied analysis defaults for sequence entries.
- `ui/ui_config/analysis_default_config.json`: Adds default configuration values for exposed analysis items.
- `unit_test/ui/test_analysis_config_defaults.py`: Adds tests for default config coverage and isolation.

## Test Plan

- [ ] Not run during PR creation; PR is based on the latest existing commit.