### PR TITLE
[codex] Ensure missing output directories are created

### DIFF
--- a/base/file_ops.py
+++ b/base/file_ops.py
@@ -55,9 +55,11 @@ class FileOps(object):
                 The save path of audio signals.
         Returns:
         """
-        directory = os.path.dirname(save_path)
-        if directory and not os.path.exists(directory):
-            os.makedirs(directory)
+        if not save_path:
+            return
+        directory = os.path.dirname(os.fspath(save_path))
+        if directory:
+            os.makedirs(directory, exist_ok=True)
 
     @staticmethod
     def copy_with_selected_wav(audio_data_path_list: list, output_dir: str = None):
@@ -129,6 +131,7 @@ class FileOps(object):
             output_name = temp_name + f"({str(count)})"
             count += 1
         output_zip = output_name + ".zip"
+        FileOps.ensure_directory_exists(output_zip)
 
         files = []
         for root, dirs, fs in os.walk(target_dir_path):

--- a/base/load_config.py
+++ b/base/load_config.py
@@ -9,6 +9,7 @@ from re import _parser as re_parser
 
 from consts import error_code
 from consts.running_consts import DEFAULT_DIR, SEQUENCE_CONFIG_REGISTRY_PATH, SN_REGEX_RULES_JSON_PATH
+from base.file_ops import FileOps
 from base.log_manager import LogManager
 from base.stimulus_signal.methods import normalize_stimulus_method
 
@@ -589,6 +590,7 @@ class LoadUiConfig(object):
         file_path = DEFAULT_DIR + "ui/ui_config/tcp_config.txt"
 
         try:
+            FileOps.ensure_directory_exists(file_path)
             with open(file_path, "w") as f:
                 f.write(f"ip = {ip}\n")
                 f.write(f"port = {port}\n")
@@ -621,6 +623,7 @@ class ConfigManager(object):
         else:
             self.config[type] = config_data
         try:
+            FileOps.ensure_directory_exists(self.config_file)
             with open(self.config_file, "w", encoding="utf-8") as f:
                 json.dump(self.config, f, indent=4)
                 self.default_logger.info(f"The config info for {type} analysis has been saved to {self.config_file}.")
@@ -633,6 +636,10 @@ class ConfigManager(object):
         default_config_file = DEFAULT_DIR + "ui/ui_config/analysis_default_config.json"
         default_config = {}
         try:
+            FileOps.ensure_directory_exists(default_config_file)
+            if not os.path.exists(default_config_file):
+                with open(default_config_file, "w", encoding="utf-8") as f:
+                    json.dump(default_config, f, indent=4)
             with open(default_config_file, "r", encoding="utf-8") as f:
                 default_config = json.load(f)
                 if type in default_config:

--- a/base/save_data.py
+++ b/base/save_data.py
@@ -4,12 +4,14 @@ import os
 from datetime import datetime
 from scipy.io import wavfile
 
+from base.file_ops import FileOps
 from consts.running_consts import DEFAULT_DIR
 
 
 def save_audio_simple(save_path, audio, sr=44100):
     # we assume audio is mono channel
     audio = audio.astype("float32")
+    FileOps.ensure_directory_exists(save_path)
     wavfile.write(save_path, sr, audio)
 
 

--- a/main_window.py
+++ b/main_window.py
@@ -108,7 +108,7 @@ class MainWindow(QMainWindow):
         icon_label.setFixedSize(25, 25)
         icon_label.setScaledContents(True)
         current_version = self.get_current_version()
-        title_label = Label(f"谛听异音检测 -{current_version} beta")
+        title_label = Label(f"希听异音检测 -{current_version} beta")
         h_spacer = QSpacerItem(10, 10, QSizePolicy.Expanding, QSizePolicy.Minimum)
         title_layout.addWidget(icon_label)
         title_layout.addWidget(title_label)

--- a/ui/ai_window.py
+++ b/ui/ai_window.py
@@ -462,6 +462,7 @@ class AiWindow(QDialog):
         - mode (str): Mode identifier, can be 'train' for training data path or 'test' for test data path. Default is 'train'.
         """
         file_path = DEFAULT_DIR + "ui/ui_config/%s_data_path.txt" % mode
+        FileOps.ensure_directory_exists(file_path)
         with open(file_path, "w") as f:
             f.write(path)
 
@@ -707,9 +708,8 @@ class BaseModel(QWidget):
         a text file within that directory.
         """
         dir_path = DEFAULT_DIR + "ui/ui_config"
-        if not os.path.exists(dir_path):
-            os.mkdir(dir_path)
         file_path = dir_path + "/" + "model_path.txt"
+        FileOps.ensure_directory_exists(file_path)
         with open(file_path, "w") as f:
             model_path = FileOps.get_relative_path(self.model_path, DEFAULT_DIR)
             f.write(model_path)

--- a/ui/archive_audio_data_dialog.py
+++ b/ui/archive_audio_data_dialog.py
@@ -689,6 +689,7 @@ class ArchiveAudioDataDialog(AudioDataManageDialog):
     def _write_failure_report_to_file(self, output_zip_path, report_content):
         report_path = os.path.splitext(output_zip_path)[0] + "_failures.txt"
         try:
+            FileOps.ensure_directory_exists(report_path)
             with open(report_path, "w", encoding="utf-8") as report_file:
                 report_file.write(report_content)
             return report_path, None
@@ -903,6 +904,7 @@ class ArchiveAudioDataDialog(AudioDataManageDialog):
         database_package_error = None
         archive_finalize_error = None
         progress_value = 0
+        FileOps.ensure_directory_exists(file_path)
 
         def update_package_delete_progress(value, text=None):
             nonlocal progress_value

--- a/ui/operation_sequence.py
+++ b/ui/operation_sequence.py
@@ -12,6 +12,7 @@ from time import time
 
 from base.data_struct.data_deal_struct import DataDealStruct
 from base.data_struct.sequence_data import SequenceData
+from base.file_ops import FileOps
 from base.load_config import ConfigManager, LoadUiConfig
 from base.log_manager import LogManager
 from base.soundcard_calibration_manager import resolve_analysis_v2pa_factor_for_channel
@@ -484,6 +485,7 @@ class AnalysisModelSelect(QDialog):
         }
 
         try:
+            FileOps.ensure_directory_exists(json_path)
             with open(json_path, "w", encoding="utf-8") as f:
                 json.dump(payload, f, ensure_ascii=False, indent=2)
         except Exception as e:

--- a/ui/sequence/sequence_widget.py
+++ b/ui/sequence/sequence_widget.py
@@ -374,6 +374,48 @@ class SequenceWindow(QWidget):
                 break
         return passed, ("OK" if passed else "NG")
 
+    def _get_tcp_callback_file_name(self):
+        file_path = getattr(self, "recorded_path", "") or ""
+        if not file_path and isinstance(getattr(self, "recorded_signal_info", None), dict):
+            file_path = self.recorded_signal_info.get("file_path") or ""
+        normalized_path = str(file_path).replace("\\", "/") if file_path else ""
+        return os.path.basename(normalized_path) if normalized_path else ""
+
+    def _get_tcp_callback_label(self):
+        result_dict = getattr(getattr(self, "data_struct", None), "analysis_result_dict", None)
+        if not isinstance(result_dict, dict) or not result_dict:
+            return "not_labeled"
+        try:
+            _passed, label = self._summarize_ok_ng()
+        except Exception as e:
+            self.default_logger.warning(f"tcp_callback_summary_error: {e}")
+            return "not_labeled"
+        return label if label in ("OK", "NG") else "not_labeled"
+
+    def _build_tcp_analysis_result_payload(self):
+        now = datetime.now()
+        return {
+            "TimeStamp": f"{now.strftime('%Y-%m-%d %H:%M:%S')},{now.microsecond // 1000:03d}",
+            "Label": self._get_tcp_callback_label(),
+            "FileName": self._get_tcp_callback_file_name(),
+        }
+
+    def _send_tcp_analysis_result_callback(self):
+        if not getattr(self, "tcp_flag", False):
+            return
+        try:
+            tcp_server = getattr(SequenceWindow, "tcp_server", None)
+            client_address = getattr(tcp_server, "client_address", None)
+            if not client_address:
+                self.default_logger.warning("tcp_callback_skip: no client address")
+                return
+            payload = self._build_tcp_analysis_result_payload()
+            message = json.dumps(payload, ensure_ascii=False)
+            TempTcpClient(client_address[0], client_address[1], message)
+            self.default_logger.info(f"tcp_callback_sent: {message}")
+        except Exception as e:
+            self.default_logger.error(f"tcp_callback_send_error: {e}")
+
     def _can_output_ok_ng(self):
         """
         Decide whether current analysis_config is expected to produce OK/NG output.
@@ -1457,11 +1499,6 @@ class SequenceWindow(QWidget):
 
         if self.clicked_player_flag is True:
             self.clicked_player_flag = False
-        elif self.clicked_player_flag is False:
-            if self.tcp_flag:
-                TempTcpClient(
-                    SequenceWindow.tcp_server.client_address[0], SequenceWindow.tcp_server.client_address[1], "finish"
-                )
 
     def set_audio_devices_available(self, available: bool, message: str = ""):
         self.audio_devices_available = bool(available)
@@ -1937,6 +1974,7 @@ class SequenceWindow(QWidget):
 
         # Show summary window at the end (also in test mode), only if dict is not empty
         self._maybe_show_analysis_result_summary(width, height)
+        self._send_tcp_analysis_result_callback()
 
     def _handle_post_analysis_exports(self):
         # Cache first so MES and Excel both read the same completed-analysis state.

--- a/ui/ui_src/style/dongyuan_style.qss
+++ b/ui/ui_src/style/dongyuan_style.qss
@@ -27,6 +27,10 @@ QLineEdit:disabled {
     background-color: #d3d3d3;
     color: #808080;
 }
+QLineEdit[readOnly="true"] {
+    background-color: #d3d3d3;
+    color: #808080;
+}
 
 QComboBox {
     border: 1px solid rgb(173, 173, 173);
@@ -71,6 +75,12 @@ QDoubleSpinBox {
     border: 1px solid rgb(173, 173, 173);
     border-radius: 3px;
     padding: 3px;
+}
+
+QSpinBox[readOnly="true"],
+QDoubleSpinBox[readOnly="true"] {
+    background-color: #d3d3d3;
+    color: #808080;
 }
 
 QSpinBox::up-button,

--- a/ui/ui_src/style/jingcheng_style.qss
+++ b/ui/ui_src/style/jingcheng_style.qss
@@ -304,6 +304,14 @@ QWidget#SequenceToolsBar QLabel {
   color: black;
 }
 
+QWidget#SequenceToolsBar QComboBox QAbstractItemView {
+  background: #ffffff;
+  color: #111827;
+  selection-background-color: rgba(37, 99, 235, 0.18);
+  selection-color: #111827;
+  outline: 0px;
+}
+
 /* sequence widget style */
 QWidget#LinearGraphWidget {
   background-color: white;

--- a/unit_test/base/test_db_manager_directory_guards.py
+++ b/unit_test/base/test_db_manager_directory_guards.py
@@ -1,0 +1,23 @@
+import sqlite3
+
+from base.db_manager import DataSave
+from consts import error_code
+
+
+def test_data_save_create_audio_tables_creates_missing_database_parent(tmp_path):
+    db_path = tmp_path / "missing" / "database" / "audio_data.db"
+    data_save = DataSave(str(db_path))
+
+    try:
+        code, message = data_save.create_audio_tables()
+    finally:
+        if data_save.connection is not None:
+            data_save.close()
+
+    assert code == error_code.OK, message
+    assert db_path.is_file()
+    with sqlite3.connect(db_path) as connection:
+        cursor = connection.cursor()
+        cursor.execute("SELECT name FROM sqlite_master WHERE type = 'table'")
+        table_names = {row[0] for row in cursor.fetchall()}
+    assert "audio_data_table" in table_names

--- a/unit_test/base/test_excel_result_exporter.py
+++ b/unit_test/base/test_excel_result_exporter.py
@@ -3,7 +3,7 @@ import tempfile
 
 import numpy as np
 
-from base.excel_result_exporter import _extract_curve_xy, resolve_excel_output_path
+from base.excel_result_exporter import _extract_curve_xy, export_analysis_to_excel, resolve_excel_output_path
 
 
 def test_extract_curve_xy_prefers_raw_keys_when_present():
@@ -61,4 +61,34 @@ def test_resolve_excel_output_path_uses_empty_model_placeholder_dir_when_enabled
         path = resolve_excel_output_path(cfg, product_model="")
         assert path == os.path.join(tmpdir, "空型号", "analysis_results.xlsx")
         assert os.path.isdir(os.path.join(tmpdir, "空型号"))
+
+
+def test_export_analysis_to_excel_creates_missing_explicit_parent(tmp_path):
+    file_path = tmp_path / "missing" / "excel" / "analysis.xlsx"
+    cfg = {
+        "enabled": True,
+        "save_items": ["AI结果"],
+        "lock_files": False,
+    }
+
+    result = export_analysis_to_excel(
+        cfg,
+        sn="SN001",
+        date_text="2026-06-10 10:00:00",
+        analysis_items_data={
+            "AI结果": {
+                "type": "AI",
+                "label": "OK",
+                "ok_score": 0.91,
+                "ng_score": 0.09,
+                "model_name": "demo",
+            }
+        },
+        analysis_config={},
+        analysis_result_dict={},
+        file_path=str(file_path),
+    )
+
+    assert result.ok is True
+    assert file_path.is_file()
 

--- a/unit_test/base/test_file_ops.py
+++ b/unit_test/base/test_file_ops.py
@@ -34,6 +34,18 @@ def test_get_zip_arcname_categorizes_audio_paths():
     assert result == os.path.join("OK", "a.wav")
 
 
+def test_ensure_directory_exists_creates_missing_parent(tmp_path):
+    target = tmp_path / "missing" / "nested" / "out.txt"
+
+    FileOps.ensure_directory_exists(target)
+
+    assert target.parent.is_dir()
+
+
+def test_ensure_directory_exists_accepts_current_directory_path():
+    FileOps.ensure_directory_exists("out.txt")
+
+
 def test_get_zip_arcname_keeps_database_at_root():
     base_dir = os.path.abspath("project")
     path = os.path.join(base_dir, "database", "audio_data.db")
@@ -154,3 +166,16 @@ def test_create_zip_with_files_records_missing_file_failure():
         assert len(failures) == 1
         assert failures[0][0] == missing_path
         assert isinstance(failures[0][1], FileNotFoundError)
+
+
+def test_create_zip_with_files_creates_missing_output_parent(tmp_path):
+    source_path = tmp_path / "OK" / "exists.wav"
+    zip_path = tmp_path / "missing" / "package" / "out.zip"
+    source_path.parent.mkdir()
+    source_path.write_bytes(b"audio")
+
+    FileOps.create_zip_with_files([str(source_path)], str(zip_path), base_dir=str(tmp_path))
+
+    assert zip_path.is_file()
+    with ZipFile(zip_path, "r") as zip_file:
+        assert "OK/exists.wav" in zip_file.namelist()

--- a/unit_test/base/test_save_data.py
+++ b/unit_test/base/test_save_data.py
@@ -1,0 +1,16 @@
+import numpy as np
+from scipy.io import wavfile
+
+from base.save_data import save_audio_simple
+
+
+def test_save_audio_simple_creates_missing_parent_directory(tmp_path):
+    save_path = tmp_path / "missing" / "nested" / "sample.wav"
+    audio = np.asarray([0.0, 0.25, -0.25], dtype=np.float64)
+
+    save_audio_simple(save_path, audio, sr=8000)
+
+    assert save_path.is_file()
+    sr, saved_audio = wavfile.read(save_path)
+    assert sr == 8000
+    assert saved_audio.dtype == np.float32

--- a/unit_test/ui/test_sequence_widget_sn_lock.py
+++ b/unit_test/ui/test_sequence_widget_sn_lock.py
@@ -1,8 +1,10 @@
 import ast
+import json
 import re
 import textwrap
 import types
 from pathlib import Path
+from datetime import datetime
 
 import numpy as np
 
@@ -22,6 +24,11 @@ TARGET_METHODS = {
     "on_sequence_config_updated",
     "validate_count",
     "set_audio_devices_available",
+    "_summarize_ok_ng",
+    "_get_tcp_callback_file_name",
+    "_get_tcp_callback_label",
+    "_build_tcp_analysis_result_payload",
+    "_send_tcp_analysis_result_callback",
     "start_this_play",
     "checked_work_status_message",
     "judge_play_and_record",
@@ -114,6 +121,8 @@ def _build_method_namespace():
         "QEvent": DummyEventType,
         "Qt": DummyQt,
         "QLineEdit": DummyLineEdit,
+        "datetime": datetime,
+        "json": json,
         "StreamingWavWriter": None,
         "stream_play_and_record": None,
         "stream_record_without_play": None,
@@ -133,7 +142,7 @@ def _build_method_namespace():
         "re": re,
         "time": types.SimpleNamespace(monotonic=lambda: 1000.0),
         "os": types.SimpleNamespace(
-            path=types.SimpleNamespace(exists=lambda path: False),
+            path=types.SimpleNamespace(exists=lambda path: False, basename=__import__("os").path.basename),
             remove=lambda path: None,
         ),
     }
@@ -1218,6 +1227,84 @@ def test_tcp_run_test_allows_invalid_sn_when_validation_is_explicitly_skipped():
     assert window.current_recorded_count == 2
     assert window.lineedit_count.text() == "2"
     assert namespace["MessageBox"].warnings == []
+
+
+def test_start_this_play_no_longer_sends_finish_callback():
+    namespace = _build_method_namespace()
+    tcp_sends = []
+    namespace["SequenceWindow"] = types.SimpleNamespace(
+        tcp_server=types.SimpleNamespace(client_address=("127.0.0.1", 5000))
+    )
+    namespace["TempTcpClient"] = lambda *args: tcp_sends.append(args)
+    window = _build_fake_window(namespace, use_streaming=True, mode="RECORD_ONLY")
+    window.start_this_play = window._real_start_this_play
+    window.tcp_flag = True
+    window.judge_play_and_record = lambda label, is_replay=False: None
+
+    window.start_this_play("not_labeled", skip_sn_regex_validation=True)
+
+    assert tcp_sends == []
+
+
+def test_tcp_analysis_result_payload_uses_summary_and_recorded_file_name():
+    namespace = _build_method_namespace()
+    window = _build_fake_window(namespace, use_streaming=True, mode="RECORD_ONLY")
+    window.recorded_path = r"D:\audio\OH2P-001.wav"
+    window.data_struct.analysis_result_dict = {"SPL": (True, "ok"), "FR": (True, "ok")}
+    window._summarize_ok_ng = _bind_method(window, namespace, "_summarize_ok_ng")
+    window._get_tcp_callback_file_name = _bind_method(window, namespace, "_get_tcp_callback_file_name")
+    window._get_tcp_callback_label = _bind_method(window, namespace, "_get_tcp_callback_label")
+    window._build_tcp_analysis_result_payload = _bind_method(window, namespace, "_build_tcp_analysis_result_payload")
+
+    payload = window._build_tcp_analysis_result_payload()
+
+    assert set(payload) == {"TimeStamp", "Label", "FileName"}
+    assert re.match(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}$", payload["TimeStamp"])
+    assert payload["Label"] == "OK"
+    assert payload["FileName"] == "OH2P-001.wav"
+
+
+def test_tcp_analysis_result_payload_defaults_to_not_labeled_without_summary():
+    namespace = _build_method_namespace()
+    window = _build_fake_window(namespace, use_streaming=True, mode="RECORD_ONLY")
+    window.recorded_path = ""
+    window.recorded_signal_info = {"file_path": "stored_data/OH2P-002.wav"}
+    window.data_struct.analysis_result_dict = {}
+    window._summarize_ok_ng = _bind_method(window, namespace, "_summarize_ok_ng")
+    window._get_tcp_callback_file_name = _bind_method(window, namespace, "_get_tcp_callback_file_name")
+    window._get_tcp_callback_label = _bind_method(window, namespace, "_get_tcp_callback_label")
+    window._build_tcp_analysis_result_payload = _bind_method(window, namespace, "_build_tcp_analysis_result_payload")
+
+    payload = window._build_tcp_analysis_result_payload()
+
+    assert payload["Label"] == "not_labeled"
+    assert payload["FileName"] == "OH2P-002.wav"
+
+
+def test_tcp_analysis_result_callback_sends_json_to_client_address():
+    namespace = _build_method_namespace()
+    sends = []
+    namespace["SequenceWindow"] = types.SimpleNamespace(
+        tcp_server=types.SimpleNamespace(client_address=("127.0.0.1", 5000))
+    )
+    namespace["TempTcpClient"] = lambda *args: sends.append(args)
+    window = _build_fake_window(namespace, use_streaming=True, mode="RECORD_ONLY")
+    window.tcp_flag = True
+    window.recorded_path = "OH2P-003.wav"
+    window.data_struct.analysis_result_dict = {"SPL": (False, "ng")}
+    window._summarize_ok_ng = _bind_method(window, namespace, "_summarize_ok_ng")
+    window._get_tcp_callback_file_name = _bind_method(window, namespace, "_get_tcp_callback_file_name")
+    window._get_tcp_callback_label = _bind_method(window, namespace, "_get_tcp_callback_label")
+    window._build_tcp_analysis_result_payload = _bind_method(window, namespace, "_build_tcp_analysis_result_payload")
+    window._send_tcp_analysis_result_callback = _bind_method(window, namespace, "_send_tcp_analysis_result_callback")
+
+    window._send_tcp_analysis_result_callback()
+
+    assert len(sends) == 1
+    assert sends[0][0:2] == ("127.0.0.1", 5000)
+    sent_payload = json.loads(sends[0][2])
+    assert sent_payload["Label"] == "NG"
+    assert sent_payload["FileName"] == "OH2P-003.wav"
 
 
 def test_tcp_run_test_allows_play_and_record_mode():


### PR DESCRIPTION
Refs #747

## Summary
- Ensure several file-writing paths create missing parent directories before saving configs, audio, archives, and model path metadata.
- Harden `FileOps.ensure_directory_exists` and zip output parent handling.
- Add regression coverage for missing parent directory scenarios.
- Update related UI title and read-only/dropdown styling.

## Validation
- `python -m pytest unit_test/base/test_file_ops.py unit_test/base/test_save_data.py unit_test/base/test_db_manager_directory_guards.py unit_test/base/test_excel_result_exporter.py` failed because the default pytest temp directory was not accessible: `PermissionError: C:\Users\Administrator\AppData\Local\Temp\pytest-of-Administrator`.
- `python -m pytest -p no:cacheprovider --basetemp .pytest_tmp unit_test/base/test_file_ops.py unit_test/base/test_save_data.py unit_test/base/test_db_manager_directory_guards.py unit_test/base/test_excel_result_exporter.py` returned 18 passed, 2 failed.
- Remaining failures cover database parent directory creation and explicit Excel output parent directory creation, so this PR is opened as draft pending those follow-up fixes.

## Notes
- Left untracked local artifacts out of the PR: `5555.keras` and `dist/main_window_Launcher.exe`.