### PR TITLE
feat(ui): add semantic analysis config layout

### DIFF
--- a/ui/ui_analysis_config/ai_config_dialog.py
+++ b/ui/ui_analysis_config/ai_config_dialog.py
@@ -1,40 +1,44 @@
 from typing import List, Optional
 
 from PyQt5.QtCore import QTimer
-from PyQt5.QtWidgets import QHBoxLayout, QVBoxLayout, QSizePolicy
+from PyQt5.QtWidgets import QHBoxLayout, QSizePolicy
 
 from base.training_model_management import TrainingModelManagement
 from consts import error_code
 from consts.running_consts import DEFAULT_DIR
 from ui.custom_ui_widget.popuputils import PopupUtils
 from ui.custom_ui_widget.widgets import ComboBox, Label, GroupBox, MessageBox
-from ui.ui_analysis_config.common_widgets import AnalysisConfigDialogBase, ChannelSelectorWidget
+from ui.ui_analysis_config.common_widgets import ChannelSelectorWidget, SemanticAnalysisConfigDialogBase
 from ui.ui_src import ui_resources
 
 
-class AIConfigWindow(AnalysisConfigDialogBase):
+class AIConfigWindow(SemanticAnalysisConfigDialogBase):
     def __init__(self, config_manager, model_type, signal_len=None, available_channels: Optional[List[int]] = None):
         super().__init__(disable_close_button=True)
         self.signal_len = signal_len
         self.config_manager = config_manager
+        self.config_key = model_type
         self.model_list = self.load_model_name_from_db()
-        self.load_config = self.config_manager.load_config().get(model_type, {})
+        self.load_config = self.config_manager.load_config().get(self.config_key, {})
         self.show_channel_selector = available_channels is not None
         self.available_channels = available_channels
         self.init_ui()
 
     def init_ui(self):
-        self.setMinimumSize(200, 300)
-        layout = QVBoxLayout()
+        self.apply_semantic_dialog_size()
+        self.set_semantic_button_callbacks(
+            default_callback=self.on_default_btn_clicked,
+            restore_callback=self.on_restore_default_btn_clicked,
+            ok_callback=self.on_click_ok_btn,
+        )
+        self._build_semantic_sections()
+
+    def _build_semantic_sections(self):
         if self.show_channel_selector:
             self.channel_selector = ChannelSelectorWidget(self.load_config, self.available_channels, self)
-            layout.addWidget(self.channel_selector)
+            self.add_semantic_section("input", widget=self.channel_selector)
         model_box = self.create_model_layout()
-        btn_layout = self.create_btn()
-        layout.addWidget(model_box)
-        layout.addStretch()
-        layout.addLayout(btn_layout)
-        self.setLayout(layout)
+        self.add_semantic_section("compute", widget=model_box)
 
     def cheack_model_list(self):
         if self.analyse_model_combo_box.count() == 0:
@@ -89,6 +93,11 @@ class AIConfigWindow(AnalysisConfigDialogBase):
         config_data = self.get_default_config()
         save_flag = self.config_manager.save_default_config("AI", config_data)
         PopupUtils().save_popup(self, success_flag=save_flag)
+
+    def on_restore_default_btn_clicked(self):
+        self.load_config = self.config_manager.load_config().get(self.config_key, {})
+        self.clear_semantic_sections()
+        self._build_semantic_sections()
 
     def on_click_ok_btn(self):
         config_data = self.get_default_config()

--- a/ui/ui_analysis_config/common_widgets.py
+++ b/ui/ui_analysis_config/common_widgets.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import Any
+from typing import Any, Callable
 
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtGui import QIcon
@@ -41,9 +41,26 @@ OCTAVE_SMOOTHING_LABELS = {
     48: "1/48 Oct",
 }
 
+SEMANTIC_GROUP_TITLES = {
+    "input": "输入参数",
+    "compute": "计算参数",
+    "preprocess": "预处理参数",
+    "detection": "检测参数",
+    "judgment": "判定参数",
+    "reference": "基准参数",
+    "display": "显示参数",
+    "output": "输出参数",
+}
+
+VERTICAL_GOLDEN_DIALOG_WIDTH = 630
+VERTICAL_GOLDEN_DIALOG_HEIGHT = 840
+
 
 class AnalysisConfigDialogBase(QDialog):
     """Base dialog helpers for analysis configuration windows."""
+
+    DEFAULT_DIALOG_WIDTH = VERTICAL_GOLDEN_DIALOG_WIDTH
+    DEFAULT_DIALOG_HEIGHT = VERTICAL_GOLDEN_DIALOG_HEIGHT
 
     def __init__(self, *args, disable_close_button: bool = False, **kwargs):
         super().__init__(*args, **kwargs)
@@ -68,6 +85,417 @@ class AnalysisConfigDialogBase(QDialog):
 
     def show_default_save_popup(self, success_flag: bool) -> None:
         PopupUtils().save_popup(self, success_flag=success_flag)
+
+    def apply_vertical_golden_dialog_size(
+        self,
+        width: int = DEFAULT_DIALOG_WIDTH,
+        height: int = DEFAULT_DIALOG_HEIGHT,
+    ) -> None:
+        self.setMinimumSize(width, height)
+        self.resize(width, height)
+
+
+class SemanticAnalysisConfigDialogBase(AnalysisConfigDialogBase):
+    """Base dialog with semantic navigation and a single scrollable form page."""
+
+    DEFAULT_DIALOG_WIDTH = VERTICAL_GOLDEN_DIALOG_WIDTH
+    DEFAULT_DIALOG_HEIGHT = VERTICAL_GOLDEN_DIALOG_HEIGHT
+
+    def __init__(
+        self,
+        *args,
+        nav_width: int = 150,
+        disable_close_button: bool = True,
+        **kwargs,
+    ):
+        super().__init__(*args, disable_close_button=disable_close_button, **kwargs)
+        self._semantic_nav_buttons: dict[str, PushButton] = {}
+        self._semantic_sections: dict[str, QWidget] = {}
+        self._semantic_section_contents: dict[str, QWidget] = {}
+        self._semantic_section_indicators: dict[str, Label] = {}
+        self._semantic_section_collapsed: dict[str, bool] = {}
+        self._active_semantic_group_key: str | None = None
+        self._default_callback: Callable[[], Any] | None = None
+        self._restore_callback: Callable[[], Any] | None = None
+        self._ok_callback: Callable[[], Any] | None = None
+        self._cancel_callback: Callable[[], Any] | None = None
+        self._syncing_scroll = False
+        self.setObjectName("semanticAnalysisConfigDialog")
+        self.setStyleSheet(self._semantic_dialog_stylesheet())
+
+        self._root_layout = QVBoxLayout(self)
+        self._root_layout.setContentsMargins(12, 12, 12, 12)
+        self._root_layout.setSpacing(10)
+
+        self._content_layout = QHBoxLayout()
+        self._content_layout.setSpacing(12)
+
+        self.nav_widget = QWidget(self)
+        self.nav_widget.setObjectName("semanticNav")
+        self.nav_widget.setFixedWidth(nav_width)
+        self.nav_layout = QVBoxLayout(self.nav_widget)
+        self.nav_layout.setContentsMargins(10, 12, 10, 12)
+        self.nav_layout.setSpacing(6)
+        self.nav_title_label = Label("参数分组")
+        self.nav_title_label.setObjectName("semanticNavTitle")
+        self.nav_layout.addWidget(self.nav_title_label)
+        self.nav_layout.addStretch(1)
+
+        self.section_scroll_area = QScrollArea(self)
+        self.section_scroll_area.setObjectName("semanticSectionScrollArea")
+        self.section_scroll_area.setWidgetResizable(True)
+        self.section_scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.section_container = QWidget(self.section_scroll_area)
+        self.section_container.setObjectName("semanticSectionContainer")
+        self.section_layout = QVBoxLayout(self.section_container)
+        self.section_layout.setContentsMargins(0, 0, 0, 0)
+        self.section_layout.setSpacing(22)
+        self.section_layout.addStretch(1)
+        self.section_scroll_area.setWidget(self.section_container)
+        self.section_scroll_area.verticalScrollBar().valueChanged.connect(self._sync_active_section_from_scroll)
+
+        self._content_layout.addWidget(self.nav_widget)
+        self._content_layout.addWidget(self.section_scroll_area, 1)
+        self._root_layout.addLayout(self._content_layout, 1)
+        self._root_layout.addLayout(self._create_semantic_footer_layout())
+
+    def apply_semantic_dialog_size(
+        self,
+        width: int = DEFAULT_DIALOG_WIDTH,
+        height: int = DEFAULT_DIALOG_HEIGHT,
+    ) -> None:
+        self.apply_vertical_golden_dialog_size(width, height)
+
+    def _semantic_dialog_stylesheet(self) -> str:
+        return """
+        QDialog#semanticAnalysisConfigDialog {
+            background: #f5f7fa;
+        }
+        QWidget#semanticNav {
+            background: #f2f5f9;
+            border: 1px solid #d9e0ea;
+            border-radius: 8px;
+        }
+        Label#semanticNavTitle {
+            color: #667085;
+            font-size: 13px;
+            font-weight: 600;
+            padding: 0 4px 6px 4px;
+        }
+        PushButton#semanticNavButton {
+            min-height: 32px;
+            text-align: left;
+            padding: 5px 10px;
+            border: 1px solid transparent;
+            border-radius: 7px;
+            background: transparent;
+            color: #344054;
+        }
+        PushButton#semanticNavButton:hover {
+            background: #edf2f7;
+            border-color: #d9e0ea;
+        }
+        PushButton#semanticNavButton[active="true"] {
+            background: #e8f0ff;
+            border-color: #bad0ff;
+            color: #123d93;
+            font-weight: 600;
+        }
+        QScrollArea#semanticSectionScrollArea {
+            background: #f8fafc;
+            border: 1px solid #d9e0ea;
+            border-radius: 8px;
+        }
+        QWidget#semanticSectionContainer {
+            background: #f8fafc;
+        }
+        QWidget#semanticSectionCard {
+            background: #ffffff;
+            border: 1px solid #d9e0ea;
+            border-radius: 8px;
+        }
+        QWidget#semanticSectionHeader {
+            background: #fbfcfe;
+            border-bottom: 1px solid #d9e0ea;
+            border-top-left-radius: 8px;
+            border-top-right-radius: 8px;
+        }
+        Label#semanticSectionTitle {
+            color: #1f2937;
+            font-size: 16px;
+            font-weight: 600;
+        }
+        Label#semanticSectionDescription {
+            color: #667085;
+            font-size: 12px;
+        }
+        Label#semanticSectionIndicator {
+            color: #667085;
+            font-size: 16px;
+            font-weight: 600;
+        }
+        QWidget#semanticSectionContent {
+            background: #ffffff;
+            border-bottom-left-radius: 8px;
+            border-bottom-right-radius: 8px;
+        }
+        PushButton {
+            min-height: 30px;
+            border: 1px solid #b9c4d2;
+            border-radius: 6px;
+            background: #ffffff;
+            padding: 0 12px;
+            color: #344054;
+        }
+        PushButton:hover {
+            border-color: #8fa4c0;
+            background: #f8fafc;
+        }
+        PushButton#semanticPrimaryButton {
+            background: #2563eb;
+            border-color: #1d4ed8;
+            color: #ffffff;
+        }
+        PushButton#semanticPrimaryButton:hover {
+            background: #1d4ed8;
+            border-color: #1e40af;
+        }
+        QGroupBox {
+            background: #f8fafc;
+            border: 1px solid #d9e0ea;
+            border-radius: 6px;
+            margin-top: 12px;
+            padding: 10px;
+        }
+        QGroupBox::title {
+            subcontrol-origin: margin;
+            left: 10px;
+            padding: 0 4px;
+            color: #344054;
+        }
+        QComboBox, QLineEdit, QSpinBox, QDoubleSpinBox, QTextEdit, QPlainTextEdit {
+            min-height: 28px;
+            border: 1px solid #b9c4d2;
+            border-radius: 6px;
+            background: #ffffff;
+            padding: 2px 8px;
+            color: #1f2937;
+        }
+        QComboBox:hover, QLineEdit:hover, QSpinBox:hover, QDoubleSpinBox:hover {
+            border-color: #8fa4c0;
+        }
+        """
+
+    def _create_semantic_footer_layout(self) -> QHBoxLayout:
+        footer_layout = QHBoxLayout()
+        self.semantic_default_btn = PushButton(" 设为默认 ")
+        self.semantic_restore_btn = PushButton(" 恢复默认 ")
+        self.semantic_cancel_btn = PushButton(" 取  消 ")
+        self.semantic_ok_btn = PushButton(" 确  认 ")
+        self.semantic_ok_btn.setObjectName("semanticPrimaryButton")
+
+        self.semantic_default_btn.clicked.connect(self._on_default_clicked)
+        self.semantic_restore_btn.clicked.connect(self._on_restore_clicked)
+        self.semantic_cancel_btn.clicked.connect(self._on_cancel_clicked)
+        self.semantic_ok_btn.clicked.connect(self._on_ok_clicked)
+
+        footer_layout.addWidget(self.semantic_default_btn)
+        footer_layout.addWidget(self.semantic_restore_btn)
+        footer_layout.addStretch()
+        footer_layout.addWidget(self.semantic_cancel_btn)
+        footer_layout.addWidget(self.semantic_ok_btn)
+        return footer_layout
+
+    def set_semantic_button_callbacks(
+        self,
+        *,
+        default_callback: Callable[[], Any] | None = None,
+        restore_callback: Callable[[], Any] | None = None,
+        ok_callback: Callable[[], Any] | None = None,
+        cancel_callback: Callable[[], Any] | None = None,
+    ) -> None:
+        self._default_callback = default_callback
+        self._restore_callback = restore_callback
+        self._ok_callback = ok_callback
+        self._cancel_callback = cancel_callback
+
+    def add_semantic_section(
+        self,
+        group_key: str,
+        *,
+        title: str | None = None,
+        description: str | None = None,
+        widget: QWidget | None = None,
+        layout: QVBoxLayout | QHBoxLayout | None = None,
+    ) -> QVBoxLayout:
+        if group_key in self._semantic_sections:
+            raise ValueError(f"Semantic section already exists: {group_key}")
+
+        section_title = title or SEMANTIC_GROUP_TITLES.get(group_key, str(group_key))
+        nav_button = PushButton(section_title)
+        nav_button.setObjectName("semanticNavButton")
+        nav_button.setCheckable(True)
+        nav_button.setFlat(True)
+        nav_button.setCursor(Qt.PointingHandCursor)
+        nav_button.clicked.connect(partial(self.scroll_to_semantic_section, group_key))
+        self._semantic_nav_buttons[group_key] = nav_button
+        self.nav_layout.insertWidget(max(self.nav_layout.count() - 1, 0), nav_button)
+
+        section_widget = QWidget(self.section_container)
+        section_widget.setObjectName("semanticSectionCard")
+        section_widget.setProperty("semanticGroupKey", group_key)
+        section_widget.setAttribute(Qt.WA_StyledBackground, True)
+        section_layout = QVBoxLayout(section_widget)
+        section_layout.setContentsMargins(0, 0, 0, 0)
+        section_layout.setSpacing(0)
+
+        header_widget = QWidget(section_widget)
+        header_widget.setObjectName("semanticSectionHeader")
+        header_widget.setAttribute(Qt.WA_StyledBackground, True)
+        header_widget.setCursor(Qt.PointingHandCursor)
+        header_widget.mousePressEvent = partial(self._on_section_header_clicked, group_key)
+        header_layout = QVBoxLayout(header_widget)
+        header_layout.setContentsMargins(14, 10, 14, 10)
+        header_layout.setSpacing(4)
+
+        title_row = QHBoxLayout()
+        title_row.setContentsMargins(0, 0, 0, 0)
+        title_row.setSpacing(8)
+        title_label = Label(section_title)
+        title_label.setObjectName("semanticSectionTitle")
+        title_label.setAlignment(Qt.AlignLeft)
+        indicator_label = Label("v")
+        indicator_label.setObjectName("semanticSectionIndicator")
+        indicator_label.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
+        title_row.addWidget(title_label)
+        title_row.addStretch()
+        title_row.addWidget(indicator_label)
+        header_layout.addLayout(title_row)
+
+        if description:
+            description_label = Label(description)
+            description_label.setObjectName("semanticSectionDescription")
+            description_label.setAlignment(Qt.AlignLeft)
+            header_layout.addWidget(description_label)
+        section_layout.addWidget(header_widget)
+
+        content_widget = QWidget(section_widget)
+        content_widget.setObjectName("semanticSectionContent")
+        content_widget.setAttribute(Qt.WA_StyledBackground, True)
+        content_layout = QVBoxLayout(content_widget)
+        content_layout.setContentsMargins(14, 12, 14, 14)
+        content_layout.setSpacing(10)
+        if widget is not None:
+            content_layout.addWidget(widget)
+        if layout is not None:
+            content_layout.addLayout(layout)
+        section_layout.addWidget(content_widget)
+
+        self._semantic_sections[group_key] = section_widget
+        self._semantic_section_contents[group_key] = content_widget
+        self._semantic_section_indicators[group_key] = indicator_label
+        self._semantic_section_collapsed[group_key] = False
+        self.section_layout.insertWidget(max(self.section_layout.count() - 1, 0), section_widget)
+
+        if self._active_semantic_group_key is None:
+            self._set_active_semantic_group(group_key)
+        return content_layout
+
+    def semantic_group_keys(self) -> list[str]:
+        return list(self._semantic_sections.keys())
+
+    def current_semantic_group_key(self) -> str | None:
+        return self._active_semantic_group_key
+
+    def clear_semantic_sections(self) -> None:
+        for button in self._semantic_nav_buttons.values():
+            self.nav_layout.removeWidget(button)
+            button.deleteLater()
+        for section in self._semantic_sections.values():
+            self.section_layout.removeWidget(section)
+            section.deleteLater()
+        self._semantic_nav_buttons.clear()
+        self._semantic_sections.clear()
+        self._semantic_section_contents.clear()
+        self._semantic_section_indicators.clear()
+        self._semantic_section_collapsed.clear()
+        self._active_semantic_group_key = None
+
+    def is_semantic_section_collapsed(self, group_key: str) -> bool:
+        return bool(self._semantic_section_collapsed.get(group_key, False))
+
+    def set_semantic_section_collapsed(self, group_key: str, collapsed: bool) -> None:
+        content = self._semantic_section_contents.get(group_key)
+        indicator = self._semantic_section_indicators.get(group_key)
+        if content is None:
+            return
+        collapsed = bool(collapsed)
+        content.setVisible(not collapsed)
+        self._semantic_section_collapsed[group_key] = collapsed
+        if indicator is not None:
+            indicator.setText(">" if collapsed else "v")
+
+    def toggle_semantic_section(self, group_key: str) -> None:
+        self.set_semantic_section_collapsed(group_key, not self.is_semantic_section_collapsed(group_key))
+
+    def _on_section_header_clicked(self, group_key: str, event) -> None:
+        self.toggle_semantic_section(group_key)
+        if event is not None:
+            event.accept()
+
+    def scroll_to_semantic_section(self, group_key: str) -> None:
+        section = self._semantic_sections.get(group_key)
+        if section is None:
+            return
+        self._set_active_semantic_group(group_key)
+        self.section_scroll_area.ensureWidgetVisible(section, 0, 0)
+
+    def _sync_active_section_from_scroll(self) -> None:
+        if self._syncing_scroll or not self._semantic_sections:
+            return
+        scroll_value = self.section_scroll_area.verticalScrollBar().value()
+        current_key = self._active_semantic_group_key
+        for group_key, section in self._semantic_sections.items():
+            if section.y() <= scroll_value + 12:
+                current_key = group_key
+            else:
+                break
+        if current_key is not None:
+            self._set_active_semantic_group(current_key)
+
+    def _set_active_semantic_group(self, group_key: str) -> None:
+        if group_key not in self._semantic_sections:
+            return
+        self._syncing_scroll = True
+        try:
+            self._active_semantic_group_key = group_key
+            for key, button in self._semantic_nav_buttons.items():
+                button.setChecked(key == group_key)
+                button.setProperty("active", key == group_key)
+                button.style().unpolish(button)
+                button.style().polish(button)
+        finally:
+            self._syncing_scroll = False
+
+    def _on_default_clicked(self) -> None:
+        if self._default_callback is not None:
+            self._default_callback()
+
+    def _on_restore_clicked(self) -> None:
+        if self._restore_callback is not None:
+            self._restore_callback()
+
+    def _on_cancel_clicked(self) -> None:
+        if self._cancel_callback is not None:
+            self._cancel_callback()
+        else:
+            self.reject()
+
+    def _on_ok_clicked(self) -> None:
+        if self._ok_callback is not None:
+            self._ok_callback()
+        else:
+            self.accept()
 
 
 class ChannelSelectorWidget(QWidget):

--- a/ui/ui_analysis_config/excel_config_dialog.py
+++ b/ui/ui_analysis_config/excel_config_dialog.py
@@ -1,16 +1,15 @@
 import os
 
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QIcon
-from PyQt5.QtWidgets import QDialog, QFileDialog, QHBoxLayout, QScrollArea, QVBoxLayout, QWidget
+from PyQt5.QtWidgets import QFileDialog, QHBoxLayout, QScrollArea, QVBoxLayout, QWidget
 
 from consts.running_consts import DEFAULT_DIR
 from ui.custom_ui_widget.popuputils import PopupUtils
 from ui.custom_ui_widget.widgets import PushButton, Label, GroupBox, CheckBox, LineEdit, SpinBox, MessageBox
+from ui.ui_analysis_config.common_widgets import SemanticAnalysisConfigDialogBase
 from ui.ui_src import ui_resources
 
 
-class ExcelConfigWindow(QDialog):
+class ExcelConfigWindow(SemanticAnalysisConfigDialogBase):
     """
     Excel 结果导出配置（全局分析项）
 
@@ -20,7 +19,7 @@ class ExcelConfigWindow(QDialog):
     """
 
     def __init__(self, config_manager, model_type):
-        super().__init__()
+        super().__init__(disable_close_button=True)
         self.config_manager = config_manager
         self.model_type = model_type
         self.load_config = self.config_manager.load_config().get(model_type, {})
@@ -30,13 +29,25 @@ class ExcelConfigWindow(QDialog):
         self.init_ui()
 
     def init_ui(self):
-        self.setWindowFlag(Qt.WindowCloseButtonHint, False)
-        self.setWindowFlag(Qt.WindowContextHelpButtonHint, False)
-        self.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
-        self.setMinimumSize(420, 420)
+        self.apply_semantic_dialog_size()
+        self.set_semantic_button_callbacks(
+            default_callback=self.on_default_btn_clicked,
+            restore_callback=self.on_restore_default_btn_clicked,
+            ok_callback=self.on_click_ok_btn,
+        )
+        self._build_semantic_sections()
 
-        layout = QVBoxLayout()
+    def _build_semantic_sections(self):
+        output_widget = QWidget(self)
+        output_layout = QVBoxLayout(output_widget)
+        output_layout.setContentsMargins(0, 0, 0, 0)
+        output_layout.setSpacing(12)
 
+        output_layout.addWidget(self._create_excel_save_group())
+        output_layout.addWidget(self._create_mes_save_group())
+        self.add_semantic_section("output", widget=output_widget)
+
+    def _create_excel_save_group(self):
         basic_box = GroupBox("Excel 保存设置")
         basic_layout = QVBoxLayout()
 
@@ -121,8 +132,9 @@ class ExcelConfigWindow(QDialog):
         basic_layout.addWidget(select_box)
 
         basic_box.setLayout(basic_layout)
-        layout.addWidget(basic_box)
+        return basic_box
 
+    def _create_mes_save_group(self):
         mes_box = GroupBox("MES 保存设置")
         mes_layout = QVBoxLayout()
 
@@ -154,12 +166,7 @@ class ExcelConfigWindow(QDialog):
         mes_layout.addLayout(mes_name_layout)
 
         mes_box.setLayout(mes_layout)
-        layout.addWidget(mes_box)
-
-        layout.addStretch()
-        layout.addLayout(self.create_btn())
-
-        self.setLayout(layout)
+        return mes_box
 
     def _get_available_analysis_items(self) -> list[str]:
         """
@@ -324,6 +331,12 @@ class ExcelConfigWindow(QDialog):
         config_data = self.get_default_config()
         save_flag = self.config_manager.save_default_config("Excel", config_data)
         PopupUtils().save_popup(self, success_flag=save_flag)
+
+    def on_restore_default_btn_clicked(self):
+        self.load_config = self.config_manager.load_config().get(self.model_type, {})
+        self._item_checkbox_by_name = {}
+        self.clear_semantic_sections()
+        self._build_semantic_sections()
 
     def on_click_ok_btn(self):
         ok, msg = self._validate_save_dir_text(self.save_dir_edit.text(), create=True)

--- a/ui/ui_analysis_config/fba_config_dialog.py
+++ b/ui/ui_analysis_config/fba_config_dialog.py
@@ -7,8 +7,8 @@ from ui.custom_ui_widget.popuputils import PopupUtils
 
 # 确保这里导入的是你项目中正确的 ThresholdConfigWidget 路径
 from ui.ui_analysis_config.common_widgets import (
-    AnalysisConfigDialogBase,
     ChannelSelectorWidget,
+    SemanticAnalysisConfigDialogBase,
     WeightingSelectorWidget,
 )
 from ui.ui_analysis_config.threshold_config_widget import ThresholdConfigWidget
@@ -16,7 +16,7 @@ from ui.custom_ui_widget.widgets import ComboBox, Label, GroupBox, DoubleSpinBox
 from ui.ui_src import ui_resources
 
 
-class FbaConfigWindow(AnalysisConfigDialogBase):
+class FbaConfigWindow(SemanticAnalysisConfigDialogBase):
     """
     FBA 频段能量分析配置窗口 (修复布局版)
     """
@@ -34,6 +34,7 @@ class FbaConfigWindow(AnalysisConfigDialogBase):
     def __init__(self, config_manager, model_type, available_channels: Optional[List[int]] = None):
         super().__init__(disable_close_button=True)
         self.config_manager = config_manager
+        self.config_key = model_type
         # 提取模型类型中的字母部分，例如 "FBA"
         self.model_type_str = "".join(re.findall(r"[A-Za-z]", str(model_type))) or "FBA"
         self.show_channel_selector = available_channels is not None
@@ -41,26 +42,30 @@ class FbaConfigWindow(AnalysisConfigDialogBase):
 
         # 加载配置
         full_config = self.config_manager.load_config()
-        self.load_config = full_config.get(model_type, {})
+        self.load_config = full_config.get(self.config_key, {})
 
         self.init_ui()
 
     def init_ui(self):
         # --- 窗口基本设置 ---
         self.setWindowTitle("FBA 分析配置")
-        # 该对话框主要是纵向排布；过大的默认宽度会让界面“显得很宽”
-        # 同时避免默认高度过大把“阈值展示区域”撑得太高
-        self.setMinimumSize(420, 620)
-        self.resize(420, 620)
+        self.apply_semantic_dialog_size()
+        self.set_semantic_button_callbacks(
+            default_callback=self.on_default_btn_clicked,
+            restore_callback=self.on_restore_default_btn_clicked,
+            ok_callback=self.on_click_ok_btn,
+        )
+        self._build_semantic_sections()
 
-        # --- 主布局：垂直流式布局 ---
-        main_layout = QVBoxLayout()
-        main_layout.setSpacing(15)
-        main_layout.setContentsMargins(20, 20, 20, 20)
-
+    def _build_semantic_sections(self):
         if self.show_channel_selector:
             self.channel_selector = ChannelSelectorWidget(self.load_config, self.available_channels, self)
-            main_layout.addWidget(self.channel_selector)
+            self.add_semantic_section("input", widget=self.channel_selector)
+
+        compute_widget = QWidget(self)
+        compute_layout = QVBoxLayout(compute_widget)
+        compute_layout.setContentsMargins(0, 0, 0, 0)
+        compute_layout.setSpacing(12)
 
         # =========================================================
         # 1. 频段划分策略 (GroupBox)
@@ -107,7 +112,7 @@ class FbaConfigWindow(AnalysisConfigDialogBase):
         strategy_layout.addWidget(self.custom_widget)
 
         strategy_group.setLayout(strategy_layout)
-        main_layout.addWidget(strategy_group)
+        compute_layout.addWidget(strategy_group)
 
         # =========================================================
         # 2. 频率范围 (GroupBox)
@@ -134,7 +139,7 @@ class FbaConfigWindow(AnalysisConfigDialogBase):
         range_layout.addWidget(self.f_max_spin)
 
         range_group.setLayout(range_layout)
-        main_layout.addWidget(range_group)
+        compute_layout.addWidget(range_group)
 
         self.weighting_selector = WeightingSelectorWidget(
             self.load_config,
@@ -142,7 +147,7 @@ class FbaConfigWindow(AnalysisConfigDialogBase):
             default="A",
             parent=self,
         )
-        main_layout.addWidget(self.weighting_selector)
+        compute_layout.addWidget(self.weighting_selector)
 
         # =========================================================
         # 4. 阈值配置组件 (ThresholdConfigWidget)
@@ -154,17 +159,8 @@ class FbaConfigWindow(AnalysisConfigDialogBase):
         # 不让阈值组件吃掉所有剩余高度（否则内部 addStretch 会形成很大空白）
         self.threshold_widget.setMaximumHeight(360)
         self.threshold_widget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
-        main_layout.addWidget(self.threshold_widget)
-
-        # =========================================================
-        # 5. 底部按钮
-        # =========================================================
-        main_layout.addStretch(1)
-        main_layout.addLayout(self.create_btn())
-
-        self.setLayout(main_layout)
-
-        # --- 样式设置 ---
+        self.add_semantic_section("compute", widget=compute_widget)
+        self.add_semantic_section("judgment", widget=self.threshold_widget)
 
         # --- 信号连接 ---
         self.strategy_combo.currentTextChanged.connect(self._on_strategy_changed)
@@ -271,6 +267,11 @@ class FbaConfigWindow(AnalysisConfigDialogBase):
         config_data = self.get_default_config()
         save_flag = self.config_manager.save_default_config(self.model_type_str, config_data)
         PopupUtils().save_popup(self, success_flag=save_flag)
+
+    def on_restore_default_btn_clicked(self):
+        self.load_config = self.config_manager.load_config().get(self.config_key, {})
+        self.clear_semantic_sections()
+        self._build_semantic_sections()
 
     def on_click_ok_btn(self):
         if not self._validate_custom_bands_if_needed():

--- a/ui/ui_analysis_config/fr_config_dialog.py
+++ b/ui/ui_analysis_config/fr_config_dialog.py
@@ -2,36 +2,38 @@
 FR (Frequency Response) 分析配置对话框
 """
 
-from PyQt5.QtWidgets import QVBoxLayout
-
 from consts.running_consts import DEFAULT_DIR
 from ui.custom_ui_widget.popuputils import PopupUtils
 from ui.ui_analysis_config.common_widgets import (
-    AnalysisConfigDialogBase,
     GoldenSampleWidget,
     OctaveSmoothingSelectorWidget,
+    SemanticAnalysisConfigDialogBase,
 )
 from ui.ui_analysis_config.threshold_config_widget import ThresholdConfigWidget
 from ui.ui_src import ui_resources
 
 
-class FrConfigWindow(AnalysisConfigDialogBase):
+class FrConfigWindow(SemanticAnalysisConfigDialogBase):
     """FR 频率响应分析配置对话框"""
 
     def __init__(self, config_manager, model_type):
         super().__init__(disable_close_button=True)
         self.config_manager = config_manager
+        self.config_key = model_type
         self.model_type = model_type
-        self.load_config = self.config_manager.load_config().get(model_type, {})
+        self.load_config = self.config_manager.load_config().get(self.config_key, {})
         self.init_ui()
 
     def init_ui(self):
-        # 默认高度偏小会把阈值绘图区域压缩得很矮
-        self.setMinimumSize(380, 420)
-        self.resize(380, 450)
+        self.apply_semantic_dialog_size()
+        self.set_semantic_button_callbacks(
+            default_callback=self.on_default_btn_clicked,
+            restore_callback=self.on_restore_default_btn_clicked,
+            ok_callback=self.on_click_ok_btn,
+        )
+        self._build_semantic_sections()
 
-        layout = QVBoxLayout()
-
+    def _build_semantic_sections(self):
         self.smoothing_selector = OctaveSmoothingSelectorWidget(self.load_config, parent=self)
         self.golden_chk_box = GoldenSampleWidget(self.load_config, self)
 
@@ -42,14 +44,9 @@ class FrConfigWindow(AnalysisConfigDialogBase):
             model_type=self.model_type,
         )
 
-        btn_layout = self.create_btn()
-
-        layout.addWidget(self.smoothing_selector)
-        layout.addWidget(self.golden_chk_box)
-        layout.addWidget(self.threshold_widget)
-        layout.addStretch()
-        layout.addLayout(btn_layout)
-        self.setLayout(layout)
+        self.add_semantic_section("compute", widget=self.smoothing_selector)
+        self.add_semantic_section("reference", widget=self.golden_chk_box)
+        self.add_semantic_section("judgment", widget=self.threshold_widget)
 
     def create_btn(self):
         return self.create_standard_button_layout(self.on_default_btn_clicked, self.on_click_ok_btn)
@@ -68,6 +65,11 @@ class FrConfigWindow(AnalysisConfigDialogBase):
             return
         save_flag = self.config_manager.save_default_config("FR", config_data)
         PopupUtils().save_popup(self, success_flag=save_flag)
+
+    def on_restore_default_btn_clicked(self):
+        self.load_config = self.config_manager.load_config().get(self.config_key, {})
+        self.clear_semantic_sections()
+        self._build_semantic_sections()
 
     def on_click_ok_btn(self):
         config_data = self.get_default_config()

--- a/ui/ui_analysis_config/hd_config_dialog.py
+++ b/ui/ui_analysis_config/hd_config_dialog.py
@@ -6,13 +6,17 @@ from PyQt5.QtWidgets import QVBoxLayout
 
 from consts.running_consts import DEFAULT_DIR
 from ui.custom_ui_widget.popuputils import PopupUtils
-from ui.ui_analysis_config.common_widgets import AnalysisConfigDialogBase, GoldenSampleWidget, HarmonicSelectorWidget
+from ui.ui_analysis_config.common_widgets import (
+    GoldenSampleWidget,
+    HarmonicSelectorWidget,
+    SemanticAnalysisConfigDialogBase,
+)
 from ui.ui_analysis_config.threshold_config_widget import ThresholdConfigWidget
 from ui.custom_ui_widget.widgets import GroupBox, MessageBox
 from ui.ui_src import ui_resources
 
 
-class HdConfigWindow(AnalysisConfigDialogBase):
+class HdConfigWindow(SemanticAnalysisConfigDialogBase):
     """谐波失真 (THD) 分析配置对话框"""
 
     def __init__(self, config_manager, model_type):
@@ -23,13 +27,15 @@ class HdConfigWindow(AnalysisConfigDialogBase):
         self.init_ui()
 
     def init_ui(self):
-        self.setObjectName("HdConfigWindow")
-        self.setMinimumSize(320, 480)
-        self.resize(380, 620)
+        self.apply_semantic_dialog_size()
+        self.set_semantic_button_callbacks(
+            default_callback=self.on_default_btn_clicked,
+            restore_callback=self.on_restore_default_btn_clicked,
+            ok_callback=self.on_click_ok_btn,
+        )
+        self._build_semantic_sections()
 
-        layout = QVBoxLayout()
-
-        # 谐波选择组
+    def _build_semantic_sections(self):
         harmonic_group_box = GroupBox("谐波失真")
         harmonic_slider_layout = QVBoxLayout()
         harmonic_slider_layout.setSpacing(12)
@@ -46,14 +52,9 @@ class HdConfigWindow(AnalysisConfigDialogBase):
             model_type=self.model_type,
         )
 
-        btn_layout = self.create_btn()
-
-        layout.addWidget(harmonic_group_box)
-        layout.addWidget(self.golden_chk_box)
-        layout.addWidget(self.threshold_widget)
-        layout.addStretch()
-        layout.addLayout(btn_layout)
-        self.setLayout(layout)
+        self.add_semantic_section("detection", widget=harmonic_group_box)
+        self.add_semantic_section("reference", widget=self.golden_chk_box)
+        self.add_semantic_section("judgment", widget=self.threshold_widget)
 
     def create_btn(self):
         return self.create_standard_button_layout(self.on_default_btn_clicked, self.on_click_ok_btn)
@@ -72,6 +73,11 @@ class HdConfigWindow(AnalysisConfigDialogBase):
             return
         save_flag = self.config_manager.save_default_config("HD", config_data)
         PopupUtils().save_popup(self, success_flag=save_flag)
+
+    def on_restore_default_btn_clicked(self):
+        self.load_config = self.config_manager.load_config().get(self.model_type, {})
+        self.clear_semantic_sections()
+        self._build_semantic_sections()
 
     def on_click_ok_btn(self):
         if not self.harmonic_selector.selected_labels():

--- a/ui/ui_analysis_config/lp_config_dialog.py
+++ b/ui/ui_analysis_config/lp_config_dialog.py
@@ -6,37 +6,39 @@ from PyQt5.QtWidgets import QHBoxLayout, QVBoxLayout
 from consts.running_consts import DEFAULT_DIR
 from ui.custom_ui_widget.popuputils import PopupUtils
 from ui.custom_ui_widget.widgets import GroupBox, Label, SpinBox
-from ui.ui_analysis_config.common_widgets import AnalysisConfigDialogBase, ChannelSelectorWidget
+from ui.ui_analysis_config.common_widgets import ChannelSelectorWidget, SemanticAnalysisConfigDialogBase
 from ui.ui_src import ui_resources
 
 
-class LPConfigWindow(AnalysisConfigDialogBase):
+class LPConfigWindow(SemanticAnalysisConfigDialogBase):
     def __init__(self, config_manager, model_type, available_channels: Optional[List[int]] = None):
         super().__init__()
         self.config_manager = config_manager
-        self.load_config = self.config_manager.load_config().get(model_type, {})
+        self.config_key = model_type
+        self.load_config = self.config_manager.load_config().get(self.config_key, {})
         self.show_channel_selector = available_channels is not None
         self.available_channels = available_channels
 
         self.init_ui()
 
     def init_ui(self):
-        self.setMinimumSize(350, 350)
-        layout = QVBoxLayout()
-        lp_config_box = self.create_lp_config_box()
-        btn_layout = self.create_btn_layout()
-        layout.addWidget(lp_config_box)
-        layout.addStretch()
-        layout.addLayout(btn_layout)
-        self.setLayout(layout)
+        self.apply_semantic_dialog_size()
+        self.set_semantic_button_callbacks(
+            default_callback=self.on_click_default_btn,
+            restore_callback=self.on_restore_default_btn_clicked,
+            ok_callback=self.on_click_ok_btn,
+        )
+        self._build_semantic_sections()
+
+    def _build_semantic_sections(self):
+        if self.show_channel_selector:
+            self.channel_selector = ChannelSelectorWidget(self.load_config, self.available_channels, self)
+            self.add_semantic_section("input", widget=self.channel_selector)
+        self.add_semantic_section("detection", widget=self.create_lp_config_box())
 
     def create_lp_config_box(self):
         lp_config_box = GroupBox("松散颗粒参数配置")
         lp_config_box_layout = QVBoxLayout()
-        if self.show_channel_selector:
-            self.channel_selector = ChannelSelectorWidget(self.load_config, self.available_channels, self)
-            lp_config_box_layout.addWidget(self.channel_selector)
-            lp_config_box_layout.addStretch()
         trigger_threshold_layout = self.create_trigger_threshold_layout()
         comfirm_threshold_layout = self.create_confirm_threshold_layout()
         max_check_duration_layout = self.create_max_check_duration_layout()
@@ -156,6 +158,11 @@ class LPConfigWindow(AnalysisConfigDialogBase):
         config_data = self.get_default_config()
         save_flag = self.config_manager.save_default_config("LP", config_data)
         PopupUtils().save_popup(self, success_flag=save_flag)
+
+    def on_restore_default_btn_clicked(self):
+        self.load_config = self.config_manager.load_config().get(self.config_key, {})
+        self.clear_semantic_sections()
+        self._build_semantic_sections()
 
     def on_click_ok_btn(self):
         config_data = self.get_default_config()

--- a/ui/ui_analysis_config/perceptual_rb_config_dialog.py
+++ b/ui/ui_analysis_config/perceptual_rb_config_dialog.py
@@ -10,13 +10,13 @@ from PyQt5.QtWidgets import QVBoxLayout
 
 from consts.running_consts import DEFAULT_DIR
 from ui.custom_ui_widget.popuputils import PopupUtils
-from ui.ui_analysis_config.common_widgets import AnalysisConfigDialogBase, GoldenSampleWidget
+from ui.ui_analysis_config.common_widgets import GoldenSampleWidget, SemanticAnalysisConfigDialogBase
 from ui.ui_analysis_config.threshold_config_widget import ThresholdConfigWidget
 from ui.custom_ui_widget.widgets import GroupBox, Label, ComboBox
 from ui.ui_src import ui_resources
 
 
-class PerceptualRbConfigWindow(AnalysisConfigDialogBase):
+class PerceptualRbConfigWindow(SemanticAnalysisConfigDialogBase):
     """
     Perceptual Rub & Buzz (PRB) 分析配置对话框
 
@@ -32,18 +32,19 @@ class PerceptualRbConfigWindow(AnalysisConfigDialogBase):
         self.init_ui()
 
     def init_ui(self):
-        # 默认高度偏小会把阈值绘图区域压缩得很矮
-        self.setMinimumSize(380, 420)
-        self.resize(400, 480)
+        self.apply_semantic_dialog_size()
+        self.set_semantic_button_callbacks(
+            default_callback=self.on_default_btn_clicked,
+            restore_callback=self.on_restore_default_btn_clicked,
+            ok_callback=self.on_click_ok_btn,
+        )
+        self._build_semantic_sections()
 
-        root_layout = QVBoxLayout()
-
-        # PRB 输出选项组
+    def _build_semantic_sections(self):
         group = GroupBox("PRB")
         group.setObjectName("prb_group_box")
         group_layout = QVBoxLayout()
 
-        # 输出结果选择
         self.sc_metric_desc = Label("选择输出结果：")
         self.sc_metric_desc.setAlignment(Qt.AlignLeft)
         self.sc_metric_combo = ComboBox()
@@ -76,13 +77,9 @@ class PerceptualRbConfigWindow(AnalysisConfigDialogBase):
             model_type=self.model_type,
         )
 
-        root_layout.addWidget(group)
-        root_layout.addWidget(self.golden_chk_box)
-        root_layout.addWidget(self.threshold_widget)
-        root_layout.addStretch()
-        root_layout.addLayout(self.create_standard_button_layout(self.on_default_btn_clicked, self.on_click_ok_btn))
-        self.setLayout(root_layout)
-
+        self.add_semantic_section("compute", widget=group)
+        self.add_semantic_section("reference", widget=self.golden_chk_box)
+        self.add_semantic_section("judgment", widget=self.threshold_widget)
 
     def get_default_config(self):
         """获取配置数据"""
@@ -109,6 +106,11 @@ class PerceptualRbConfigWindow(AnalysisConfigDialogBase):
             return
         save_flag = self.config_manager.save_default_config("PRB", config_data)
         PopupUtils().save_popup(self, success_flag=save_flag)
+
+    def on_restore_default_btn_clicked(self):
+        self.load_config = self.config_manager.load_config().get(self.model_type, {}) if self.config_manager else {}
+        self.clear_semantic_sections()
+        self._build_semantic_sections()
 
     def on_click_ok_btn(self):
         config_data = self.get_default_config()

--- a/ui/ui_analysis_config/rb_config_dialog.py
+++ b/ui/ui_analysis_config/rb_config_dialog.py
@@ -9,12 +9,16 @@ from PyQt5.QtWidgets import QVBoxLayout
 from consts.running_consts import DEFAULT_DIR
 from ui.custom_ui_widget.popuputils import PopupUtils
 from ui.custom_ui_widget.widgets import GroupBox, MessageBox
-from ui.ui_analysis_config.common_widgets import AnalysisConfigDialogBase, GoldenSampleWidget, HarmonicSelectorWidget
+from ui.ui_analysis_config.common_widgets import (
+    GoldenSampleWidget,
+    HarmonicSelectorWidget,
+    SemanticAnalysisConfigDialogBase,
+)
 from ui.ui_analysis_config.threshold_config_widget import ThresholdConfigWidget
 from ui.ui_src import ui_resources
 
 
-class RbConfigWindow(AnalysisConfigDialogBase):
+class RbConfigWindow(SemanticAnalysisConfigDialogBase):
     """
     Rub & Buzz 分析配置对话框
 
@@ -29,13 +33,15 @@ class RbConfigWindow(AnalysisConfigDialogBase):
         self.init_ui()
 
     def init_ui(self):
-        self.setObjectName("RbConfigWindow")
-        self.setMinimumSize(320, 480)
-        self.resize(380, 620)
+        self.apply_semantic_dialog_size()
+        self.set_semantic_button_callbacks(
+            default_callback=self.on_default_btn_clicked,
+            restore_callback=self.on_restore_default_btn_clicked,
+            ok_callback=self.on_click_ok_btn,
+        )
+        self._build_semantic_sections()
 
-        layout = QVBoxLayout()
-
-        # 谐波选择组
+    def _build_semantic_sections(self):
         harmonic_group_box = GroupBox("Rub & Buzz")
         harmonic_group_box.setObjectName("harmonic_group_box")
         harmonic_slider_layout = QVBoxLayout()
@@ -53,14 +59,9 @@ class RbConfigWindow(AnalysisConfigDialogBase):
             model_type=self.model_type,
         )
 
-        btn_layout = self.create_btn()
-
-        layout.addWidget(harmonic_group_box)
-        layout.addWidget(self.golden_chk_box)
-        layout.addWidget(self.threshold_widget)
-        layout.addStretch()
-        layout.addLayout(btn_layout)
-        self.setLayout(layout)
+        self.add_semantic_section("detection", widget=harmonic_group_box)
+        self.add_semantic_section("reference", widget=self.golden_chk_box)
+        self.add_semantic_section("judgment", widget=self.threshold_widget)
 
     def create_btn(self):
         return self.create_standard_button_layout(self.on_default_btn_clicked, self.on_click_ok_btn)
@@ -79,6 +80,11 @@ class RbConfigWindow(AnalysisConfigDialogBase):
             return
         save_flag = self.config_manager.save_default_config("RB", config_data)
         PopupUtils().save_popup(self, success_flag=save_flag)
+
+    def on_restore_default_btn_clicked(self):
+        self.load_config = self.config_manager.load_config().get(self.model_type, {})
+        self.clear_semantic_sections()
+        self._build_semantic_sections()
 
     def on_click_ok_btn(self):
         if not self.harmonic_selector.selected_labels():

--- a/ui/ui_analysis_config/reference_spectrum_config_dialog.py
+++ b/ui/ui_analysis_config/reference_spectrum_config_dialog.py
@@ -41,10 +41,10 @@ from ui.custom_ui_widget.widgets import (
     LineEdit,
     SpinBox,
 )
-from ui.ui_analysis_config.common_widgets import AnalysisConfigDialogBase, OctaveSmoothingSelectorWidget
+from ui.ui_analysis_config.common_widgets import OctaveSmoothingSelectorWidget, SemanticAnalysisConfigDialogBase
 
 
-class ReferenceSpectrumConfigWindow(AnalysisConfigDialogBase):
+class ReferenceSpectrumConfigWindow(SemanticAnalysisConfigDialogBase):
     WINDOW_OPTIONS = ["hann", "hamming", "blackman"]
     NPERSEG_OPTIONS = ["1024", "2048", "4096", "8192"]
     OVERLAP_OPTIONS = [("25%", 0.25), ("50%", 0.5), ("75%", 0.75)]
@@ -65,18 +65,28 @@ class ReferenceSpectrumConfigWindow(AnalysisConfigDialogBase):
         self._bind_initial_values()
 
     def init_ui(self):
-        self.setMinimumSize(520, 680)
-        self.resize(560, 720)
+        self.apply_semantic_dialog_size()
+        self.set_semantic_button_callbacks(
+            default_callback=self.on_default_btn_clicked,
+            restore_callback=self.on_restore_default_btn_clicked,
+            ok_callback=self.on_click_ok_btn,
+        )
+        self.default_btn = self.semantic_default_btn
+        self.ok_btn = self.semantic_ok_btn
+        self._build_semantic_sections()
 
-        layout = QVBoxLayout()
-        layout.addWidget(self._create_reference_group())
-        layout.addWidget(self._create_band_group())
-        layout.addWidget(self._create_threshold_group())
-        layout.addWidget(self._create_channel_name_group())
-        layout.addWidget(self._create_advanced_group())
-        layout.addStretch()
-        layout.addLayout(self.create_btn())
-        self.setLayout(layout)
+    def _build_semantic_sections(self):
+        compute_widget = QWidget(self)
+        compute_layout = QVBoxLayout(compute_widget)
+        compute_layout.setContentsMargins(0, 0, 0, 0)
+        compute_layout.setSpacing(12)
+        compute_layout.addWidget(self._create_band_group())
+        compute_layout.addWidget(self._create_advanced_group())
+
+        self.add_semantic_section("reference", widget=self._create_reference_group())
+        self.add_semantic_section("compute", widget=compute_widget)
+        self.add_semantic_section("judgment", widget=self._create_threshold_group())
+        self.add_semantic_section("display", widget=self._create_channel_name_group())
 
     def _create_reference_group(self):
         group = GroupBox("参考样本")
@@ -191,10 +201,10 @@ class ReferenceSpectrumConfigWindow(AnalysisConfigDialogBase):
         return self.channel_name_group
 
     def _create_advanced_group(self):
-        group = GroupBox("高级设置（可选）")
+        group = GroupBox("频谱估计参数（可选）")
         layout = QVBoxLayout()
 
-        self.show_advanced_checkbox = CheckBox("调整高级参数")
+        self.show_advanced_checkbox = CheckBox("调整频谱估计参数")
         self.show_advanced_checkbox.setChecked(False)
         self.show_advanced_checkbox.stateChanged.connect(self._on_advanced_visibility_changed)
         layout.addWidget(self.show_advanced_checkbox)
@@ -248,6 +258,16 @@ class ReferenceSpectrumConfigWindow(AnalysisConfigDialogBase):
         self.default_btn = btn_layout.itemAt(0).widget()
         self.ok_btn = btn_layout.itemAt(2).widget()
         return btn_layout
+
+    def on_restore_default_btn_clicked(self):
+        self.load_config = self.config_manager.load_config().get(self.model_type, {})
+        self._reference_audio_meta = None
+        self._reference_data_path = ""
+        self._reference_data_last_generated_at = self.load_config.get("reference_data_last_generated_at")
+        self._channel_name_inputs = {}
+        self.clear_semantic_sections()
+        self._build_semantic_sections()
+        self._bind_initial_values()
 
     def _bind_initial_values(self):
         cfg = self.load_config or {}

--- a/ui/ui_analysis_config/spec_config_dialog.py
+++ b/ui/ui_analysis_config/spec_config_dialog.py
@@ -6,37 +6,41 @@ from PyQt5.QtWidgets import QHBoxLayout, QVBoxLayout
 from consts.running_consts import DEFAULT_DIR
 from ui.custom_ui_widget.popuputils import PopupUtils
 from ui.custom_ui_widget.widgets import CheckBox, GroupBox, Label, ComboBox, SpinBox, MessageBox
-from ui.ui_analysis_config.common_widgets import AnalysisConfigDialogBase, ChannelSelectorWidget
+from ui.ui_analysis_config.common_widgets import ChannelSelectorWidget, SemanticAnalysisConfigDialogBase
 from ui.ui_src import ui_resources
 
 
-class SpecConfigWindow(AnalysisConfigDialogBase):
+class SpecConfigWindow(SemanticAnalysisConfigDialogBase):
     def __init__(self, config_manager, model_type, available_channels: Optional[List[int]] = None):
         super().__init__(disable_close_button=True)
         self.config_manager = config_manager
-        self.load_config = self.config_manager.load_config().get(model_type, {})
+        self.config_key = model_type
+        self.load_config = self.config_manager.load_config().get(self.config_key, {})
         self.show_channel_selector = available_channels is not None
         self.available_channels = available_channels
         self.init_ui()
 
     def init_ui(self):
-        self.setMinimumSize(350, 350)
-        self.resize(350, 420)
-        layout = QVBoxLayout()
+        self.apply_semantic_dialog_size()
+        self.set_semantic_button_callbacks(
+            default_callback=self.on_default_btn_clicked,
+            restore_callback=self.on_restore_default_btn_clicked,
+            ok_callback=self.on_click_ok_btn,
+        )
+        self._build_semantic_sections()
+
+    def _build_semantic_sections(self):
         if self.show_channel_selector:
             self.channel_selector = ChannelSelectorWidget(self.load_config, self.available_channels, self)
-            layout.addWidget(self.channel_selector)
-        spec_param_group_box = GroupBox("频谱图参数配置")
-        param_layout = self.create_spec_param()
-        spec_param_group_box.setLayout(param_layout)
-        btn_layout = self.create_btn()
+            self.add_semantic_section("input", widget=self.channel_selector)
+        compute_group_box = GroupBox("频谱计算参数")
+        compute_group_box.setLayout(self.create_compute_param())
+        display_group_box = GroupBox("频谱显示参数")
+        display_group_box.setLayout(self.create_display_param())
+        self.add_semantic_section("compute", widget=compute_group_box)
+        self.add_semantic_section("display", widget=display_group_box)
 
-        layout.addWidget(spec_param_group_box)
-        layout.addStretch()
-        layout.addLayout(btn_layout)
-        self.setLayout(layout)
-
-    def create_spec_param(self):
+    def create_compute_param(self):
         freq_scale_label = Label("频率轴类型")
         self.freq_scale_box = ComboBox()
         self.freq_scale_box.addItems(["linear", "log"])
@@ -75,6 +79,18 @@ class SpecConfigWindow(AnalysisConfigDialogBase):
         window_layout.addWidget(window_func_label)
         window_layout.addWidget(self.window_func_box)
 
+        param_layout = QVBoxLayout()
+        param_layout.addLayout(freq_scale_layout)
+        param_layout.addStretch()
+        param_layout.addLayout(fft_layout)
+        param_layout.addStretch()
+        param_layout.addLayout(hop_layout)
+        param_layout.addStretch()
+        param_layout.addLayout(window_layout)
+        param_layout.setSpacing(10)
+        return param_layout
+
+    def create_display_param(self):
         colormap_label = Label("配色")
         self.colormap_box = ComboBox()
         self.colormap_box.addItems(["viridis", "plasma", "magma", "inferno"])
@@ -117,15 +133,6 @@ class SpecConfigWindow(AnalysisConfigDialogBase):
         self.custom_limit_checkbox.setChecked(self.load_config.get("custom_limit", False))
 
         param_layout = QVBoxLayout()
-        param_layout.addStretch()
-        param_layout.addLayout(freq_scale_layout)
-        param_layout.addStretch()
-        param_layout.addLayout(fft_layout)
-        param_layout.addStretch()
-        param_layout.addLayout(hop_layout)
-        param_layout.addStretch()
-        param_layout.addLayout(window_layout)
-        param_layout.addStretch()
         param_layout.addLayout(colormap_layout)
         param_layout.addStretch()
         param_layout.addWidget(self.custom_limit_checkbox)
@@ -169,6 +176,11 @@ class SpecConfigWindow(AnalysisConfigDialogBase):
             return
         save_flag = self.config_manager.save_default_config("Spec", config_data)
         PopupUtils().save_popup(self, success_flag=save_flag)
+
+    def on_restore_default_btn_clicked(self):
+        self.load_config = self.config_manager.load_config().get(self.config_key, {})
+        self.clear_semantic_sections()
+        self._build_semantic_sections()
 
     def on_click_ok_btn(self):
         config_data = self.get_default_config()

--- a/ui/ui_analysis_config/spl_config_dialog.py
+++ b/ui/ui_analysis_config/spl_config_dialog.py
@@ -5,42 +5,45 @@ SPL (Sound Pressure Level) 分析配置对话框
 import re
 from typing import List, Optional
 
-from PyQt5.QtWidgets import QVBoxLayout
+from PyQt5.QtWidgets import QVBoxLayout, QWidget
 
 from consts.running_consts import DEFAULT_DIR
 from ui.custom_ui_widget.popuputils import PopupUtils
 from ui.custom_ui_widget.widgets import CheckBox, GroupBox, RadioButton
 from ui.ui_analysis_config.common_widgets import (
-    AnalysisConfigDialogBase,
     ChannelSelectorWidget,
     GoldenSampleWidget,
     OctaveSmoothingSelectorWidget,
+    SemanticAnalysisConfigDialogBase,
     WeightingSelectorWidget,
 )
 from ui.ui_analysis_config.threshold_config_widget import ThresholdConfigWidget
 from ui.ui_src import ui_resources
 
 
-class SplConfigWindow(AnalysisConfigDialogBase):
+class SplConfigWindow(SemanticAnalysisConfigDialogBase):
     """SPL 分析配置对话框"""
 
     def __init__(self, config_manager, model_type, available_channels: Optional[List[int]] = None):
         super().__init__(disable_close_button=True)
         self.config_manager = config_manager
-        self.load_config = self.config_manager.load_config().get(model_type, {})
+        self.config_key = model_type
+        self.load_config = self.config_manager.load_config().get(self.config_key, {})
         self.model_type = "".join(re.findall(r"[A-Za-z]", str(model_type))) or "SPL"
         self.show_channel_selector = available_channels is not None
         self.available_channels = available_channels
         self.init_ui()
 
     def init_ui(self):
-        # 默认高度偏小会把阈值绘图区域压缩得很矮，导致“显示不完整”的观感
-        height = 570 if self.model_type == "SPLF" else 430
-        self.setMinimumSize(380, height)
-        self.resize(380, height)
+        self.apply_semantic_dialog_size()
+        self.set_semantic_button_callbacks(
+            default_callback=self.on_default_btn_clicked,
+            restore_callback=self.on_restore_default_btn_clicked,
+            ok_callback=self.on_click_ok_btn,
+        )
+        self._build_semantic_sections()
 
-        layout = QVBoxLayout()
-
+    def _build_semantic_sections(self):
         # SPL: time-domain smoothing checkbox
         self.smooth_chk_box = None
         if self.model_type != "SPLF":
@@ -81,24 +84,25 @@ class SplConfigWindow(AnalysisConfigDialogBase):
 
         self.weighting_selector = WeightingSelectorWidget(self.load_config, parent=self)
 
-        btn_layout = self.create_btn()
-
         if self.show_channel_selector:
             self.channel_selector = ChannelSelectorWidget(self.load_config, self.available_channels, self)
-            layout.addWidget(self.channel_selector)
-        layout.addWidget(self.weighting_selector)
+            self.add_semantic_section("input", widget=self.channel_selector)
+
+        compute_widget = QWidget(self)
+        compute_layout = QVBoxLayout(compute_widget)
+        compute_layout.setContentsMargins(0, 0, 0, 0)
+        compute_layout.setSpacing(8)
+        compute_layout.addWidget(self.weighting_selector)
         if self.splf_mode_group_box is not None:
-            layout.addWidget(self.splf_mode_group_box)
-            layout.addWidget(self.smoothing_selector)
+            compute_layout.addWidget(self.splf_mode_group_box)
+            compute_layout.addWidget(self.smoothing_selector)
         elif self.smooth_chk_box is not None:
-            layout.addWidget(self.smooth_chk_box)
+            compute_layout.addWidget(self.smooth_chk_box)
+        self.add_semantic_section("compute", widget=compute_widget)
+
         if self.golden_chk_box is not None:
-            layout.addWidget(self.golden_chk_box)
-        layout.addWidget(self.threshold_widget)
-        layout.addStretch()
-        layout.addLayout(btn_layout)
-        layout.setSpacing(10)
-        self.setLayout(layout)
+            self.add_semantic_section("reference", widget=self.golden_chk_box)
+        self.add_semantic_section("judgment", widget=self.threshold_widget)
 
     def create_btn(self):
         return self.create_standard_button_layout(self.on_default_btn_clicked, self.on_click_ok_btn)
@@ -130,6 +134,11 @@ class SplConfigWindow(AnalysisConfigDialogBase):
             return
         save_flag = self.config_manager.save_default_config(self.model_type, config_data)
         PopupUtils().save_popup(self, success_flag=save_flag)
+
+    def on_restore_default_btn_clicked(self):
+        self.load_config = self.config_manager.load_config().get(self.config_key, {})
+        self.clear_semantic_sections()
+        self._build_semantic_sections()
 
     def on_click_ok_btn(self):
         config_data = self.get_default_config()

--- a/unit_test/ui/test_analysis_config_common_widgets.py
+++ b/unit_test/ui/test_analysis_config_common_widgets.py
@@ -4,13 +4,14 @@ os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 import pytest
 from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QApplication
+from PyQt5.QtWidgets import QApplication, QWidget, QVBoxLayout
 
 from ui.ui_analysis_config.common_widgets import (
     ChannelSelectorWidget,
     GoldenSampleWidget,
     HarmonicSelectorWidget,
     OctaveSmoothingSelectorWidget,
+    SemanticAnalysisConfigDialogBase,
     TimeSmoothingWidget,
     WeightingSelectorWidget,
 )
@@ -134,3 +135,98 @@ def test_harmonic_selector_toggle_label_updates_selection(qapp):
 
     assert widget.selected_labels() == []
     assert first_label.text().startswith("  ")
+
+
+def _filler_widget(min_height=120):
+    widget = QWidget()
+    widget.setMinimumHeight(min_height)
+    layout = QVBoxLayout(widget)
+    layout.addWidget(ChannelSelectorWidget({"analysis_channel": 0}, [0]))
+    return widget
+
+
+def test_semantic_dialog_registers_only_added_groups(qapp):
+    dialog = SemanticAnalysisConfigDialogBase()
+    dialog.add_semantic_section("input", widget=_filler_widget())
+    dialog.add_semantic_section("compute", widget=_filler_widget())
+    dialog.add_semantic_section("judgment", title="判定参数", widget=_filler_widget())
+
+    assert dialog.semantic_group_keys() == ["input", "compute", "judgment"]
+    assert set(dialog._semantic_nav_buttons) == {"input", "compute", "judgment"}
+    assert dialog.current_semantic_group_key() == "input"
+    assert dialog._semantic_nav_buttons["input"].isChecked() is True
+
+
+def test_semantic_dialog_rejects_duplicate_group_keys(qapp):
+    dialog = SemanticAnalysisConfigDialogBase()
+    dialog.add_semantic_section("input", widget=_filler_widget())
+
+    with pytest.raises(ValueError):
+        dialog.add_semantic_section("input", widget=_filler_widget())
+
+
+def test_semantic_dialog_nav_click_updates_active_group(qapp):
+    dialog = SemanticAnalysisConfigDialogBase()
+    dialog.add_semantic_section("input", widget=_filler_widget())
+    dialog.add_semantic_section("compute", widget=_filler_widget())
+
+    dialog.scroll_to_semantic_section("compute")
+
+    assert dialog.current_semantic_group_key() == "compute"
+    assert dialog._semantic_nav_buttons["compute"].isChecked() is True
+    assert dialog._semantic_nav_buttons["input"].isChecked() is False
+
+
+def test_semantic_dialog_sections_are_collapsible_and_expanded_by_default(qapp):
+    dialog = SemanticAnalysisConfigDialogBase()
+    dialog.add_semantic_section("compute", widget=_filler_widget())
+
+    assert dialog.is_semantic_section_collapsed("compute") is False
+    assert dialog._semantic_section_contents["compute"].isHidden() is False
+
+    dialog.toggle_semantic_section("compute")
+
+    assert dialog.is_semantic_section_collapsed("compute") is True
+    assert dialog._semantic_section_contents["compute"].isHidden() is True
+    assert dialog._semantic_section_indicators["compute"].text() == ">"
+
+    dialog.set_semantic_section_collapsed("compute", False)
+
+    assert dialog.is_semantic_section_collapsed("compute") is False
+    assert dialog._semantic_section_contents["compute"].isHidden() is False
+    assert dialog._semantic_section_indicators["compute"].text() == "v"
+
+
+def test_semantic_dialog_scroll_sync_updates_active_group(qapp):
+    dialog = SemanticAnalysisConfigDialogBase()
+    dialog.add_semantic_section("input", widget=_filler_widget(200))
+    dialog.add_semantic_section("compute", widget=_filler_widget(200))
+    dialog.add_semantic_section("judgment", widget=_filler_widget(200))
+    dialog.resize(500, 260)
+    dialog.show()
+    qapp.processEvents()
+
+    judgment_y = dialog._semantic_sections["judgment"].y()
+    dialog.section_scroll_area.verticalScrollBar().setValue(judgment_y)
+    qapp.processEvents()
+
+    assert dialog.current_semantic_group_key() == "judgment"
+    assert dialog._semantic_nav_buttons["judgment"].isChecked() is True
+
+
+def test_semantic_dialog_footer_buttons_call_callbacks(qapp):
+    dialog = SemanticAnalysisConfigDialogBase()
+    calls = []
+    dialog.set_semantic_button_callbacks(
+        default_callback=lambda: calls.append("default"),
+        restore_callback=lambda: calls.append("restore"),
+        ok_callback=lambda: calls.append("ok"),
+        cancel_callback=lambda: calls.append("cancel"),
+    )
+
+    dialog.semantic_default_btn.click()
+    dialog.semantic_restore_btn.click()
+    dialog.semantic_cancel_btn.click()
+    dialog.semantic_ok_btn.click()
+
+    assert calls == ["default", "restore", "cancel", "ok"]

--- a/unit_test/ui/test_analysis_config_dialog_migration.py
+++ b/unit_test/ui/test_analysis_config_dialog_migration.py
@@ -86,6 +86,12 @@ def qapp():
     return QApplication.instance() or QApplication([])
 
 
+def assert_vertical_golden_size(window):
+    assert window.minimumWidth() == 630
+    assert window.minimumHeight() == 840
+    assert round(window.minimumWidth() / window.minimumHeight(), 2) == 0.75
+
+
 def test_ai_dialog_uses_shared_channel_selector_without_changing_config(qapp, monkeypatch):
     class FakeTrainingModelManagement:
         def get_all_model_name_from_db(self):
@@ -103,6 +109,8 @@ def test_ai_dialog_uses_shared_channel_selector_without_changing_config(qapp, mo
 
     window = ai_config_dialog.AIConfigWindow(config_manager, "AI", available_channels=[0, 2])
 
+    assert_vertical_golden_size(window)
+    assert window.semantic_group_keys() == ["input", "compute"]
     assert window.get_default_config() == {
         "analyse_model_name": "model_a",
         "analysis_channel": 2,
@@ -128,6 +136,8 @@ def test_lp_dialog_preserves_saved_keys_after_channel_migration(qapp):
 
     window = LPConfigWindow(config_manager, "LP", available_channels=[0, 1])
 
+    assert_vertical_golden_size(window)
+    assert window.semantic_group_keys() == ["input", "detection"]
     assert window.get_default_config() == {
         "trigger_threshold": 12,
         "hysterests_threshold": 3,
@@ -160,6 +170,8 @@ def test_spec_dialog_preserves_saved_keys_after_channel_migration(qapp):
 
     window = SpecConfigWindow(config_manager, "Spec", available_channels=[1, 3])
 
+    assert_vertical_golden_size(window)
+    assert window.semantic_group_keys() == ["input", "compute", "display"]
     assert window.get_default_config() == {
         "n_fft": 1024,
         "hop_length": 128,
@@ -190,6 +202,8 @@ def test_spl_dialog_preserves_saved_keys_after_shared_control_migration(qapp):
 
     window = SplConfigWindow(config_manager, "SPL", available_channels=[0, 2])
 
+    assert_vertical_golden_size(window)
+    assert window.semantic_group_keys() == ["input", "compute", "judgment"]
     assert window.get_default_config() == {
         "smooth_checked": True,
         "limit_checked": False,
@@ -218,6 +232,8 @@ def test_splf_dialog_preserves_saved_keys_after_shared_control_migration(qapp):
 
     window = SplConfigWindow(config_manager, "SPLF", available_channels=[0, 1])
 
+    assert_vertical_golden_size(window)
+    assert window.semantic_group_keys() == ["input", "compute", "reference", "judgment"]
     assert window.get_default_config() == {
         "splf_calc_mode": "total",
         "octave_smoothing": 3,
@@ -245,11 +261,50 @@ def test_fr_dialog_uses_shared_octave_smoothing_legacy_fallback(qapp):
 
     window = FrConfigWindow(config_manager, "FR")
 
+    assert_vertical_golden_size(window)
+    assert window.semantic_group_keys() == ["compute", "reference", "judgment"]
     assert window.get_default_config() == {
         "octave_smoothing": 6,
         "golden_sample_checked": True,
         "limit_checked": False,
         "limit_data": None,
+    }
+
+
+def test_spl_dialog_restore_default_reloads_semantic_sections(qapp):
+    from ui.ui_analysis_config.spl_config_dialog import SplConfigWindow
+
+    config_manager = FakeConfigManager(
+        {
+            "SPL": {
+                "smooth_checked": True,
+                "limit_checked": False,
+                "limit_data": None,
+                "weighting": "A",
+                "analysis_channel": 0,
+            }
+        }
+    )
+    window = SplConfigWindow(config_manager, "SPL", available_channels=[0, 1])
+
+    config_manager.config = {
+        "SPL": {
+            "smooth_checked": False,
+            "limit_checked": False,
+            "limit_data": None,
+            "weighting": "C",
+            "analysis_channel": 1,
+        }
+    }
+    window.on_restore_default_btn_clicked()
+
+    assert window.semantic_group_keys() == ["input", "compute", "judgment"]
+    assert window.get_default_config() == {
+        "smooth_checked": False,
+        "limit_checked": False,
+        "limit_data": None,
+        "weighting": "C",
+        "analysis_channel": 1,
     }
 
 
@@ -273,6 +328,8 @@ def test_fba_dialog_preserves_saved_keys_after_shared_control_migration(qapp):
 
     window = FbaConfigWindow(config_manager, "FBA", available_channels=[1, 3])
 
+    assert_vertical_golden_size(window)
+    assert window.semantic_group_keys() == ["input", "compute", "judgment"]
     assert window.get_default_config() == {
         "band_strategy": "1/3 倍频程",
         "f_min": 50,
@@ -302,6 +359,8 @@ def test_hd_dialog_uses_shared_harmonic_and_golden_widgets(qapp):
 
     window = HdConfigWindow(config_manager, "HD")
 
+    assert_vertical_golden_size(window)
+    assert window.semantic_group_keys() == ["detection", "reference", "judgment"]
     assert window.get_default_config() == {
         "selected_labels": [2, 3],
         "all_checked": False,
@@ -328,6 +387,8 @@ def test_rb_dialog_filters_harmonics_to_rub_buzz_range(qapp):
 
     window = RbConfigWindow(config_manager, "RB")
 
+    assert_vertical_golden_size(window)
+    assert window.semantic_group_keys() == ["detection", "reference", "judgment"]
     assert window.get_default_config() == {
         "selected_labels": [10, 12],
         "all_checked": False,
@@ -354,6 +415,8 @@ def test_prb_dialog_preserves_metric_fallback_and_golden_sample(qapp):
     window = PerceptualRbConfigWindow(config_manager, "PRB")
     config = window.get_default_config()
 
+    assert_vertical_golden_size(window)
+    assert window.semantic_group_keys() == ["compute", "reference", "judgment"]
     assert config["prb_method"] == "sc"
     assert config["masking_config"] == {"sc_metric": "totalnl_x_ehs", "keep": "value"}
     assert config["golden_sample_checked"] is True
@@ -389,11 +452,56 @@ def test_rsc_dialog_keeps_smoothing_key_after_shared_selector_migration(qapp, mo
     window = rsc_dialog.ReferenceSpectrumConfigWindow(config_manager, "RSC")
     config = window.get_default_config()
 
+    assert_vertical_golden_size(window)
+    assert window.semantic_group_keys() == ["reference", "compute", "judgment", "display"]
     assert config["smoothing"] == 3
     assert "octave_smoothing" not in config
     assert config["enable_threshold_judgment"] is True
     assert config["lower_offset_db"] == -2.0
     assert config["upper_offset_db"] == 2.0
+
+
+def test_excel_dialog_preserves_output_config_after_semantic_migration(qapp):
+    from ui.ui_analysis_config.excel_config_dialog import ExcelConfigWindow
+
+    config_manager = FakeConfigManager(
+        {
+            "Excel": {
+                "save_dir": "",
+                "file_base": "result",
+                "add_date": False,
+                "add_model_dir": True,
+                "lock_files": False,
+                "max_points": 500,
+                "save_items": ["SPL", "FBA"],
+                "save_mes_enabled": True,
+                "mes_file_base": "D:/dataMES",
+                "mes_file_name": "MES_Result",
+            },
+            "SPL": {"type": "SPL"},
+            "FBA": {"type": "FBA"},
+            "Spec": {"type": "Spec"},
+        }
+    )
+
+    window = ExcelConfigWindow(config_manager, "Excel")
+
+    assert_vertical_golden_size(window)
+    assert window.semantic_group_keys() == ["output"]
+    assert window.get_default_config() == {
+        "enabled": True,
+        "save_dir": None,
+        "file_base": "result",
+        "add_date": False,
+        "add_model_dir": True,
+        "lock_files": False,
+        "date_format": "%Y%m%d",
+        "max_points": 500,
+        "save_items": ["FBA", "SPL"],
+        "save_mes_enabled": True,
+        "mes_file_base": "D:/dataMES",
+        "mes_file_name": "MES_Result",
+    }
 
 
 def test_pd_dialog_preserves_time_smoothing_keys_after_widget_migration(qapp):


### PR DESCRIPTION
## Summary

- Add a reusable semantic analysis config dialog layout with left navigation, scroll-synced sections, collapsible groups, and footer actions.
- Migrate SPL/SPLF, FR, HD, RB, PRB, FBA, Spec, AI, RSC, Excel, and LP config dialogs to the semantic layout.
- Add regression coverage for the shared layout behavior and migrated dialog config compatibility.

## Related Issue

Closes #749

## Test Plan

- [x] `python -m py_compile ui\ui_analysis_config\common_widgets.py ui\ui_analysis_config\ai_config_dialog.py ui\ui_analysis_config\lp_config_dialog.py ui\ui_analysis_config\spec_config_dialog.py ui\ui_analysis_config\fba_config_dialog.py ui\ui_analysis_config\spl_config_dialog.py ui\ui_analysis_config\fr_config_dialog.py ui\ui_analysis_config\hd_config_dialog.py ui\ui_analysis_config\rb_config_dialog.py ui\ui_analysis_config\perceptual_rb_config_dialog.py ui\ui_analysis_config\reference_spectrum_config_dialog.py ui\ui_analysis_config\excel_config_dialog.py unit_test\ui\test_analysis_config_common_widgets.py unit_test\ui\test_analysis_config_dialog_migration.py`
- [x] `python -m pytest unit_test\ui\test_analysis_config_common_widgets.py unit_test\ui\test_analysis_config_normalization.py unit_test\ui\test_analysis_config_defaults.py unit_test\ui\test_analysis_config_dialog_migration.py -q`

## Notes

PD, PM, and ED are intentionally left on the existing layout for a separate migration pass.