### PR TITLE
BUG20260617-fix-tcp-same-socket-callback

### DIFF
--- a/base/tcp_service.py
+++ b/base/tcp_service.py
@@ -80,7 +80,6 @@ class TcpServer:
                 self.server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 self.server_socket.bind((self.host, self.port))
                 self.server_socket.listen(5)
-                print("Tcp_service is waiting for a connection...")
                 client_socket, client_address = self.server_socket.accept()
                 self._set_current_client(client_socket, client_address)
                 self.default_logger.info(f"client_address from {client_address} build")
@@ -104,7 +103,6 @@ class TcpServer:
                             self.default_logger.error(f"server_socket accept error: {e}")
                             break
                 finally:
-                    print("client close")
                     self.default_logger.info(f"client close")
                     self._clear_current_client(expected_socket=client_socket)
             except Exception as e:

--- a/base/tcp_service.py
+++ b/base/tcp_service.py
@@ -17,7 +17,9 @@ class TcpServer:
         self.server_thread = None
         self.stop_flag = False  # False 服务停止标记, True 开启
         self.request_id = None
+        self.client_socket = None
         self.client_address = None
+        self.client_lock = threading.RLock()
         self.default_logger = LogManager.set_log_handler("core")
 
     def start(self):
@@ -28,6 +30,7 @@ class TcpServer:
 
     def stop(self):
         self.stop_flag = False
+        self._clear_current_client()
         if self.server_socket:
             self.server_socket.close()
             self.server_socket = None
@@ -35,37 +38,84 @@ class TcpServer:
         else:
             self.default_logger.info("no tcp server running")
 
+    def _set_current_client(self, client_socket, client_address):
+        with self.client_lock:
+            self.client_socket = client_socket
+            self.client_address = client_address
+
+    def _clear_current_client(self, expected_socket=None):
+        with self.client_lock:
+            current_socket = self.client_socket
+            if expected_socket is not None and current_socket is not expected_socket:
+                return
+            self.client_socket = None
+            self.client_address = None
+
+        if current_socket:
+            try:
+                current_socket.close()
+            except OSError as e:
+                self.default_logger.error(f"client_socket close error: {e}")
+
+    def send_to_current_client(self, message):
+        with self.client_lock:
+            client_socket = self.client_socket
+            if client_socket is None:
+                self.default_logger.warning("tcp_send_skip: no active client socket")
+                return False
+            payload = f"{message}".encode()
+            try:
+                client_socket.sendall(payload)
+                return True
+            except OSError as e:
+                self.default_logger.error(f"tcp_send_error: {e}")
+
+        self._clear_current_client(expected_socket=client_socket)
+        return False
+
     def _run(self):
         while self.stop_flag:
+            client_socket = None
             try:
                 self.server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 self.server_socket.bind((self.host, self.port))
                 self.server_socket.listen(5)
                 print("Tcp_service is waiting for a connection...")
-                client_socket, self.client_address = self.server_socket.accept()
-                self.default_logger.info(f"client_address from {self.client_address} build")
+                client_socket, client_address = self.server_socket.accept()
+                self._set_current_client(client_socket, client_address)
+                self.default_logger.info(f"client_address from {client_address} build")
 
-                while True:
-                    if not self.stop_flag:
-                        break
-                    try:
-                        recved = client_socket.recv(tcp_service_recv_bytes)
-                        if not recved:
-                            self.default_logger.info(f"client No data sent or has been closed")
+                try:
+                    while True:
+                        if not self.stop_flag:
                             break
-                        info = recved.decode()
+                        try:
+                            recved = client_socket.recv(tcp_service_recv_bytes)
+                            if not recved:
+                                self.default_logger.info(f"client No data sent or has been closed")
+                                break
+                            info = recved.decode()
 
-                        res = self.callback(info)
-                        client_socket.send(f"{res}".encode())
+                            res = self.callback(info)
+                            if not self.send_to_current_client(res):
+                                break
 
-                    except OSError as e:
-                        self.default_logger.error(f"server_socket accept error: {e}")
-                        break
-                print("client close")
-                self.default_logger.info(f"client close")
-                client_socket.close()
+                        except OSError as e:
+                            self.default_logger.error(f"server_socket accept error: {e}")
+                            break
+                finally:
+                    print("client close")
+                    self.default_logger.info(f"client close")
+                    self._clear_current_client(expected_socket=client_socket)
             except Exception as e:
                 self.default_logger.error(f"tcp service except: {e}")
+                if self.server_socket:
+                    try:
+                        self.server_socket.close()
+                    except OSError as close_error:
+                        self.default_logger.error(f"server_socket close error: {close_error}")
+                    finally:
+                        self.server_socket = None
                 time.sleep(1)
 
 

--- a/ui/sequence/sequence_widget.py
+++ b/ui/sequence/sequence_widget.py
@@ -49,7 +49,6 @@ from base.save_data import ensure_test_result_file, save_recorded_data_to_json, 
 from base.soundcard_audio_processor import SoundcardAudioProcessor
 from base.soundcard_calibration_manager import resolve_analysis_v2pa_factor_for_channel
 from base.tcp_service import TcpServer, check_tcp_msg_format
-from base.temp_tcp_client import TempTcpClient
 from base.streaming_file_writer import StreamingWavWriter
 from base.pre_processing.alignment_processing import AlignmentProcessing
 from base.pre_processing.split_repeat_signal import SplitRepeatSignal
@@ -406,14 +405,15 @@ class SequenceWindow(QWidget):
             return
         try:
             tcp_server = getattr(SequenceWindow, "tcp_server", None)
-            client_address = getattr(tcp_server, "client_address", None)
-            if not client_address:
-                self.default_logger.warning("tcp_callback_skip: no client address")
+            if tcp_server is None:
+                self.default_logger.warning("tcp_callback_skip: no tcp server")
                 return
             payload = self._build_tcp_analysis_result_payload()
             message = json.dumps(payload, ensure_ascii=False)
-            TempTcpClient(client_address[0], client_address[1], message)
-            self.default_logger.info(f"tcp_callback_sent: {message}")
+            if tcp_server.send_to_current_client(message):
+                self.default_logger.info(f"tcp_callback_sent: {message}")
+            else:
+                self.default_logger.warning("tcp_callback_skip: no active tcp client")
         except Exception as e:
             self.default_logger.error(f"tcp_callback_send_error: {e}")
 

--- a/unit_test/base/test_tcp_service.py
+++ b/unit_test/base/test_tcp_service.py
@@ -1,0 +1,207 @@
+import pytest
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from base.tcp_service import TcpServer
+
+
+class FakeSocket:
+    def __init__(self, fail_send=False):
+        self.fail_send = fail_send
+        self.sent = []
+        self.closed = False
+
+    def sendall(self, payload):
+        if self.fail_send:
+            raise OSError("send failed")
+        self.sent.append(payload)
+
+    def close(self):
+        self.closed = True
+
+
+def test_send_to_current_client_sends_encoded_message():
+    server = TcpServer(host="127.0.0.1", port=50000, callback=lambda info: "ok")
+    fake_socket = FakeSocket()
+    server.client_socket = fake_socket
+    server.client_address = ("127.0.0.1", 64902)
+
+    assert server.send_to_current_client("ok") is True
+
+    assert fake_socket.sent == [b"ok"]
+    assert server.client_socket is fake_socket
+    assert server.client_address == ("127.0.0.1", 64902)
+
+
+def test_send_to_current_client_returns_false_without_connected_client():
+    server = TcpServer(host="127.0.0.1", port=50000, callback=lambda info: "ok")
+
+    assert server.send_to_current_client("ok") is False
+
+
+def test_send_to_current_client_closes_and_clears_state_on_send_error():
+    server = TcpServer(host="127.0.0.1", port=50000, callback=lambda info: "ok")
+    fake_socket = FakeSocket(fail_send=True)
+    server.client_socket = fake_socket
+    server.client_address = ("127.0.0.1", 64902)
+
+    assert server.send_to_current_client("ok") is False
+
+    assert fake_socket.closed is True
+    assert server.client_socket is None
+    assert server.client_address is None
+
+
+def test_run_routes_callback_response_through_send_to_current_client(monkeypatch):
+    class FakeClientSocket:
+        def __init__(self):
+            self.closed = False
+
+        def recv(self, _size):
+            return b"request"
+
+        def send(self, _payload):
+            raise AssertionError("direct client_socket.send should not be used")
+
+        def close(self):
+            self.closed = True
+
+    class FakeListeningSocket:
+        def __init__(self, client_socket):
+            self.client_socket = client_socket
+            self.closed = False
+
+        def bind(self, _address):
+            return None
+
+        def listen(self, _backlog):
+            return None
+
+        def accept(self):
+            return self.client_socket, ("127.0.0.1", 64902)
+
+        def close(self):
+            self.closed = True
+
+    client_socket = FakeClientSocket()
+    listening_socket = FakeListeningSocket(client_socket)
+
+    def callback(_info):
+        server.stop_flag = False
+        return "ok"
+
+    server = TcpServer(host="127.0.0.1", port=50000, callback=callback)
+    sent_messages = []
+    server.send_to_current_client = lambda message: sent_messages.append(message) or True
+    monkeypatch.setattr("base.tcp_service.socket.socket", lambda *_args, **_kwargs: listening_socket)
+    server.stop_flag = True
+
+    server._run()
+
+    assert sent_messages == ["ok"]
+
+
+def test_run_closes_and_clears_current_client_when_callback_raises(monkeypatch):
+    class FakeClientSocket:
+        def __init__(self):
+            self.closed = False
+
+        def recv(self, _size):
+            return b"request"
+
+        def close(self):
+            self.closed = True
+
+    class FakeListeningSocket:
+        def __init__(self, client_socket):
+            self.client_socket = client_socket
+            self.closed = False
+
+        def bind(self, _address):
+            return None
+
+        def listen(self, _backlog):
+            return None
+
+        def accept(self):
+            return self.client_socket, ("127.0.0.1", 64902)
+
+        def close(self):
+            self.closed = True
+
+    client_socket = FakeClientSocket()
+    listening_socket = FakeListeningSocket(client_socket)
+
+    def callback(_info):
+        server.stop_flag = False
+        raise RuntimeError("callback failed")
+
+    server = TcpServer(host="127.0.0.1", port=50000, callback=callback)
+    monkeypatch.setattr("base.tcp_service.socket.socket", lambda *_args, **_kwargs: listening_socket)
+    monkeypatch.setattr("base.tcp_service.time.sleep", lambda _seconds: None)
+    server.stop_flag = True
+
+    server._run()
+
+    assert client_socket.closed is True
+    assert server.client_socket is None
+    assert server.client_address is None
+
+
+def test_run_closes_listening_socket_before_retry_when_callback_raises(monkeypatch):
+    class FakeClientSocket:
+        def __init__(self):
+            self.closed = False
+
+        def recv(self, _size):
+            return b"request"
+
+        def close(self):
+            self.closed = True
+
+    class FakeListeningSocket:
+        def __init__(self, client_socket=None):
+            self.client_socket = client_socket
+            self.closed = False
+
+        def bind(self, _address):
+            return None
+
+        def listen(self, _backlog):
+            return None
+
+        def accept(self):
+            return self.client_socket, ("127.0.0.1", 64902)
+
+        def close(self):
+            self.closed = True
+
+    class RetryListeningSocket(FakeListeningSocket):
+        def bind(self, _address):
+            retry_saw_first_closed.append(first_listening.closed)
+            server.stop_flag = False
+            raise RuntimeError("stop after retry cleanup check")
+
+    client_socket = FakeClientSocket()
+    first_listening = FakeListeningSocket(client_socket)
+    second_listening = RetryListeningSocket()
+    sockets = iter([first_listening, second_listening])
+    retry_saw_first_closed = []
+
+    def callback(_info):
+        raise RuntimeError("callback failed")
+
+    server = TcpServer(host="127.0.0.1", port=50000, callback=callback)
+    monkeypatch.setattr("base.tcp_service.socket.socket", lambda *_args, **_kwargs: next(sockets))
+    monkeypatch.setattr("base.tcp_service.time.sleep", lambda _seconds: None)
+    server.stop_flag = True
+
+    server._run()
+
+    assert retry_saw_first_closed == [True]
+    assert first_listening.closed is True
+    assert server.server_socket is None

--- a/unit_test/ui/test_sequence_widget_sn_lock.py
+++ b/unit_test/ui/test_sequence_widget_sn_lock.py
@@ -184,7 +184,6 @@ def _build_method_namespace():
         "error_code": types.SimpleNamespace(OK="OK"),
         "save_audio_simple": lambda *args, **kwargs: None,
         "save_recorded_data_to_json": lambda *args, **kwargs: None,
-        "TempTcpClient": lambda *args, **kwargs: None,
         "normalize_play_record_detail": normalize_play_record_detail,
         "normalize_record_only_detail": normalize_record_only_detail,
         "np": np,
@@ -1674,9 +1673,11 @@ def test_start_this_play_no_longer_sends_finish_callback():
     namespace = _build_method_namespace()
     tcp_sends = []
     namespace["SequenceWindow"] = types.SimpleNamespace(
-        tcp_server=types.SimpleNamespace(client_address=("127.0.0.1", 5000))
+        tcp_server=types.SimpleNamespace(
+            client_address=("127.0.0.1", 5000),
+            send_to_current_client=lambda message: tcp_sends.append(message) or True,
+        )
     )
-    namespace["TempTcpClient"] = lambda *args: tcp_sends.append(args)
     window = _build_fake_window(namespace, use_streaming=True, mode="RECORD_ONLY")
     window.start_this_play = window._real_start_this_play
     window.tcp_flag = True
@@ -1722,13 +1723,15 @@ def test_tcp_analysis_result_payload_defaults_to_not_labeled_without_summary():
     assert payload["FileName"] == "OH2P-002.wav"
 
 
-def test_tcp_analysis_result_callback_sends_json_to_client_address():
+def test_tcp_analysis_result_callback_sends_json_to_current_tcp_client():
     namespace = _build_method_namespace()
     sends = []
-    namespace["SequenceWindow"] = types.SimpleNamespace(
-        tcp_server=types.SimpleNamespace(client_address=("127.0.0.1", 5000))
+    fake_tcp_server = types.SimpleNamespace(
+        send_to_current_client=lambda message: sends.append(message) or True
     )
-    namespace["TempTcpClient"] = lambda *args: sends.append(args)
+    namespace["SequenceWindow"] = types.SimpleNamespace(
+        tcp_server=fake_tcp_server
+    )
     window = _build_fake_window(namespace, use_streaming=True, mode="RECORD_ONLY")
     window.tcp_flag = True
     window.recorded_path = "OH2P-003.wav"
@@ -1742,10 +1745,22 @@ def test_tcp_analysis_result_callback_sends_json_to_client_address():
     window._send_tcp_analysis_result_callback()
 
     assert len(sends) == 1
-    assert sends[0][0:2] == ("127.0.0.1", 5000)
-    sent_payload = json.loads(sends[0][2])
+    sent_payload = json.loads(sends[0])
     assert sent_payload["Label"] == "NG"
     assert sent_payload["FileName"] == "OH2P-003.wav"
+
+
+def test_tcp_analysis_result_callback_skips_without_tcp_server():
+    namespace = _build_method_namespace()
+    namespace["SequenceWindow"] = types.SimpleNamespace(tcp_server=None)
+    window = _build_fake_window(namespace, use_streaming=True, mode="RECORD_ONLY")
+    window.tcp_flag = True
+    window._build_tcp_analysis_result_payload = lambda: {"TimeStamp": "t", "Label": "OK", "FileName": "a.wav"}
+    window._send_tcp_analysis_result_callback = _bind_method(window, namespace, "_send_tcp_analysis_result_callback")
+
+    window._send_tcp_analysis_result_callback()
+
+    assert any("tcp_callback_skip" in message for level, message in window.default_logger.messages)
 
 
 def test_tcp_run_test_allows_play_and_record_mode():


### PR DESCRIPTION
## Summary
- Send TCP analysis-result callbacks over the existing accepted client socket instead of reverse-connecting to the client's ephemeral port.
- Centralize TCP writes through `TcpServer.send_to_current_client()` with cleanup on send/callback failures.
- Add regression coverage for same-socket responses and TCP socket lifecycle cleanup.

## Test Plan
- pytest unit_test/base/test_tcp_service.py unit_test/ui/test_sequence_widget_sn_lock.py -v --basetemp .pytest-temp-push

Closes #755