### PR TITLE
US20260709-add-wav-calibration-metadata

### DIFF
--- a/base/data_struct/data_deal_struct.py
+++ b/base/data_struct/data_deal_struct.py
@@ -17,6 +17,9 @@ class DataDealStruct(object):
 
             self.store_wave_data = None
             self.store_wave_data_multi = None
+            self.wav_calibration_metadata = None
+            self.wav_calibration_metadata_authoritative = False
+            self.wav_calibration_warning_shown = False
             self.split_repeat_data = None
             self.stimulus_data = None
             self.stimulus_info = None
@@ -36,6 +39,9 @@ class DataDealStruct(object):
     def clear_data(self):
         self.store_wave_data = None
         self.store_wave_data_multi = None
+        self.wav_calibration_metadata = None
+        self.wav_calibration_metadata_authoritative = False
+        self.wav_calibration_warning_shown = False
         self.split_repeat_data = None
         # self.stimulus_data = None
         self.fft_result = None

--- a/base/play_and_record.py
+++ b/base/play_and_record.py
@@ -2,16 +2,18 @@ import os
 from datetime import datetime
 
 from base.data_struct.data_deal_struct import DataDealStruct
+from base.log_manager import LogManager
 from base.system_intervction.hardware_intervction import get_mac_address
 from base.pre_processing.split_repeat_signal import SplitRepeatSignal
 from base.recording_management import RecordingManager
-from base.save_data import save_audio_simple
+from base.save_data import save_audio_simple, save_audio_with_calibration_metadata
 from base.soundcard_audio_processor import SoundcardAudioProcessor, alignment_reference_from_stimulus
 from base.streaming_audio_processor import StreamingAudioProcessor
 from consts.audio_consts import normalize_float_bit_depth
 from consts import error_code, model_consts
 
 data_struct = DataDealStruct()
+logger = LogManager.set_log_handler("soundcard_core")
 
 
 def _coerce_runtime_sample_rate(sample_rate):
@@ -78,7 +80,19 @@ def record_without_play(recorded_dict, recorded_path, recorded_signal_info):
 
     sample_rate = _require_recording_runtime_sample_rate(recorded_dict)
     bit_depth = normalize_float_bit_depth(recorded_dict.get("bit_depth", 32))
-    if bit_depth == 32 and "bit_depth" not in recorded_dict:
+    calibration_metadata = recorded_dict.get("wav_calibration_metadata")
+    if calibration_metadata:
+        save_kwargs = {"logger": logger}
+        if bit_depth != 32:
+            save_kwargs["bit_depth"] = bit_depth
+        save_audio_with_calibration_metadata(
+            recorded_path,
+            recorded_signal,
+            sample_rate,
+            calibration_metadata,
+            **save_kwargs,
+        )
+    elif bit_depth == 32 and "bit_depth" not in recorded_dict:
         save_audio_simple(recorded_path, recorded_signal, sample_rate)
     else:
         save_audio_simple(recorded_path, recorded_signal, sample_rate, bit_depth=bit_depth)
@@ -101,7 +115,12 @@ def play_last_stimulus_wave(stimulus_dict, recorded_dict, recorded_path, recorde
     sample_rate = data_struct.sample_rate
 
     sap = SoundcardAudioProcessor()
-    record_code, recorded_signal = sap.sd_play_rec(recorded_dict, stimulus_dict, recorded_path)
+    record_code, recorded_signal = sap.sd_play_rec(
+        recorded_dict,
+        stimulus_dict,
+        recorded_path,
+        calibration_metadata=recorded_dict.get("wav_calibration_metadata"),
+    )
     if record_code != error_code.OK:
         return record_code, recorded_signal
 
@@ -243,6 +262,7 @@ def stream_play_and_record(stimulus_dict, recorded_dict, recorded_path, recorded
 
     input_device = recorded_dict.get("input_device")
     output_device = recorded_dict.get("output_device")
+    input_channels = recorded_dict.get("input_channels")
     recording_start_delay_frames = recorded_dict.get("recording_start_delay_frames", 0)
     bit_depth = normalize_float_bit_depth(recorded_dict.get("bit_depth", 32))
 
@@ -256,6 +276,7 @@ def stream_play_and_record(stimulus_dict, recorded_dict, recorded_path, recorded
         target_samples=target_samples,  # Use exact sample count instead of duration
         input_device=input_device,
         output_device=output_device,
+        input_channels=input_channels,
         prepare_frames=prepare_frames,
         prolong_frames=prolong_frames,
         discard_initial_samples=recording_start_delay_frames,

--- a/base/recording_calibration_snapshot.py
+++ b/base/recording_calibration_snapshot.py
@@ -1,0 +1,87 @@
+import math
+
+from base.hardware_management import HardwareManagementRepository
+from base.soundcard_calibration_manager import load_mic_channel_v2pa_factors
+
+
+def _warn(logger, message):
+    if logger is not None and hasattr(logger, "warning"):
+        logger.warning(message)
+
+
+def _finite_float(value):
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(number):
+        return None
+    return number
+
+
+def _finite_positive_float(value):
+    number = _finite_float(value)
+    if number is None or number <= 0:
+        return None
+    return number
+
+
+def _uncalibrated_metadata(input_channels):
+    return {
+        "recorded_channels": [
+            {
+                "wav_channel_index": wav_channel_index,
+                "v2pa_factor": None,
+                "standard_spl": None,
+                "calibrated": False,
+            }
+            for wav_channel_index, _channel_index in enumerate(input_channels)
+        ]
+    }
+
+
+def load_mic_channel_standard_spl(hardware_id=None, db_path=None):
+    rows = HardwareManagementRepository(db_path).list_channel_calibrations(
+        hardware_id,
+        "input",
+        "mic_v2pa",
+    )
+    standard_spl = {}
+    for row in rows:
+        try:
+            channel_index = int(row["channel_index"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        spl = _finite_float(row.get("standard_spl"))
+        if spl is not None:
+            standard_spl[channel_index] = spl
+    return standard_spl
+
+
+def build_recording_wav_calibration_metadata(input_channels, hardware_id=None, db_path=None, logger=None):
+    try:
+        normalized_channels = [int(channel) for channel in input_channels]
+    except (TypeError, ValueError):
+        normalized_channels = []
+
+    try:
+        v2pa_factors = load_mic_channel_v2pa_factors(hardware_id=hardware_id, db_path=db_path)
+        standard_spl = load_mic_channel_standard_spl(hardware_id=hardware_id, db_path=db_path)
+    except Exception as exc:
+        _warn(logger, f"Failed to build WAV calibration metadata; channels marked uncalibrated. {exc}")
+        return _uncalibrated_metadata(normalized_channels)
+
+    recorded_channels = []
+    for wav_channel_index, input_channel in enumerate(normalized_channels):
+        factor = _finite_positive_float(v2pa_factors.get(input_channel))
+        spl = _finite_float(standard_spl.get(input_channel))
+        calibrated = factor is not None and spl is not None
+        recorded_channels.append(
+            {
+                "wav_channel_index": wav_channel_index,
+                "v2pa_factor": factor if calibrated else None,
+                "standard_spl": spl if calibrated else None,
+                "calibrated": calibrated,
+            }
+        )
+    return {"recorded_channels": recorded_channels}

--- a/base/save_data.py
+++ b/base/save_data.py
@@ -8,11 +8,7 @@ from scipy.io import wavfile
 from base.file_ops import FileOps
 from consts.audio_consts import bit_depth_to_dtype
 from consts.running_consts import DEFAULT_DIR
-
-try:
-    from base.wav_calibration_metadata import append_wav_calibration_metadata
-except ImportError:
-    append_wav_calibration_metadata = None
+from base.wav_calibration_metadata import append_wav_calibration_metadata
 
 
 def save_audio_simple(save_path, audio, sr=44100, bit_depth=32):
@@ -24,13 +20,7 @@ def save_audio_simple(save_path, audio, sr=44100, bit_depth=32):
 
 def save_audio_with_calibration_metadata(save_path, audio, sr=44100, calibration_metadata=None, logger=None, bit_depth=32):
     save_audio_simple(save_path, audio, sr, bit_depth=bit_depth)
-    if calibration_metadata is None:
-        return
-    if append_wav_calibration_metadata is None:
-        if logger is not None:
-            log_method = getattr(logger, "warning", None) or getattr(logger, "error", None)
-            if log_method is not None:
-                log_method("WAV calibration metadata support is unavailable")
+    if not calibration_metadata:
         return
     try:
         appended = append_wav_calibration_metadata(save_path, calibration_metadata, logger=logger)
@@ -39,11 +29,11 @@ def save_audio_with_calibration_metadata(save_path, audio, sr=44100, calibration
         if logger is not None:
             log_method = getattr(logger, "warning", None) or getattr(logger, "error", None)
             if log_method is not None:
-                log_method(f"Failed to append WAV calibration metadata: {exc}")
+                log_method(f"Failed to append WAV calibration metadata; audio file was kept. {exc}")
     if not appended and logger is not None:
         log_method = getattr(logger, "warning", None) or getattr(logger, "error", None)
         if log_method is not None:
-            log_method("Failed to append WAV calibration metadata")
+            log_method("Failed to append WAV calibration metadata; audio file was kept.")
 
 
 def save_recorded_data_to_json(product_model, current_recorded_count, scanner_barcode, scanner_barcode_check):

--- a/base/soundcard_audio_processor.py
+++ b/base/soundcard_audio_processor.py
@@ -2,8 +2,9 @@ import numpy as np
 from scipy.signal import correlate
 
 from base.log_manager import LogManager
-from base.save_data import save_audio_simple
+from base.save_data import save_audio_simple, save_audio_with_calibration_metadata
 from base.sound_device_manager import sd
+from base.wav_calibration_metadata import normalize_wav_calibration_metadata
 from consts import error_code
 from consts.audio_consts import normalize_float_bit_depth, bit_depth_to_dtype
 
@@ -40,6 +41,20 @@ def bounded_aligned_recording_slice(recorded_signal, start_frame, sample_count):
     if copied_count:
         aligned_data[:copied_count] = recorded_signal[start_frame:end_frame]
     return aligned_data
+
+
+def project_calibration_metadata_to_mono_wav(metadata):
+    normalized = normalize_wav_calibration_metadata(metadata)
+    if normalized is None:
+        return metadata
+
+    channels = normalized["recorded_channels"]
+    if len(channels) == 1 and channels[0]["wav_channel_index"] == 0:
+        return metadata
+
+    retained_channel = dict(channels[0])
+    retained_channel["wav_channel_index"] = 0
+    return {"recorded_channels": [retained_channel]}
 
 
 class SoundcardAudioProcessor(object):
@@ -135,7 +150,7 @@ class SoundcardAudioProcessor(object):
             return None, output_index
         return None
 
-    def sd_play_rec(self, record_dict, stimulus_dict, recording_path):
+    def sd_play_rec(self, record_dict, stimulus_dict, recording_path, *, calibration_metadata=None):
         sr, validation_code, validation_msg = self._resolve_playrec_sample_rate(record_dict, stimulus_dict)
         if validation_code != error_code.OK:
             return validation_code, validation_msg
@@ -160,17 +175,36 @@ class SoundcardAudioProcessor(object):
             ]
         )
         device = self._playrec_device_selector(record_dict)
+        input_channels = record_dict.get("input_channels")
+        selected_channels = []
+        if input_channels is not None:
+            if isinstance(input_channels, int):
+                selected_channels = [input_channels]
+            else:
+                selected_channels = list(input_channels)
+        record_channels = max(selected_channels) + 1 if selected_channels else 1
         if device is None:
-            rec_data = sd.playrec(prolong_data, samplerate=sr, channels=1, blocking=True, dtype=dtype).T[0]
+            rec_data = sd.playrec(prolong_data, samplerate=sr, channels=record_channels, blocking=True, dtype=dtype)
         else:
             rec_data = sd.playrec(
-                prolong_data, samplerate=sr, channels=1, blocking=True, device=device, dtype=dtype
-            ).T[0]
+                prolong_data, samplerate=sr, channels=record_channels, blocking=True, device=device, dtype=dtype
+            )
+        rec_data = np.asarray(rec_data)
+        if rec_data.ndim > 1:
+            record_channel = selected_channels[0] if selected_channels else 0
+            rec_data = rec_data[:, record_channel]
         if delay_frames > 0:
             rec_data = rec_data[delay_frames:]
         align_frames = self.calculate_alignment(alignment_reference, rec_data)
         aligned_data = bounded_aligned_recording_slice(rec_data, align_frames, len(alignment_reference))
-        if bit_depth == 32 and "bit_depth" not in record_dict:
+        metadata = calibration_metadata if calibration_metadata is not None else record_dict.get("wav_calibration_metadata")
+        metadata = project_calibration_metadata_to_mono_wav(metadata)
+        if metadata:
+            save_kwargs = {"logger": self.logger}
+            if bit_depth != 32:
+                save_kwargs["bit_depth"] = bit_depth
+            save_audio_with_calibration_metadata(recording_path, aligned_data, sr, metadata, **save_kwargs)
+        elif bit_depth == 32 and "bit_depth" not in record_dict:
             save_audio_simple(recording_path, aligned_data, sr)
         else:
             save_audio_simple(recording_path, aligned_data, sr, bit_depth=bit_depth)

--- a/base/soundcard_audio_processor.py
+++ b/base/soundcard_audio_processor.py
@@ -150,7 +150,7 @@ class SoundcardAudioProcessor(object):
             return None, output_index
         return None
 
-    def sd_play_rec(self, record_dict, stimulus_dict, recording_path, *, calibration_metadata=None):
+    def sd_play_rec(self, record_dict, stimulus_dict, recording_path, calibration_metadata=None):
         sr, validation_code, validation_msg = self._resolve_playrec_sample_rate(record_dict, stimulus_dict)
         if validation_code != error_code.OK:
             return validation_code, validation_msg

--- a/base/wav_calibration_metadata.py
+++ b/base/wav_calibration_metadata.py
@@ -1,0 +1,380 @@
+import json
+import math
+import os
+import struct
+from dataclasses import dataclass
+from numbers import Integral, Real
+from typing import Any, Optional
+
+from consts.audio_consts import CHUNK_HEADER_SIZE, MAX_RIFF_SIZE, RIFF_HEADER_SIZE
+
+
+@dataclass(frozen=True)
+class WavCalibrationResolution:
+    factor: float
+    has_valid_metadata: bool
+    used_file_metadata: bool
+
+
+def normalize_wav_calibration_metadata(payload: Any) -> Optional[dict]:
+    if not isinstance(payload, dict):
+        return None
+
+    recorded_channels = payload.get("recorded_channels")
+    if not isinstance(recorded_channels, list):
+        return None
+
+    normalized_channels = []
+    seen_wav_channel_indices = set()
+    for channel in recorded_channels:
+        normalized_channel = _normalize_channel(channel)
+        if normalized_channel is None:
+            return None
+        wav_channel_index = normalized_channel["wav_channel_index"]
+        if wav_channel_index in seen_wav_channel_indices:
+            return None
+        seen_wav_channel_indices.add(wav_channel_index)
+        normalized_channels.append(normalized_channel)
+
+    if not normalized_channels:
+        return None
+
+    return {"recorded_channels": normalized_channels}
+
+
+def resolve_wav_channel_v2pa_factor(metadata: Any, wav_channel_index: int) -> WavCalibrationResolution:
+    try:
+        normalized = normalize_wav_calibration_metadata(metadata)
+        selected_index = _coerce_wav_channel_index(wav_channel_index)
+    except (OverflowError, TypeError, ValueError):
+        return WavCalibrationResolution(1.0, False, False)
+
+    if normalized is None:
+        return WavCalibrationResolution(1.0, False, False)
+
+    for channel in normalized["recorded_channels"]:
+        if channel["wav_channel_index"] != selected_index:
+            continue
+        if channel["calibrated"] and channel["v2pa_factor"] is not None:
+            return WavCalibrationResolution(float(channel["v2pa_factor"]), True, True)
+        return WavCalibrationResolution(1.0, True, False)
+
+    return WavCalibrationResolution(1.0, True, False)
+
+
+def append_wav_calibration_metadata(path, metadata, logger=None) -> bool:
+    try:
+        normalized = normalize_wav_calibration_metadata(metadata)
+        if normalized is None:
+            _log_metadata_issue(
+                logger,
+                "Invalid WAV calibration metadata",
+                ValueError("metadata payload was rejected"),
+            )
+            return False
+
+        comment = "mic_calibration=" + json.dumps(normalized, ensure_ascii=True, separators=(",", ":"))
+        list_chunk = _build_info_comment_list_chunk(comment)
+
+        with open(path, "r+b") as wav_file:
+            if not _is_riff_wave_file(wav_file):
+                _log_metadata_issue(
+                    logger,
+                    "Unsupported WAV file",
+                    ValueError("file is not a RIFF/WAVE file"),
+                )
+                return False
+            wav_file.seek(0, os.SEEK_END)
+            file_size = wav_file.tell()
+            append_offset = _read_authoritative_riff_end(wav_file, file_size, logger)
+            if append_offset is None:
+                return False
+            if _scan_declared_riff_chunks(wav_file, append_offset, logger, read_metadata=False) is None:
+                return False
+
+            new_riff_size = append_offset + len(list_chunk) - 8
+            if new_riff_size > MAX_RIFF_SIZE:
+                _log_metadata_issue(
+                    logger,
+                    "Failed to append WAV calibration metadata",
+                    ValueError("RIFF size exceeds 32-bit limit"),
+                )
+                return False
+
+            wav_file.seek(append_offset)
+            wav_file.truncate()
+            wav_file.write(list_chunk)
+            file_size = wav_file.tell()
+            wav_file.seek(4)
+            wav_file.write(struct.pack("<I", file_size - 8))
+        return True
+    except Exception as exc:
+        _log_metadata_issue(logger, "Failed to append WAV calibration metadata", exc)
+        return False
+
+
+def read_wav_calibration_metadata(path, logger=None) -> Optional[dict]:
+    last_valid_metadata = None
+    try:
+        with open(path, "rb") as wav_file:
+            if not _is_riff_wave_file(wav_file):
+                return None
+            wav_file.seek(0, os.SEEK_END)
+            file_size = wav_file.tell()
+            wav_file.seek(4)
+            riff_size = struct.unpack("<I", wav_file.read(4))[0]
+            if riff_size + 8 > file_size:
+                _log_metadata_issue(
+                    logger,
+                    "Invalid WAV RIFF structure",
+                    ValueError("declared RIFF size exceeds file size"),
+                )
+                return None
+            parse_end = riff_size + 8
+            last_valid_metadata = _scan_declared_riff_chunks(wav_file, parse_end, logger, read_metadata=True)
+            if last_valid_metadata is None:
+                return None
+    except Exception as exc:
+        _log_metadata_issue(logger, "Failed to read WAV calibration metadata", exc)
+        return None
+
+    return last_valid_metadata
+
+
+def _normalize_channel(channel: Any) -> Optional[dict]:
+    if not isinstance(channel, dict):
+        return None
+
+    try:
+        wav_channel_index = _coerce_wav_channel_index(channel.get("wav_channel_index"))
+    except (TypeError, ValueError):
+        return None
+    calibrated = bool(channel.get("calibrated", False))
+
+    if calibrated:
+        v2pa_factor = _coerce_positive_finite_float(channel.get("v2pa_factor"))
+    else:
+        v2pa_factor = None
+
+    return {
+        "wav_channel_index": wav_channel_index,
+        "v2pa_factor": v2pa_factor,
+        "standard_spl": _coerce_optional_finite_float(channel.get("standard_spl")),
+        "calibrated": calibrated,
+    }
+
+
+def _build_info_comment_list_chunk(comment: str) -> bytes:
+    comment_payload = comment.encode("utf-8") + b"\x00"
+    icmt_chunk = _build_chunk(b"ICMT", comment_payload)
+    return _build_chunk(b"LIST", b"INFO" + icmt_chunk)
+
+
+def _build_chunk(chunk_id: bytes, payload: bytes) -> bytes:
+    chunk = chunk_id + struct.pack("<I", len(payload)) + payload
+    if len(payload) % 2:
+        chunk += b"\x00"
+    return chunk
+
+
+def _is_riff_wave_file(wav_file) -> bool:
+    wav_file.seek(0)
+    header = wav_file.read(RIFF_HEADER_SIZE)
+    return len(header) == RIFF_HEADER_SIZE and header[:4] == b"RIFF" and header[8:12] == b"WAVE"
+
+
+def _read_authoritative_riff_end(wav_file, file_size: int, logger=None) -> Optional[int]:
+    wav_file.seek(4)
+    riff_size_data = wav_file.read(4)
+    if len(riff_size_data) != 4:
+        _log_metadata_issue(logger, "Invalid WAV RIFF structure", ValueError("missing RIFF size"))
+        return None
+
+    riff_end = struct.unpack("<I", riff_size_data)[0] + 8
+    if riff_end < RIFF_HEADER_SIZE:
+        _log_metadata_issue(logger, "Invalid WAV RIFF structure", ValueError("declared RIFF size is too small"))
+        return None
+    if riff_end > file_size:
+        _log_metadata_issue(logger, "Invalid WAV RIFF structure", ValueError("declared RIFF size exceeds file size"))
+        return None
+    return riff_end
+
+
+def _scan_declared_riff_chunks(wav_file, parse_end: int, logger=None, *, read_metadata: bool) -> Optional[dict]:
+    last_valid_metadata = None
+    wav_file.seek(RIFF_HEADER_SIZE)
+
+    while wav_file.tell() + CHUNK_HEADER_SIZE <= parse_end:
+        chunk_header = wav_file.read(CHUNK_HEADER_SIZE)
+        if len(chunk_header) < CHUNK_HEADER_SIZE:
+            break
+        chunk_id, chunk_size = struct.unpack("<4sI", chunk_header)
+        chunk_data_start = wav_file.tell()
+        chunk_data_end = chunk_data_start + chunk_size
+        if chunk_data_end > parse_end:
+            _log_metadata_issue(
+                logger,
+                "Invalid WAV chunk structure",
+                ValueError("chunk payload extends beyond declared RIFF data"),
+            )
+            return None
+        if chunk_size % 2 and chunk_data_end + 1 > parse_end:
+            _log_metadata_issue(
+                logger,
+                "Invalid WAV chunk structure",
+                ValueError("missing padding byte after odd-sized chunk"),
+            )
+            return None
+
+        if read_metadata and chunk_id == b"LIST" and chunk_size >= 4:
+            list_data = wav_file.read(chunk_size)
+            valid_metadata = _read_info_comment_metadata(list_data, logger)
+            if valid_metadata is not None:
+                last_valid_metadata = valid_metadata
+        else:
+            wav_file.seek(chunk_size, os.SEEK_CUR)
+
+        if chunk_size % 2:
+            padding = wav_file.read(1)
+            if padding != b"\x00":
+                _log_metadata_issue(
+                    logger,
+                    "Invalid WAV chunk structure",
+                    ValueError("nonzero padding byte after odd-sized chunk"),
+                )
+                return None
+
+    if wav_file.tell() != parse_end:
+        _log_metadata_issue(
+            logger,
+            "Invalid WAV RIFF structure",
+            ValueError("unconsumed trailing bytes in declared RIFF data"),
+        )
+        return None
+
+    return last_valid_metadata if read_metadata else {}
+
+
+def _read_info_comment_metadata(list_data: bytes, logger=None) -> Optional[dict]:
+    if len(list_data) < 4 or list_data[:4] != b"INFO":
+        return None
+
+    last_valid_metadata = None
+    offset = 4
+    while offset + CHUNK_HEADER_SIZE <= len(list_data):
+        subchunk_id, subchunk_size = struct.unpack("<4sI", list_data[offset : offset + CHUNK_HEADER_SIZE])
+        offset += CHUNK_HEADER_SIZE
+        payload_end = offset + subchunk_size
+        if payload_end > len(list_data):
+            _log_metadata_issue(
+                logger,
+                "Invalid WAV LIST/INFO structure",
+                ValueError("subchunk payload extends beyond LIST data"),
+            )
+            return None
+        if subchunk_size % 2 and payload_end + 1 > len(list_data):
+            _log_metadata_issue(
+                logger,
+                "Invalid WAV LIST/INFO structure",
+                ValueError("missing padding byte after odd-sized subchunk"),
+            )
+            return None
+        if subchunk_size % 2 and list_data[payload_end : payload_end + 1] != b"\x00":
+            _log_metadata_issue(
+                logger,
+                "Invalid WAV LIST/INFO structure",
+                ValueError("nonzero padding byte after odd-sized subchunk"),
+            )
+            return None
+
+        if subchunk_id == b"ICMT":
+            metadata = _parse_info_comment_payload(list_data[offset:payload_end], logger)
+            if metadata is not None:
+                last_valid_metadata = metadata
+
+        offset = payload_end + (subchunk_size % 2)
+
+    if offset != len(list_data):
+        _log_metadata_issue(
+            logger,
+            "Invalid WAV LIST/INFO structure",
+            ValueError("unconsumed trailing bytes in LIST data"),
+        )
+        return None
+
+    return last_valid_metadata
+
+
+def _parse_info_comment_payload(payload: bytes, logger=None) -> Optional[dict]:
+    try:
+        comment = payload.rstrip(b"\x00").decode("utf-8")
+    except UnicodeDecodeError as exc:
+        _log_metadata_issue(logger, "Failed to decode WAV calibration metadata", exc)
+        return None
+
+    if not comment.startswith("mic_calibration="):
+        return None
+
+    try:
+        raw_metadata = json.loads(comment[len("mic_calibration=") :])
+        normalized = normalize_wav_calibration_metadata(raw_metadata)
+    except (json.JSONDecodeError, TypeError, ValueError) as exc:
+        _log_metadata_issue(logger, "Invalid WAV calibration metadata", exc)
+        return None
+    if normalized is None:
+        _log_metadata_issue(logger, "Invalid WAV calibration metadata", ValueError("metadata payload was rejected"))
+        return None
+    return normalized
+
+
+def _log_metadata_issue(logger, message: str, exc: Exception) -> None:
+    if logger is None:
+        return
+    log_message = f"{message}: {exc}"
+    log_method = getattr(logger, "warning", None) or getattr(logger, "error", None)
+    if log_method is not None:
+        log_method(log_message)
+
+
+def _coerce_wav_channel_index(value: Any) -> int:
+    if isinstance(value, bool):
+        raise ValueError("wav_channel_index must be a non-negative integer")
+    if isinstance(value, Integral):
+        index = int(value)
+    elif isinstance(value, Real):
+        if not math.isfinite(value) or not float(value).is_integer():
+            raise ValueError("wav_channel_index must be a non-negative integer")
+        index = int(value)
+    elif isinstance(value, str):
+        if not value.isdecimal():
+            raise ValueError("wav_channel_index must be a non-negative integer")
+        index = int(value)
+    else:
+        raise ValueError("wav_channel_index must be a non-negative integer")
+    if index < 0:
+        raise ValueError("wav_channel_index must be a non-negative integer")
+    return index
+
+
+def _coerce_positive_finite_float(value: Any) -> float:
+    if isinstance(value, bool):
+        raise ValueError("v2pa_factor must be a finite positive number")
+    try:
+        factor = float(value)
+    except (TypeError, OverflowError) as exc:
+        raise ValueError("v2pa_factor must be a finite positive number") from exc
+    if not math.isfinite(factor) or factor <= 0:
+        raise ValueError("v2pa_factor must be a finite positive number")
+    return factor
+
+
+def _coerce_optional_finite_float(value: Any) -> Optional[float]:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(number):
+        return None
+    return number

--- a/ui/operation_sequence.py
+++ b/ui/operation_sequence.py
@@ -15,6 +15,7 @@ from base.data_struct.sequence_data import SequenceData
 from base.file_ops import FileOps
 from base.load_config import ConfigManager, LoadUiConfig
 from base.log_manager import LogManager
+from base.recording_calibration_snapshot import build_recording_wav_calibration_metadata
 from base.soundcard_calibration_manager import resolve_analysis_v2pa_factor_for_channel
 from base.acquisition_recording_defaults import (
     load_acquisition_defaults,
@@ -505,7 +506,26 @@ class AnalysisModelSelect(QDialog):
             # Blocking play+record (also saves wav)
             try:
                 sap = SoundcardAudioProcessor()
-                record_code, aligned_data = sap.sd_play_rec(recorded_dict, stimulus_dict, recorded_wav_path)
+                mic = _safe_dialog_attr(self, "mic", None)
+                if mic is None:
+                    mic = _safe_dialog_attr(self.select_list, "mic", None)
+                hardware_id = mic.get("hardware_id") if isinstance(mic, dict) else None
+                input_channels = _safe_dialog_attr(self.select_list, "mic_channels", None) or [0]
+                input_channels = [int(channel) for channel in input_channels]
+                input_channels = [input_channels[0]] if input_channels else [0]
+                calibration_metadata = build_recording_wav_calibration_metadata(
+                    input_channels,
+                    hardware_id=hardware_id,
+                    logger=self.default_logger,
+                )
+                recorded_dict["input_channels"] = input_channels
+                recorded_dict["wav_calibration_metadata"] = calibration_metadata
+                record_code, aligned_data = sap.sd_play_rec(
+                    recorded_dict,
+                    stimulus_dict,
+                    recorded_wav_path,
+                    calibration_metadata=calibration_metadata,
+                )
                 if record_code != 0 or aligned_data is None:
                     MessageBox.warning(self, "提示", "录制黄金样本失败")
                     return

--- a/ui/sequence/sequence_widget.py
+++ b/ui/sequence/sequence_widget.py
@@ -45,11 +45,18 @@ from base.play_and_record import (
     stream_record_without_play,
 )
 from base.recording_management import RecordingManager
-from base.save_data import ensure_test_result_file, save_recorded_data_to_json, save_audio_simple
+from base.recording_calibration_snapshot import build_recording_wav_calibration_metadata
+from base.save_data import (
+    ensure_test_result_file,
+    save_recorded_data_to_json,
+    save_audio_simple,
+    save_audio_with_calibration_metadata,
+)
 from base.soundcard_audio_processor import SoundcardAudioProcessor
 from base.soundcard_calibration_manager import resolve_analysis_v2pa_factor_for_channel
 from base.tcp_service import TcpServer, check_tcp_msg_format
 from base.streaming_file_writer import StreamingWavWriter
+from base.wav_calibration_metadata import append_wav_calibration_metadata, read_wav_calibration_metadata
 from base.pre_processing.alignment_processing import AlignmentProcessing
 from base.pre_processing.split_repeat_signal import SplitRepeatSignal
 from base.acquisition_recording_defaults import normalize_play_record_detail, normalize_record_only_detail
@@ -81,8 +88,21 @@ def _clear_data_struct_stimulus_runtime_state(data_struct, *, clear_sample_rate:
         delattr(data_struct, "alignment_sample_count")
 
 
+def _clear_wav_calibration_runtime_state(data_struct) -> None:
+    if data_struct is None:
+        return
+    data_struct.wav_calibration_metadata = None
+    data_struct.wav_calibration_metadata_authoritative = False
+    data_struct.wav_calibration_warning_shown = False
+
+
+def _missing_file_calibration_warning_text():
+    return "该音频文件未包含有效校准数据，分析结果仅供参考。"
+
+
 def _clear_sequence_stimulus_runtime_state(window, *, clear_sample_rate: bool = True) -> None:
     _clear_data_struct_stimulus_runtime_state(getattr(window, "data_struct", None), clear_sample_rate=clear_sample_rate)
+    _clear_wav_calibration_runtime_state(getattr(window, "data_struct", None))
     if hasattr(window, "streaming_stimulus_data"):
         window.streaming_stimulus_data = None
 
@@ -105,6 +125,7 @@ def _clear_import_analysis_runtime_state(window) -> None:
         data_struct.audio_lenth = None
         data_struct.stimulus_data = None
         data_struct.stimulus_info = None
+        _clear_wav_calibration_runtime_state(data_struct)
         if hasattr(data_struct, "alignment_sample_count"):
             delattr(data_struct, "alignment_sample_count")
     window.recorded_path = None
@@ -239,6 +260,7 @@ class SequenceWindow(QWidget):
         self.streaming_wav_writer = None  # WAV file writer for incremental saving
         self.streaming_processor = None  # StreamingAudioProcessor instance
         self.streaming_stimulus_data = None  # Stimulus data for alignment (play+record mode)
+        self.streaming_wav_calibration_metadata = None
         self.streaming_mode = None  # "play_record" or "record_only"
         self._active_input_channels = [0]
         self.channel_workspace = None
@@ -540,6 +562,7 @@ class SequenceWindow(QWidget):
     def on_mark_btn_clicked(self):
         self.data_struct.store_wave_data = None
         self.data_struct.store_wave_data_multi = None
+        _clear_wav_calibration_runtime_state(self.data_struct)
         self._clear_plot_area()
         self._close_analysis_windows()
         self.player_btn.setDisabled(False)
@@ -1209,6 +1232,7 @@ class SequenceWindow(QWidget):
                 self.data_struct.store_wave_data = None
             if hasattr(self.data_struct, "store_wave_data_multi"):
                 self.data_struct.store_wave_data_multi = None
+            _clear_wav_calibration_runtime_state(self.data_struct)
         except Exception:
             pass
         try:
@@ -1423,6 +1447,7 @@ class SequenceWindow(QWidget):
         self.mark_result()
         self.data_struct.store_wave_data = None
         self.data_struct.store_wave_data_multi = None
+        _clear_wav_calibration_runtime_state(self.data_struct)
         self.replayer_btn.setEnabled(False)
         self.data_btn.setEnabled(False)
         self.player_status_flag = False
@@ -1534,6 +1559,22 @@ class SequenceWindow(QWidget):
             _clear_import_analysis_runtime_state(self)
             MessageBox.warning(self, "提示", "导入音频失败，请重新选择音频文件。")
             return
+        try:
+            wav_calibration_metadata = read_wav_calibration_metadata(
+                file_path,
+                logger=getattr(self, "default_logger", None),
+            )
+        except Exception as exc:
+            logger = getattr(self, "default_logger", None)
+            if logger is not None:
+                logger.warning(f"读取WAV校准数据失败: {exc}")
+            wav_calibration_metadata = None
+        self.data_struct.wav_calibration_metadata = wav_calibration_metadata
+        self.data_struct.wav_calibration_metadata_authoritative = True
+        self.data_struct.wav_calibration_warning_shown = False
+        if wav_calibration_metadata is None:
+            MessageBox.warning(self, "提示", _missing_file_calibration_warning_text())
+            self.data_struct.wav_calibration_warning_shown = True
         audio_multi = np.asarray(audio_multi, dtype=np.float32)
         if audio_multi.ndim == 1:
             audio_multi = audio_multi.reshape(1, -1)
@@ -1880,6 +1921,7 @@ class SequenceWindow(QWidget):
             recorded_dict["output_device"] = None
 
         self._active_input_channels = [int(x) for x in input_channels]
+        recorded_dict["wav_calibration_metadata"] = self._build_current_wav_calibration_metadata()
 
         in_dev = recorded_dict.get("input_device")
         out_dev = recorded_dict.get("output_device")
@@ -1910,6 +1952,11 @@ class SequenceWindow(QWidget):
         output_path = recording_output_path() if callable(recording_output_path) else self.recorded_path
         self.streaming_temp_path = None
         self.streaming_bit_depth = bit_depth
+        metadata = recorded_dict.get("wav_calibration_metadata")
+        if metadata is None:
+            metadata = self._build_current_wav_calibration_metadata()
+            recorded_dict["wav_calibration_metadata"] = metadata
+        self.streaming_wav_calibration_metadata = metadata
         if self.sequence_config[0]["seq1"]["acq"]["mode"] in ["PLAY_AND_RECORD"]:
             temp_path = output_path.replace(".wav", "_temp.wav")
             self.streaming_temp_path = temp_path
@@ -1969,6 +2016,28 @@ class SequenceWindow(QWidget):
             mono = multi.mean(axis=1).astype(multi.dtype, copy=False)
         return mono.reshape(-1), multi
 
+    def _build_current_wav_calibration_metadata(self):
+        hardware_id = None
+        mic = getattr(self, "mic", None)
+        if isinstance(mic, dict):
+            hardware_id = mic.get("hardware_id")
+        input_channels = self._current_metadata_input_channels()
+        return build_recording_wav_calibration_metadata(
+            input_channels,
+            hardware_id=hardware_id,
+            logger=getattr(self, "default_logger", None),
+        )
+
+    def _current_metadata_input_channels(self):
+        input_channels = [int(channel) for channel in (getattr(self, "_active_input_channels", []) or [0])]
+        try:
+            mode = self.sequence_config[0]["seq1"]["acq"].get("mode")
+        except Exception:
+            mode = None
+        if mode == "PLAY_AND_RECORD" and input_channels:
+            return [input_channels[0]]
+        return input_channels
+
     def _finish_recording_success(self, sample_rate):
         self.player_status_flag = False
         self._record_workflow_busy = False
@@ -1977,9 +2046,7 @@ class SequenceWindow(QWidget):
         self._delete_successful_replay_backup()
         self._clear_recording_output_attempt()
 
-        self._run_post_recording_followup(
-            "S/N input release", self._set_sn_input_recording_read_only, False
-        )
+        self._run_post_recording_followup("S/N input release", self._set_sn_input_recording_read_only, False)
         self._run_post_recording_followup("Data button enable", self.data_btn.setEnabled, True)
         self._run_post_recording_followup("Replay button enable", self.replayer_btn.setEnabled, True)
 
@@ -2023,9 +2090,16 @@ class SequenceWindow(QWidget):
             bit_depth = normalize_float_bit_depth(recorded_dict.get("bit_depth", 32))
             recording_output_path = getattr(self, "_recording_output_path", None)
             output_path = recording_output_path() if callable(recording_output_path) else self.recorded_path
+            calibration_metadata = recorded_dict.get("wav_calibration_metadata")
+            if calibration_metadata is None:
+                calibration_metadata = self._build_current_wav_calibration_metadata()
+                recorded_dict["wav_calibration_metadata"] = calibration_metadata
             if mode == "PLAY_AND_RECORD":
                 record_code, recorded_data = SoundcardAudioProcessor().sd_play_rec(
-                    recorded_dict, stimulus_dict, output_path
+                    recorded_dict,
+                    stimulus_dict,
+                    output_path,
+                    calibration_metadata=calibration_metadata,
                 )
                 if record_code != error_code.OK or recorded_data is None:
                     raise RuntimeError(recorded_data if recorded_data is not None else record_code)
@@ -2072,15 +2146,23 @@ class SequenceWindow(QWidget):
                 self.recorded_signal_info["sample_rate"] = sample_rate
 
                 if multi_data.shape[1] > 1:
-                    if bit_depth == 64:
-                        save_audio_simple(output_path, multi_data, sample_rate, bit_depth=bit_depth)
-                    else:
-                        save_audio_simple(output_path, multi_data, sample_rate)
+                    save_audio_with_calibration_metadata(
+                        output_path,
+                        multi_data,
+                        sample_rate,
+                        calibration_metadata,
+                        logger=self.default_logger,
+                        bit_depth=bit_depth,
+                    )
                 else:
-                    if bit_depth == 64:
-                        save_audio_simple(output_path, mono_data, sample_rate, bit_depth=bit_depth)
-                    else:
-                        save_audio_simple(output_path, mono_data, sample_rate)
+                    save_audio_with_calibration_metadata(
+                        output_path,
+                        mono_data,
+                        sample_rate,
+                        calibration_metadata,
+                        logger=self.default_logger,
+                        bit_depth=bit_depth,
+                    )
 
                 self._finalize_successful_replay_output()
 
@@ -2142,6 +2224,8 @@ class SequenceWindow(QWidget):
 
         # Disable replay and data buttons during recording/playback
         # They will be re-enabled in _on_streaming_complete()
+        replayer_btn_was_enabled = self.replayer_btn.isEnabled()
+        data_btn_was_enabled = self.data_btn.isEnabled()
         self.replayer_btn.setDisabled(True)
         self.data_btn.setDisabled(True)
 
@@ -2161,6 +2245,8 @@ class SequenceWindow(QWidget):
             self.player_status_flag = False
             self._record_workflow_busy = False
             self._set_sn_input_recording_read_only(False)
+            self.data_btn.setEnabled(data_btn_was_enabled)
+            self.replayer_btn.setEnabled(replayer_btn_was_enabled)
             self.update_player_btn_is_paused()
             MessageBox.warning(self, "提示", f"初始化录音失败: {e}")
             return
@@ -2170,6 +2256,8 @@ class SequenceWindow(QWidget):
             self.player_status_flag = False
             self._record_workflow_busy = False
             self._set_sn_input_recording_read_only(False)
+            self.data_btn.setEnabled(data_btn_was_enabled)
+            self.replayer_btn.setEnabled(replayer_btn_was_enabled)
             self.update_player_btn_is_paused()
             return
 
@@ -2186,6 +2274,8 @@ class SequenceWindow(QWidget):
                 self.player_status_flag = False
                 self._record_workflow_busy = False
                 self._set_sn_input_recording_read_only(False)
+                self.data_btn.setEnabled(data_btn_was_enabled)
+                self.replayer_btn.setEnabled(replayer_btn_was_enabled)
                 self.update_player_btn_is_paused()
                 MessageBox.warning(self, "提示", f"启动录音失败: {e}")
                 return
@@ -2816,7 +2906,7 @@ class SequenceWindow(QWidget):
                         raw_channel = 0
                 if raw_channel < 0:
                     raw_channel = 0
-                if requires_v2pa:
+                if requires_v2pa and self.mode not in {"IMPORT_AUDIO", "IMPORT_STIMULUS_AUDIO"}:
                     try:
                         class_instance.v2pa_factor = resolve_analysis_v2pa_factor_for_channel(
                             raw_channel,
@@ -3178,6 +3268,7 @@ class SequenceWindow(QWidget):
         self.data_btn.setDisabled(True)
         self.data_struct.store_wave_data = None
         self.data_struct.store_wave_data_multi = None
+        _clear_wav_calibration_runtime_state(self.data_struct)
 
         # 1. 强制清除下拉框焦点
         self.using_file_combobox.clearFocus()
@@ -3427,6 +3518,7 @@ class SequenceWindow(QWidget):
                 recorded_data_multi = self.streaming_processor.get_recorded_data_multi()
             sample_rate = self.data_struct.sample_rate
             bit_depth = normalize_float_bit_depth(getattr(self, "streaming_bit_depth", 32))
+            output_path = self._recording_output_path()
 
             # VERIFICATION: Check if we captured the expected number of samples
             expected_samples = self.streaming_processor.target_samples
@@ -3441,14 +3533,28 @@ class SequenceWindow(QWidget):
 
             # Perform alignment if in play+record mode
             if self.streaming_mode == "play_record" and self.streaming_stimulus_data is not None:
-                output_path = self._recording_output_path()
                 # Finalize temp file first
                 if self.streaming_wav_writer:
                     self.streaming_wav_writer.finalize()
                     self.streaming_wav_writer = None
 
+                alignment_input_data = recorded_data
+                get_recorded_data_multi = getattr(self.streaming_processor, "get_recorded_data_multi", None)
+                if callable(get_recorded_data_multi):
+                    try:
+                        retained_multi = np.asarray(get_recorded_data_multi(), dtype=np.float32)
+                    except Exception as exc:
+                        self.default_logger.warning(
+                            f"Failed to read retained streaming channels; using mono data. {exc}"
+                        )
+                    else:
+                        if retained_multi.ndim == 2 and retained_multi.shape[1] > 0:
+                            alignment_input_data = retained_multi[:, 0].reshape(-1)
+                        elif retained_multi.ndim == 1 and retained_multi.size > 0:
+                            alignment_input_data = retained_multi.reshape(-1)
+
                 aligned_data = AlignmentProcessing.align_play_and_rec_data_using_gccphat(
-                    self.streaming_stimulus_data, recorded_data
+                    self.streaming_stimulus_data, alignment_input_data
                 )
 
                 # Update plot with aligned data (refresh display)
@@ -3460,11 +3566,19 @@ class SequenceWindow(QWidget):
                 self.data_struct.store_wave_data = aligned_data
                 self.data_struct.store_wave_data_multi = np.asarray(aligned_data).reshape(-1, 1)
 
+                calibration_metadata = getattr(self, "streaming_wav_calibration_metadata", None)
+                if calibration_metadata is None:
+                    calibration_metadata = self._build_current_wav_calibration_metadata()
+
                 # Save aligned data to final file
-                if bit_depth == 64:
-                    save_audio_simple(output_path, aligned_data, sample_rate, bit_depth=bit_depth)
-                else:
-                    save_audio_simple(output_path, aligned_data, sample_rate)
+                save_audio_with_calibration_metadata(
+                    output_path,
+                    aligned_data,
+                    sample_rate,
+                    calibration_metadata,
+                    logger=self.default_logger,
+                    bit_depth=bit_depth,
+                )
 
                 # Save to database
                 self.recorded_signal_info["sample_rate"] = sample_rate
@@ -3499,7 +3613,9 @@ class SequenceWindow(QWidget):
                     if not actual_input_channels:
                         actual_input_channels = list(getattr(self, "_active_input_channels", []) or [])
                     if actual_input_channels:
-                        self._active_input_channels = [int(ch) for ch in actual_input_channels[: recorded_array.shape[1]]]
+                        self._active_input_channels = [
+                            int(ch) for ch in actual_input_channels[: recorded_array.shape[1]]
+                        ]
                     if len(getattr(self, "_active_input_channels", []) or []) != recorded_array.shape[1]:
                         self._active_input_channels = list(range(recorded_array.shape[1]))
                     self.data_struct.store_wave_data_multi = recorded_array
@@ -3520,6 +3636,20 @@ class SequenceWindow(QWidget):
                 if self.streaming_wav_writer:
                     self.streaming_wav_writer.finalize()
                     self.streaming_wav_writer = None
+                calibration_metadata = self._build_current_wav_calibration_metadata()
+                try:
+                    ok = append_wav_calibration_metadata(
+                        output_path,
+                        calibration_metadata,
+                        logger=self.default_logger,
+                    )
+                except Exception as exc:
+                    self.default_logger.warning(
+                        f"Failed to append WAV calibration metadata; audio file was kept. {exc}"
+                    )
+                else:
+                    if not ok:
+                        self.default_logger.warning("Failed to append WAV calibration metadata; audio file was kept.")
 
                 # Save to database
                 self.recorded_signal_info["sample_rate"] = sample_rate
@@ -3536,6 +3666,7 @@ class SequenceWindow(QWidget):
 
             # Handle repeat signal splitting if needed
             if self.streaming_mode == "play_record":
+
                 def split_repeat_after_save():
                     repeat_times = self.data_struct.stimulus_info.get("repeat_times", 1)
                     if repeat_times > 1:
@@ -3551,12 +3682,11 @@ class SequenceWindow(QWidget):
             self.streaming_stimulus_data = None
             self.streaming_mode = None
             self.streaming_bit_depth = 32
+            self.streaming_wav_calibration_metadata = None
             # Recording has fully ended; release S/N input and busy gating before any follow-up analysis/UI work.
             self.player_status_flag = False  # Recording complete, allow hardware access
             self._record_workflow_busy = False
-            self._run_post_recording_followup(
-                "S/N input release", self._set_sn_input_recording_read_only, False
-            )
+            self._run_post_recording_followup("S/N input release", self._set_sn_input_recording_read_only, False)
 
             # Enable buttons for replay and data analysis
             self._run_post_recording_followup("Data button enable", self.data_btn.setEnabled, True)
@@ -3601,6 +3731,7 @@ class SequenceWindow(QWidget):
             self.streaming_stimulus_data = None
             self.streaming_mode = None
             self.streaming_bit_depth = 32
+            self.streaming_wav_calibration_metadata = None
             self.player_status_flag = False  # Clear flag even on error to prevent permanent blocking
             # Still enable buttons even on error
             self.data_btn.setEnabled(True)

--- a/ui/signal_analysis_window.py
+++ b/ui/signal_analysis_window.py
@@ -38,6 +38,7 @@ from base.pre_processing.spl_runtime_config import (
     resolve_spl_window_size,
 )
 from base.soundcard_calibration_manager import resolve_analysis_v2pa_factor_for_channel
+from base.wav_calibration_metadata import resolve_wav_channel_v2pa_factor
 from base.core_algorithm.response import FrequencyResponseAnalyzer, SplFrequencyAnalyzer
 from base.stimulus_signal.methods import analysis_stimulus_method
 from base.core_algorithm.response.frequency_band_analyzer import (
@@ -125,6 +126,23 @@ def _load_golden_baseline_result(analysis_config: dict, title_name: str):
         return None
     result = item.get("result")
     return result if isinstance(result, dict) else None
+
+
+def _missing_file_calibration_warning_text():
+    return "该音频文件未包含有效校准数据，分析结果仅供参考。"
+
+
+def resolve_imported_wav_v2pa_factor(data_struct, raw_channel, warn_callback=None):
+    metadata = getattr(data_struct, "wav_calibration_metadata", None)
+    resolution = resolve_wav_channel_v2pa_factor(metadata, raw_channel)
+    if (
+        not resolution.used_file_metadata
+        and warn_callback
+        and not getattr(data_struct, "wav_calibration_warning_shown", False)
+    ):
+        warn_callback(_missing_file_calibration_warning_text())
+        data_struct.wav_calibration_warning_shown = True
+    return float(resolution.factor)
 
 
 def resolve_analysis_channel_signal(
@@ -424,6 +442,13 @@ class AnalysisGraphWidget(QWidget):
             "_v2pa_raw_analysis_channel",
             analysis_config.get("analysis_channel", 0),
         )
+        if getattr(self.data_struct, "wav_calibration_metadata_authoritative", False):
+            self.v2pa_factor = resolve_imported_wav_v2pa_factor(
+                self.data_struct,
+                raw_channel,
+                warn_callback=lambda message: MessageBox.warning(self, "提示", message),
+            )
+            return True
         try:
             self.v2pa_factor = resolve_analysis_v2pa_factor_for_channel(
                 raw_channel,
@@ -2036,6 +2061,7 @@ class PeakDetection(AnalysisGraphWidget):
         self.analysis_config = None
         self.result = None
         self.v2pa_factor = None
+        self.title_name = title_name
         self.setWindowTitle(title_name)
 
         # top status bar
@@ -2056,9 +2082,14 @@ class PeakDetection(AnalysisGraphWidget):
         """
         calculate and plot PD analysis: the upper plot is SPL time series with peak annotation;
         """
-        recorded_signal = self.data_struct.store_wave_data
         sample_rate = self.data_struct.sample_rate
-        if recorded_signal is None or sample_rate is None:
+        if sample_rate is None:
+            return None
+        try:
+            recorded_signal = resolve_analysis_channel_signal(
+                self.data_struct, self.analysis_config, self.title_name, strict=False
+            )
+        except Exception:
             return None
         if getattr(self, "_use_pre_resolved_v2pa_factor", False) and self.v2pa_factor is not None:
             self._use_pre_resolved_v2pa_factor = False
@@ -2336,15 +2367,21 @@ class PipelinePdPm(QWidget):
         """
         prepare the input data for the pipeline, including the recorded signal, sample rate, and the analysis config
         """
-        recorded_signal = self.data_struct.store_wave_data
         sample_rate = self.data_struct.sample_rate
-        if recorded_signal is None or sample_rate is None:
+        if sample_rate is None:
             return None
 
         cfg = self.analysis_config or {}
         head = cfg.get("head", {}) or {}
         tail = cfg.get("tail", {}) or {}
         if not head or not tail:
+            return None
+        head_config = head.get("config", {}) or {}
+        try:
+            recorded_signal = resolve_analysis_channel_signal(
+                self.data_struct, head_config, self.windowTitle(), strict=False
+            )
+        except Exception:
             return None
 
         class_mapping = get_class_mapping()
@@ -2528,14 +2565,21 @@ class PipelinePdPm(QWidget):
 
         recorded_signal, sample_rate, cfg, head, tail, pd_cls, pm_cls = context
         head_config = head.get("config", {}) or {}
-        try:
-            self.v2pa_factor = resolve_analysis_v2pa_factor_for_channel(
+        if getattr(self.data_struct, "wav_calibration_metadata_authoritative", False):
+            self.v2pa_factor = resolve_imported_wav_v2pa_factor(
+                self.data_struct,
                 head_config.get("analysis_channel", 0),
                 warn_callback=lambda message: MessageBox.warning(self, "提示", message),
             )
-        except Exception as exc:
-            MessageBox.warning(self, "提示", str(exc))
-            return None
+        else:
+            try:
+                self.v2pa_factor = resolve_analysis_v2pa_factor_for_channel(
+                    head_config.get("analysis_channel", 0),
+                    warn_callback=lambda message: MessageBox.warning(self, "提示", message),
+                )
+            except Exception as exc:
+                MessageBox.warning(self, "提示", str(exc))
+                return None
 
         pd_result, peak_indices = self._execute_pd(pd_cls, head)
 
@@ -2921,6 +2965,9 @@ class LoudnessAnalysis(AnalysisGraphWidget):
 
         if recorded_signal is None or sample_rate is None:
             MessageBox.warning(self, "提示", "响度分析失败：没有可用录音数据。")
+            return False
+
+        if not self._resolve_v2pa_factor_for_analysis():
             return False
 
         sq_config = self._build_sq_config(config)

--- a/unit_test/base/test_alignment_processing.py
+++ b/unit_test/base/test_alignment_processing.py
@@ -1,0 +1,42 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from base.pre_processing.alignment_processing import AlignmentProcessing
+
+
+def test_align_play_and_rec_preserves_recorded_float64_when_padding(monkeypatch):
+    monkeypatch.setattr(
+        AlignmentProcessing,
+        "gcc_phat",
+        staticmethod(lambda stimulus, recorded: (2, None, None)),
+    )
+
+    stimulus = np.arange(5, dtype=np.float32)
+    recorded = np.array([10.0, 11.0, 12.0], dtype=np.float64)
+
+    aligned = AlignmentProcessing.align_play_and_rec_data_using_gccphat(stimulus, recorded)
+
+    assert aligned.dtype == np.float64
+    np.testing.assert_array_equal(aligned, np.array([12.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float64))
+
+
+def test_align_play_and_rec_preserves_recorded_float32(monkeypatch):
+    monkeypatch.setattr(
+        AlignmentProcessing,
+        "gcc_phat",
+        staticmethod(lambda stimulus, recorded: (0, None, None)),
+    )
+
+    stimulus = np.arange(3, dtype=np.float32)
+    recorded = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+
+    aligned = AlignmentProcessing.align_play_and_rec_data_using_gccphat(stimulus, recorded)
+
+    assert aligned.dtype == np.float32
+    np.testing.assert_array_equal(aligned, recorded)

--- a/unit_test/base/test_play_and_record_channel_forwarding.py
+++ b/unit_test/base/test_play_and_record_channel_forwarding.py
@@ -7,6 +7,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from base import play_and_record
+from base import save_data
 from base import stimulus_resolver
 import numpy as np
 import pytest
@@ -237,6 +238,42 @@ def test_record_without_play_persists_runtime_sample_rate_when_global_is_stale(m
     assert recorded_signal_info["sample_rate"] == 48000
     assert calls["db_sample_rate"] == 48000
     np.testing.assert_array_equal(calls["saved_audio"], recorded_signal)
+
+
+def test_record_without_play_logs_metadata_append_failure_after_audio_save(tmp_path, monkeypatch):
+    warnings = []
+    metadata = {
+        "recorded_channels": [
+            {"wav_channel_index": 0, "v2pa_factor": 2.5, "standard_spl": 94.0, "calibrated": True}
+        ]
+    }
+
+    class FakeLogger:
+        def warning(self, message):
+            warnings.append(message)
+
+    class FakeRecordingManager:
+        def save_signal_info_to_db(self, recorded_signal_info, stimulus_info):
+            return None
+
+    monkeypatch.setattr(
+        play_and_record.SoundcardAudioProcessor,
+        "sd_rec",
+        staticmethod(lambda recorded_dict: (error_code.OK, np.array([0.1, 0.2], dtype=np.float32))),
+    )
+    monkeypatch.setattr(save_data, "append_wav_calibration_metadata", lambda *args, **kwargs: False)
+    monkeypatch.setattr(play_and_record, "logger", FakeLogger())
+    monkeypatch.setattr(play_and_record, "RecordingManager", FakeRecordingManager)
+
+    code, recorded = play_and_record.record_without_play(
+        {"sample_rate": 48000, "num_frames": 2, "wav_calibration_metadata": metadata},
+        str(tmp_path / "runtime.wav"),
+        {},
+    )
+
+    assert code == error_code.OK
+    np.testing.assert_array_equal(recorded, np.array([0.1, 0.2], dtype=np.float32))
+    assert any("Failed to append WAV calibration metadata" in message for message in warnings)
 
 
 @pytest.mark.parametrize(
@@ -515,7 +552,9 @@ def test_blocking_play_record_aligns_and_saves_tail_free_frequency_stepped_recor
     monkeypatch.setattr(SoundcardAudioProcessor, "calculate_alignment", staticmethod(fake_calculate_alignment))
     monkeypatch.setattr(
         "base.soundcard_audio_processor.save_audio_simple",
-        lambda path, audio, sr: calls.update(saved_len=len(audio), saved=np.asarray(audio), sr=sr),
+        lambda path, audio, sr, bit_depth=32: calls.update(
+            saved_len=len(audio), saved=np.asarray(audio), sr=sr
+        ),
     )
 
     stimulus_dict = {
@@ -676,7 +715,9 @@ def test_blocking_play_record_without_alignment_sample_count_keeps_existing_full
     monkeypatch.setattr(SoundcardAudioProcessor, "calculate_alignment", staticmethod(lambda ref, rec: 3))
     monkeypatch.setattr(
         "base.soundcard_audio_processor.save_audio_simple",
-        lambda path, audio, sr: calls.update(saved_len=len(audio), saved=np.asarray(audio), sr=sr),
+        lambda path, audio, sr, bit_depth=32: calls.update(
+            saved_len=len(audio), saved=np.asarray(audio), sr=sr
+        ),
     )
 
     stimulus_dict = {"data": np.arange(8, dtype=float), "amplitude": 2.0, "sr": 48000}
@@ -701,7 +742,9 @@ def test_blocking_play_record_clamps_negative_alignment_offset(monkeypatch):
     monkeypatch.setattr(SoundcardAudioProcessor, "calculate_alignment", staticmethod(lambda ref, rec: -3))
     monkeypatch.setattr(
         "base.soundcard_audio_processor.save_audio_simple",
-        lambda path, audio, sr: calls.update(saved_len=len(audio), saved=np.asarray(audio), sr=sr),
+        lambda path, audio, sr, bit_depth=32: calls.update(
+            saved_len=len(audio), saved=np.asarray(audio), sr=sr
+        ),
     )
 
     stimulus_dict = {
@@ -732,7 +775,9 @@ def test_blocking_play_record_pads_alignment_offset_near_recording_end(monkeypat
     monkeypatch.setattr(SoundcardAudioProcessor, "calculate_alignment", staticmethod(lambda ref, rec: 6))
     monkeypatch.setattr(
         "base.soundcard_audio_processor.save_audio_simple",
-        lambda path, audio, sr: calls.update(saved_len=len(audio), saved=np.asarray(audio), sr=sr),
+        lambda path, audio, sr, bit_depth=32: calls.update(
+            saved_len=len(audio), saved=np.asarray(audio), sr=sr
+        ),
     )
 
     stimulus_dict = {
@@ -808,6 +853,33 @@ def test_stream_play_and_record_forwards_float64_bit_depth(monkeypatch):
     assert calls[0]["bit_depth"] == 64
 
 
+def test_stream_play_and_record_forwards_selected_nonzero_input_channel(monkeypatch):
+    calls = []
+
+    class FakeProcessor:
+        def start_streaming_playrec(self, **kwargs):
+            calls.append(kwargs)
+            return play_and_record.error_code.OK, "ok"
+
+    monkeypatch.setattr(play_and_record, "StreamingAudioProcessor", FakeProcessor)
+    stimulus_dict = {
+        "data": np.arange(4, dtype=float),
+        "amplitude": 1.0,
+        "sr": 48000,
+    }
+    recorded_dict = {
+        "prepare_frames": 1,
+        "prolong_frames": 2,
+        "input_device": {"index": 1, "max_input_channels": 4},
+        "output_device": {"index": 2, "max_output_channels": 2},
+        "input_channels": [2],
+    }
+
+    play_and_record.stream_play_and_record(stimulus_dict, recorded_dict, "unused.wav", {})
+
+    assert calls[0]["input_channels"] == [2]
+
+
 def test_play_last_stimulus_wave_persists_runtime_sample_rate_when_global_is_stale(monkeypatch):
     calls = {}
 
@@ -819,7 +891,7 @@ def test_play_last_stimulus_wave_persists_runtime_sample_rate_when_global_is_sta
     monkeypatch.setattr(play_and_record.SoundcardAudioProcessor, "calculate_alignment", staticmethod(lambda ref, rec: 0))
     monkeypatch.setattr(
         "base.soundcard_audio_processor.save_audio_simple",
-        lambda path, audio, sample_rate: calls.update(
+        lambda path, audio, sample_rate, bit_depth=32: calls.update(
             saved_path=path,
             saved_audio=np.asarray(audio),
             saved_sample_rate=sample_rate,
@@ -854,7 +926,7 @@ def test_play_last_stimulus_wave_returns_on_playrec_failure_without_persisting_o
     calls = []
 
     class FakeSoundcardAudioProcessor:
-        def sd_play_rec(self, recorded_dict, stimulus_dict, recorded_path):
+        def sd_play_rec(self, recorded_dict, stimulus_dict, recorded_path, calibration_metadata=None):
             calls.append(("playrec", recorded_dict, stimulus_dict, recorded_path))
             return error_code.INVALID_PLAY, "sample rate mismatch"
 
@@ -1108,7 +1180,7 @@ def test_sd_play_rec_prepends_delay_silence_and_aligns_retained_capture(monkeypa
 
     monkeypatch.setattr("base.soundcard_audio_processor.sd.playrec", fake_playrec)
     monkeypatch.setattr(SoundcardAudioProcessor, "calculate_alignment", staticmethod(lambda ref, rec: 0))
-    monkeypatch.setattr("base.soundcard_audio_processor.save_audio_simple", lambda *args: None)
+    monkeypatch.setattr("base.soundcard_audio_processor.save_audio_with_calibration_metadata", lambda *args, **kwargs: None)
 
     code, aligned = SoundcardAudioProcessor().sd_play_rec(
         {"prepare_frames": 2, "prolong_frames": 1, "recording_start_delay_frames": 3, "sr": 1000},
@@ -1131,7 +1203,7 @@ def test_sd_play_rec_zero_delay_uses_original_playback_window(monkeypatch):
 
     monkeypatch.setattr("base.soundcard_audio_processor.sd.playrec", fake_playrec)
     monkeypatch.setattr(SoundcardAudioProcessor, "calculate_alignment", staticmethod(lambda ref, rec: 0))
-    monkeypatch.setattr("base.soundcard_audio_processor.save_audio_simple", lambda *args: None)
+    monkeypatch.setattr("base.soundcard_audio_processor.save_audio_with_calibration_metadata", lambda *args, **kwargs: None)
 
     code, _ = SoundcardAudioProcessor().sd_play_rec(
         {"prepare_frames": 2, "prolong_frames": 3, "recording_start_delay_frames": 0, "sr": 1000},
@@ -1153,7 +1225,7 @@ def test_sd_play_rec_invalid_recording_start_delay_defaults_to_zero(monkeypatch,
 
     monkeypatch.setattr("base.soundcard_audio_processor.sd.playrec", fake_playrec)
     monkeypatch.setattr(SoundcardAudioProcessor, "calculate_alignment", staticmethod(lambda ref, rec: 0))
-    monkeypatch.setattr("base.soundcard_audio_processor.save_audio_simple", lambda *args: None)
+    monkeypatch.setattr("base.soundcard_audio_processor.save_audio_with_calibration_metadata", lambda *args, **kwargs: None)
 
     code, aligned = SoundcardAudioProcessor().sd_play_rec(
         {"prepare_frames": 2, "prolong_frames": 1, "recording_start_delay_frames": value, "sr": 1000},
@@ -1190,7 +1262,7 @@ def test_sd_play_rec_forwards_selected_input_output_devices(monkeypatch):
         return captured
 
     monkeypatch.setattr("base.soundcard_audio_processor.sd.playrec", fake_playrec)
-    monkeypatch.setattr("base.soundcard_audio_processor.save_audio_simple", lambda *args, **kwargs: None)
+    monkeypatch.setattr("base.soundcard_audio_processor.save_audio_with_calibration_metadata", lambda *args, **kwargs: None)
     monkeypatch.setattr(SoundcardAudioProcessor, "calculate_alignment", lambda self, stimulus, recorded: 0)
 
     code, data = SoundcardAudioProcessor().sd_play_rec(

--- a/unit_test/base/test_recording_calibration_snapshot.py
+++ b/unit_test/base/test_recording_calibration_snapshot.py
@@ -1,0 +1,89 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from base import recording_calibration_snapshot
+
+
+class FakeLogger:
+    def __init__(self):
+        self.messages = []
+
+    def warning(self, message):
+        self.messages.append(message)
+
+    def error(self, message):
+        self.messages.append(message)
+
+
+def test_build_recording_wav_metadata_uses_active_channel_order(monkeypatch):
+    monkeypatch.setattr(
+        recording_calibration_snapshot,
+        "load_mic_channel_v2pa_factors",
+        lambda hardware_id=None, db_path=None: {2: 2.5, 4: 4.5},
+        raising=False,
+    )
+    monkeypatch.setattr(
+        recording_calibration_snapshot,
+        "load_mic_channel_standard_spl",
+        lambda hardware_id=None, db_path=None: {2: 94.0, 4: 114.0},
+        raising=False,
+    )
+
+    metadata = recording_calibration_snapshot.build_recording_wav_calibration_metadata(
+        [2, 4], hardware_id="mic-1", logger=FakeLogger()
+    )
+
+    assert metadata == {
+        "recorded_channels": [
+            {"wav_channel_index": 0, "v2pa_factor": 2.5, "standard_spl": 94.0, "calibrated": True},
+            {"wav_channel_index": 1, "v2pa_factor": 4.5, "standard_spl": 114.0, "calibrated": True},
+        ]
+    }
+
+
+def test_build_recording_wav_metadata_marks_uncalibrated_channels(monkeypatch):
+    monkeypatch.setattr(
+        recording_calibration_snapshot,
+        "load_mic_channel_v2pa_factors",
+        lambda hardware_id=None, db_path=None: {},
+        raising=False,
+    )
+    monkeypatch.setattr(
+        recording_calibration_snapshot,
+        "load_mic_channel_standard_spl",
+        lambda hardware_id=None, db_path=None: {},
+        raising=False,
+    )
+
+    metadata = recording_calibration_snapshot.build_recording_wav_calibration_metadata(
+        [2], hardware_id="mic-1", logger=FakeLogger()
+    )
+
+    assert metadata == {
+        "recorded_channels": [
+            {"wav_channel_index": 0, "v2pa_factor": None, "standard_spl": None, "calibrated": False},
+        ]
+    }
+
+
+def test_build_recording_wav_metadata_marks_all_channels_uncalibrated_when_lookup_fails(monkeypatch):
+    logger = FakeLogger()
+
+    def fail_lookup(hardware_id=None, db_path=None):
+        raise RuntimeError("db unavailable")
+
+    monkeypatch.setattr(recording_calibration_snapshot, "load_mic_channel_v2pa_factors", fail_lookup, raising=False)
+
+    metadata = recording_calibration_snapshot.build_recording_wav_calibration_metadata(
+        [1, 3], hardware_id="mic-1", logger=logger
+    )
+
+    assert metadata == {
+        "recorded_channels": [
+            {"wav_channel_index": 0, "v2pa_factor": None, "standard_spl": None, "calibrated": False},
+            {"wav_channel_index": 1, "v2pa_factor": None, "standard_spl": None, "calibrated": False},
+        ]
+    }
+    assert logger.messages

--- a/unit_test/base/test_soundcard_audio_processor.py
+++ b/unit_test/base/test_soundcard_audio_processor.py
@@ -1,7 +1,12 @@
 import mock
 import numpy as np
 import pytest
+import sys
+from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from base import play_and_record
 from base.soundcard_audio_processor import SoundcardAudioProcessor
 from consts import error_code
 
@@ -15,7 +20,7 @@ class TestSoundcardAudioProcessor(object):
         (0, [1, 1, 1], [1, 1, 1], -2),
         (0, [], [], 1),
     ])
-    @mock.patch("scipy.signal.correlate")
+    @mock.patch("base.soundcard_audio_processor.correlate")
     def test_calculate_alignment(self, mock_corr, corr_ret, stimulus_signal, recorded_signal, result_set):
         mock_corr.return_value = corr_ret
         result = SoundcardAudioProcessor().calculate_alignment(stimulus_signal, recorded_signal)
@@ -52,6 +57,227 @@ def test_sd_play_rec_rejects_missing_sample_rates(monkeypatch):
     assert code != error_code.OK
     assert "采样率" in msg or "sample rate" in msg.lower()
     assert calls == []
+
+
+def test_sd_play_rec_saves_explicit_calibration_metadata(monkeypatch):
+    calls = []
+    metadata = {
+        "recorded_channels": [
+            {"wav_channel_index": 0, "v2pa_factor": 2.5, "standard_spl": 94.0, "calibrated": True}
+        ]
+    }
+    processor = SoundcardAudioProcessor()
+    record = {"sr": 48000, "sample_rate": 48000, "num_frames": 4}
+    stimulus = {"data": np.array([0.0, 1.0], dtype=np.float32), "amplitude": 1.0, "sr": 48000}
+
+    monkeypatch.setattr(
+        "base.soundcard_audio_processor.sd.playrec",
+        lambda *args, **kwargs: np.array([[0.0], [1.0], [0.0], [0.0]], dtype=np.float32),
+    )
+    monkeypatch.setattr(
+        "base.soundcard_audio_processor.save_audio_with_calibration_metadata",
+        lambda path, data, sr, calibration_metadata=None, logger=None: calls.append(
+            (path, np.asarray(data), sr, calibration_metadata)
+        ),
+    )
+
+    code, recorded = processor.sd_play_rec(record, stimulus, "record.wav", calibration_metadata=metadata)
+
+    assert code == error_code.OK
+    assert np.asarray(recorded).shape == (2,)
+    assert calls[0][0] == "record.wav"
+    assert calls[0][2] == 48000
+    assert calls[0][3] is metadata
+
+
+def test_sd_play_rec_saves_record_dict_calibration_metadata(monkeypatch):
+    calls = []
+    metadata = {
+        "recorded_channels": [
+            {"wav_channel_index": 0, "v2pa_factor": 3.5, "standard_spl": 114.0, "calibrated": True}
+        ]
+    }
+    processor = SoundcardAudioProcessor()
+    record = {"sr": 48000, "sample_rate": 48000, "num_frames": 4, "wav_calibration_metadata": metadata}
+    stimulus = {"data": np.array([0.0, 1.0], dtype=np.float32), "amplitude": 1.0, "sr": 48000}
+
+    monkeypatch.setattr(
+        "base.soundcard_audio_processor.sd.playrec",
+        lambda *args, **kwargs: np.array([[0.0], [1.0], [0.0], [0.0]], dtype=np.float32),
+    )
+    monkeypatch.setattr(
+        "base.soundcard_audio_processor.save_audio_with_calibration_metadata",
+        lambda path, data, sr, calibration_metadata=None, logger=None: calls.append(
+            (path, np.asarray(data), sr, calibration_metadata)
+        ),
+    )
+
+    code, recorded = processor.sd_play_rec(record, stimulus, "record.wav")
+
+    assert code == error_code.OK
+    assert np.asarray(recorded).shape == (2,)
+    assert calls[0][3] is metadata
+
+
+def test_sd_play_rec_uses_selected_nonzero_input_channel_for_saved_metadata(monkeypatch):
+    calls = {}
+    metadata = {
+        "recorded_channels": [
+            {"wav_channel_index": 0, "v2pa_factor": 4.5, "standard_spl": 94.0, "calibrated": True}
+        ]
+    }
+    processor = SoundcardAudioProcessor()
+    record = {
+        "sr": 48000,
+        "sample_rate": 48000,
+        "input_channels": [2],
+        "prepare_frames": 0,
+        "prolong_frames": 0,
+    }
+    stimulus = {"data": np.array([0.0, 1.0, 0.0], dtype=np.float32), "amplitude": 1.0, "sr": 48000}
+    recorded_channels = np.array(
+        [
+            [10.0, 20.0, 30.0],
+            [11.0, 21.0, 31.0],
+            [12.0, 22.0, 32.0],
+        ],
+        dtype=np.float32,
+    )
+
+    def fake_playrec(playback_data, samplerate, channels, blocking, dtype=None):
+        calls["playrec"] = {
+            "playback_data": np.asarray(playback_data),
+            "samplerate": samplerate,
+            "channels": channels,
+            "blocking": blocking,
+            "dtype": dtype,
+        }
+        return recorded_channels
+
+    monkeypatch.setattr("base.soundcard_audio_processor.sd.playrec", fake_playrec)
+    monkeypatch.setattr(SoundcardAudioProcessor, "calculate_alignment", staticmethod(lambda ref, rec: 0))
+    monkeypatch.setattr(
+        "base.soundcard_audio_processor.save_audio_with_calibration_metadata",
+        lambda path, data, sr, calibration_metadata=None, logger=None: calls.update(
+            saved_path=path,
+            saved_data=np.asarray(data),
+            saved_sample_rate=sr,
+            saved_metadata=calibration_metadata,
+        ),
+    )
+
+    code, recorded = processor.sd_play_rec(record, stimulus, "record.wav", calibration_metadata=metadata)
+
+    assert code == error_code.OK
+    assert calls["playrec"]["channels"] == 3
+    assert calls["saved_path"] == "record.wav"
+    assert calls["saved_sample_rate"] == 48000
+    assert calls["saved_metadata"] is metadata
+    np.testing.assert_array_equal(calls["saved_data"], recorded_channels[:, 2])
+    np.testing.assert_array_equal(recorded, recorded_channels[:, 2])
+
+
+def test_sd_play_rec_projects_multi_channel_metadata_to_saved_mono_channel(monkeypatch):
+    calls = {}
+    metadata = {
+        "recorded_channels": [
+            {"wav_channel_index": 0, "v2pa_factor": 4.5, "standard_spl": 94.0, "calibrated": True},
+            {"wav_channel_index": 1, "v2pa_factor": 8.5, "standard_spl": 114.0, "calibrated": True},
+        ]
+    }
+    processor = SoundcardAudioProcessor()
+    record = {
+        "sr": 48000,
+        "sample_rate": 48000,
+        "input_channels": [2, 4],
+        "prepare_frames": 0,
+        "prolong_frames": 0,
+        "wav_calibration_metadata": metadata,
+    }
+    stimulus = {"data": np.array([0.0, 1.0, 0.0], dtype=np.float32), "amplitude": 1.0, "sr": 48000}
+    recorded_channels = np.array(
+        [
+            [10.0, 20.0, 30.0, 40.0, 50.0],
+            [11.0, 21.0, 31.0, 41.0, 51.0],
+            [12.0, 22.0, 32.0, 42.0, 52.0],
+        ],
+        dtype=np.float32,
+    )
+
+    monkeypatch.setattr("base.soundcard_audio_processor.sd.playrec", lambda *args, **kwargs: recorded_channels)
+    monkeypatch.setattr(SoundcardAudioProcessor, "calculate_alignment", staticmethod(lambda ref, rec: 0))
+    monkeypatch.setattr(
+        "base.soundcard_audio_processor.save_audio_with_calibration_metadata",
+        lambda path, data, sr, calibration_metadata=None, logger=None: calls.update(
+            saved_data=np.asarray(data),
+            saved_metadata=calibration_metadata,
+        ),
+    )
+
+    code, recorded = processor.sd_play_rec(record, stimulus, "record.wav")
+
+    assert code == error_code.OK
+    np.testing.assert_array_equal(calls["saved_data"], recorded_channels[:, 2])
+    np.testing.assert_array_equal(recorded, recorded_channels[:, 2])
+    assert calls["saved_metadata"] == {
+        "recorded_channels": [
+            {"wav_channel_index": 0, "v2pa_factor": 4.5, "standard_spl": 94.0, "calibrated": True}
+        ]
+    }
+
+
+def test_record_without_play_persists_metadata(monkeypatch):
+    calls = []
+    metadata = {
+        "recorded_channels": [
+            {"wav_channel_index": 0, "v2pa_factor": 2.5, "standard_spl": 94.0, "calibrated": True}
+        ]
+    }
+    recorded_dict = {"sr": 48000, "sample_rate": 48000, "wav_calibration_metadata": metadata}
+
+    monkeypatch.setattr(
+        play_and_record.SoundcardAudioProcessor,
+        "sd_rec",
+        staticmethod(lambda _recorded_dict: (error_code.OK, np.array([0.1, 0.2], dtype=np.float32))),
+    )
+    monkeypatch.setattr(
+        play_and_record,
+        "save_audio_with_calibration_metadata",
+        lambda path, data, sr, calibration_metadata=None, logger=None: calls.append((path, sr, calibration_metadata)),
+    )
+    monkeypatch.setattr(play_and_record.RecordingManager, "save_signal_info_to_db", lambda self, info, stimulus: (0, "ok"))
+
+    code, recorded = play_and_record.record_without_play(recorded_dict, "record.wav", {})
+
+    assert code == error_code.OK
+    assert np.asarray(recorded).shape == (2,)
+    assert calls == [("record.wav", 48000, metadata)]
+
+
+def test_play_last_stimulus_wave_forwards_metadata(monkeypatch):
+    calls = []
+    metadata = {
+        "recorded_channels": [
+            {"wav_channel_index": 0, "v2pa_factor": 2.5, "standard_spl": 94.0, "calibrated": True}
+        ]
+    }
+    recorded_dict = {"sr": 48000, "sample_rate": 48000, "wav_calibration_metadata": metadata}
+    stimulus_dict = {"sr": 48000, "data": np.zeros(2, dtype=np.float32), "amplitude": 1.0}
+    play_and_record.data_struct.sample_rate = 48000
+    play_and_record.data_struct.stimulus_info = {"repeat_times": 1}
+
+    def fake_sd_play_rec(self, record, stimulus, path, calibration_metadata=None):
+        calls.append((path, calibration_metadata))
+        return error_code.OK, np.array([0.1, 0.2], dtype=np.float32)
+
+    monkeypatch.setattr(play_and_record.SoundcardAudioProcessor, "sd_play_rec", fake_sd_play_rec)
+    monkeypatch.setattr(play_and_record.RecordingManager, "save_signal_info_to_db", lambda self, info, stimulus: (0, "ok"))
+
+    code, recorded = play_and_record.play_last_stimulus_wave(stimulus_dict, recorded_dict, "record.wav", {})
+
+    assert code == error_code.OK
+    assert np.asarray(recorded).shape == (2,)
+    assert calls == [("record.wav", metadata)]
 
 
 @pytest.mark.parametrize("sample_rate", [float("inf"), float("nan")])

--- a/unit_test/base/test_wav_calibration_metadata.py
+++ b/unit_test/base/test_wav_calibration_metadata.py
@@ -1,0 +1,782 @@
+import struct
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import numpy as np
+import pytest
+from scipy.io import wavfile
+
+from base import save_data
+from base import wav_calibration_metadata as wav_metadata
+from base.save_data import save_audio_with_calibration_metadata
+from base.wav_calibration_metadata import (
+    WavCalibrationResolution,
+    append_wav_calibration_metadata,
+    normalize_wav_calibration_metadata,
+    read_wav_calibration_metadata,
+    resolve_wav_channel_v2pa_factor,
+)
+
+
+def test_save_audio_with_calibration_metadata_writes_readable_wav(tmp_path):
+    path = tmp_path / "record.wav"
+    metadata = {
+        "recorded_channels": [
+            {"wav_channel_index": 0, "v2pa_factor": 2.5, "standard_spl": 94.0, "calibrated": True}
+        ]
+    }
+
+    save_audio_with_calibration_metadata(path, np.array([0.1, 0.2], dtype=np.float32), 48000, metadata)
+
+    assert read_wav_calibration_metadata(path) == metadata
+
+
+def test_save_audio_with_calibration_metadata_keeps_audio_when_metadata_append_fails(tmp_path, monkeypatch):
+    path = tmp_path / "record.wav"
+    messages = []
+    logger = SimpleNamespace(
+        warning=lambda message: messages.append(message),
+        error=lambda message: messages.append(message),
+    )
+    monkeypatch.setattr(save_data, "append_wav_calibration_metadata", lambda *args, **kwargs: False)
+
+    save_audio_with_calibration_metadata(
+        path,
+        np.array([0.1, 0.2], dtype=np.float32),
+        48000,
+        {"recorded_channels": [{"wav_channel_index": 0, "v2pa_factor": 2.5, "standard_spl": 94.0, "calibrated": True}]},
+        logger=logger,
+    )
+
+    rate, audio = wavfile.read(path)
+    assert rate == 48000
+    assert audio.size == 2
+    assert messages
+
+
+def test_save_audio_with_calibration_metadata_keeps_audio_when_metadata_append_raises(tmp_path, monkeypatch):
+    path = tmp_path / "record.wav"
+    messages = []
+    logger = SimpleNamespace(
+        warning=lambda message: messages.append(message),
+        error=lambda message: messages.append(message),
+    )
+
+    def fail_append(*args, **kwargs):
+        raise OSError("metadata write failed")
+
+    monkeypatch.setattr(save_data, "append_wav_calibration_metadata", fail_append)
+
+    save_audio_with_calibration_metadata(
+        path,
+        np.array([0.1, 0.2], dtype=np.float32),
+        48000,
+        {"recorded_channels": [{"wav_channel_index": 0, "v2pa_factor": 2.5, "standard_spl": 94.0, "calibrated": True}]},
+        logger=logger,
+    )
+
+    rate, audio = wavfile.read(path)
+    assert rate == 48000
+    assert audio.size == 2
+    assert messages
+
+
+def test_normalize_metadata_keeps_only_wav_channel_calibration_fields():
+    payload = {
+        "microphone": {"hardware_id": "must-not-survive"},
+        "recorded_channels": [
+            {
+                "wav_channel_index": 0,
+                "input_channel_index": 7,
+                "input_channel_label": "In8",
+                "calibration_type": "mic_v2pa",
+                "v2pa_factor": 2.5,
+                "standard_spl": 94.0,
+                "calibrated": True,
+            }
+        ],
+    }
+
+    normalized = normalize_wav_calibration_metadata(payload)
+
+    assert normalized == {
+        "recorded_channels": [
+            {
+                "wav_channel_index": 0,
+                "v2pa_factor": 2.5,
+                "standard_spl": 94.0,
+                "calibrated": True,
+            }
+        ]
+    }
+
+
+def test_resolve_wav_channel_factor_uses_one_for_missing_or_uncalibrated():
+    metadata = {
+        "recorded_channels": [
+            {"wav_channel_index": 0, "v2pa_factor": 2.5, "standard_spl": 94.0, "calibrated": True},
+            {"wav_channel_index": 1, "v2pa_factor": None, "standard_spl": None, "calibrated": False},
+        ]
+    }
+
+    assert resolve_wav_channel_v2pa_factor(metadata, 0).factor == 2.5
+    assert resolve_wav_channel_v2pa_factor(metadata, 1).factor == 1.0
+    assert resolve_wav_channel_v2pa_factor(metadata, 9).factor == 1.0
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        None,
+        [],
+        {"recorded_channels": []},
+        {"recorded_channels": "bad"},
+        {"recorded_channels": [{"wav_channel_index": "bad", "v2pa_factor": 2.5, "calibrated": True}]},
+    ],
+)
+def test_normalize_metadata_returns_none_for_missing_or_malformed_payload(payload):
+    assert normalize_wav_calibration_metadata(payload) is None
+
+
+def test_normalize_metadata_rejects_mixed_valid_and_malformed_channels():
+    payload = {
+        "recorded_channels": [
+            {"wav_channel_index": 0, "v2pa_factor": 2.5, "standard_spl": 94.0, "calibrated": True},
+            {"wav_channel_index": "bad", "v2pa_factor": 3.5, "standard_spl": 94.0, "calibrated": True},
+        ]
+    }
+
+    assert normalize_wav_calibration_metadata(payload) is None
+
+
+def test_normalize_metadata_rejects_duplicate_wav_channel_indices():
+    payload = {
+        "recorded_channels": [
+            {"wav_channel_index": 0, "v2pa_factor": 2.5, "standard_spl": 94.0, "calibrated": True},
+            {"wav_channel_index": 0, "v2pa_factor": 3.5, "standard_spl": 94.0, "calibrated": True},
+        ]
+    }
+
+    assert normalize_wav_calibration_metadata(payload) is None
+    assert resolve_wav_channel_v2pa_factor(payload, 0) == WavCalibrationResolution(1.0, False, False)
+
+
+def test_resolve_wav_channel_factor_returns_structured_fallback_for_mixed_malformed_metadata():
+    resolution = resolve_wav_channel_v2pa_factor(
+        {
+            "recorded_channels": [
+                {"wav_channel_index": 0, "v2pa_factor": 2.5, "standard_spl": 94.0, "calibrated": True},
+                {"wav_channel_index": "bad", "v2pa_factor": 3.5, "standard_spl": 94.0, "calibrated": True},
+            ]
+        },
+        0,
+    )
+
+    assert resolution.factor == 1.0
+    assert resolution.has_valid_metadata is False
+    assert resolution.used_file_metadata is False
+
+
+def test_resolve_wav_channel_factor_returns_structured_fallback_for_malformed_metadata():
+    resolution = resolve_wav_channel_v2pa_factor(
+        {"recorded_channels": [{"wav_channel_index": 0, "v2pa_factor": "bad", "calibrated": True}]},
+        0,
+    )
+
+    assert resolution.factor == 1.0
+    assert resolution.has_valid_metadata is False
+    assert resolution.used_file_metadata is False
+
+
+class _OverflowingFloat:
+    def __float__(self):
+        raise OverflowError("too large to convert to float")
+
+
+def test_resolve_wav_channel_factor_returns_structured_fallback_for_overflowing_factor():
+    resolution = resolve_wav_channel_v2pa_factor(
+        {"recorded_channels": [{"wav_channel_index": 0, "v2pa_factor": _OverflowingFloat(), "calibrated": True}]},
+        0,
+    )
+
+    assert resolution.factor == 1.0
+    assert resolution.has_valid_metadata is False
+    assert resolution.used_file_metadata is False
+
+
+@pytest.mark.parametrize(
+    "wav_channel_index",
+    [True, False, 0.9, 1.8, "0.9", -1, float("nan"), float("inf")],
+)
+def test_normalize_metadata_rejects_non_lossless_wav_channel_indices(wav_channel_index):
+    metadata = {
+        "recorded_channels": [
+            {
+                "wav_channel_index": wav_channel_index,
+                "v2pa_factor": 2.5,
+                "standard_spl": 94.0,
+                "calibrated": True,
+            }
+        ]
+    }
+
+    assert normalize_wav_calibration_metadata(metadata) is None
+    resolution = resolve_wav_channel_v2pa_factor(metadata, 0)
+    assert resolution.factor == 1.0
+    assert resolution.has_valid_metadata is False
+    assert resolution.used_file_metadata is False
+
+
+@pytest.mark.parametrize("factor", [0, -1, float("nan"), float("inf"), "bad"])
+def test_normalize_metadata_rejects_invalid_calibrated_factor(factor):
+    with pytest.raises(ValueError):
+        normalize_wav_calibration_metadata(
+            {"recorded_channels": [{"wav_channel_index": 0, "v2pa_factor": factor, "calibrated": True}]}
+        )
+
+
+@pytest.mark.parametrize("factor", [None, _OverflowingFloat()])
+def test_normalize_metadata_rejects_uncoercible_calibrated_factor_with_value_error(factor):
+    with pytest.raises(ValueError, match="v2pa_factor must be a finite positive number"):
+        normalize_wav_calibration_metadata(
+            {"recorded_channels": [{"wav_channel_index": 0, "v2pa_factor": factor, "calibrated": True}]}
+        )
+
+
+def test_wav_metadata_roundtrip_preserves_audio_and_rate(tmp_path):
+    path = tmp_path / "recording.wav"
+    sample_rate = 48000
+    audio = np.array([[0.1, 0.2], [0.3, 0.4]], dtype=np.float32)
+    wavfile.write(path, sample_rate, audio)
+    metadata = {
+        "recorded_channels": [
+            {"wav_channel_index": 0, "v2pa_factor": 2.5, "standard_spl": 94.0, "calibrated": True},
+            {"wav_channel_index": 1, "v2pa_factor": None, "standard_spl": None, "calibrated": False},
+        ]
+    }
+
+    append_wav_calibration_metadata(path, metadata)
+
+    assert read_wav_calibration_metadata(path) == metadata
+    loaded_rate, loaded_audio = wavfile.read(path)
+    assert loaded_rate == sample_rate
+    np.testing.assert_allclose(loaded_audio, audio)
+
+
+def test_append_writes_unprefixed_metadata_marker(tmp_path):
+    path = tmp_path / "recording.wav"
+    wavfile.write(path, 48000, np.array([0.1, 0.2], dtype=np.float32))
+    metadata = {
+        "recorded_channels": [
+            {"wav_channel_index": 0, "v2pa_factor": 2.5, "standard_spl": 94.0, "calibrated": True}
+        ]
+    }
+
+    append_wav_calibration_metadata(path, metadata)
+
+    wav_bytes = path.read_bytes()
+    assert b"mic_calibration=" in wav_bytes
+    assert b"dy_" + b"mic_calibration=" not in wav_bytes
+
+
+def test_read_unprefixed_embedded_metadata_marker(tmp_path):
+    path = tmp_path / "embedded.wav"
+    wavfile.write(path, 48000, np.array([0.1, 0.2], dtype=np.float32))
+    metadata = {
+        "recorded_channels": [
+            {"wav_channel_index": 0, "v2pa_factor": 2.5, "standard_spl": 94.0, "calibrated": True}
+        ]
+    }
+    _append_test_info_comment(
+        path,
+        'mic_calibration={"recorded_channels":[{"wav_channel_index":0,"v2pa_factor":2.5,'
+        '"standard_spl":94.0,"calibrated":true}]}',
+    )
+
+    assert read_wav_calibration_metadata(path) == metadata
+
+
+def test_read_missing_or_malformed_metadata_returns_none(tmp_path):
+    path = tmp_path / "plain.wav"
+    wavfile.write(path, 48000, np.array([0.1, 0.2], dtype=np.float32))
+
+    assert read_wav_calibration_metadata(path) is None
+
+
+def test_read_malformed_embedded_metadata_returns_none(tmp_path):
+    path = tmp_path / "malformed.wav"
+    wavfile.write(path, 48000, np.array([0.1, 0.2], dtype=np.float32))
+    _append_test_info_comment(path, "mic_calibration={not-json")
+
+    assert read_wav_calibration_metadata(path) is None
+
+
+def test_append_rejects_duplicate_wav_channel_metadata(tmp_path):
+    path = tmp_path / "duplicate_append.wav"
+    messages = []
+    logger = _ListLogger(messages)
+    wavfile.write(path, 48000, np.array([0.1, 0.2], dtype=np.float32))
+    metadata = {
+        "recorded_channels": [
+            {"wav_channel_index": 0, "v2pa_factor": 2.5, "standard_spl": 94.0, "calibrated": True},
+            {"wav_channel_index": 0, "v2pa_factor": 3.5, "standard_spl": 94.0, "calibrated": True},
+        ]
+    }
+
+    assert append_wav_calibration_metadata(path, metadata, logger=logger) is False
+    assert read_wav_calibration_metadata(path) is None
+    assert messages
+
+
+def test_append_logs_malformed_wav_channel_metadata(tmp_path):
+    path = tmp_path / "malformed_append.wav"
+    messages = []
+    logger = _ListLogger(messages)
+    wavfile.write(path, 48000, np.array([0.1, 0.2], dtype=np.float32))
+    metadata = {
+        "recorded_channels": [
+            {"wav_channel_index": "bad", "v2pa_factor": 2.5, "standard_spl": 94.0, "calibrated": True},
+        ]
+    }
+
+    assert append_wav_calibration_metadata(path, metadata, logger=logger) is False
+    assert read_wav_calibration_metadata(path) is None
+    assert messages
+
+
+def test_append_logs_unsupported_file(tmp_path):
+    path = tmp_path / "not_a_wave.txt"
+    messages = []
+    logger = _ListLogger(messages)
+    path.write_text("not a riff wave", encoding="utf-8")
+
+    assert append_wav_calibration_metadata(
+        path,
+        {"recorded_channels": [{"wav_channel_index": 0, "v2pa_factor": 2.5, "calibrated": True}]},
+        logger=logger,
+    ) is False
+    assert messages
+
+
+def test_read_rejects_duplicate_wav_channel_metadata(tmp_path):
+    path = tmp_path / "duplicate_read.wav"
+    wavfile.write(path, 48000, np.array([0.1, 0.2], dtype=np.float32))
+    _append_test_info_comment(
+        path,
+        'mic_calibration={"recorded_channels":['
+        '{"wav_channel_index":0,"v2pa_factor":2.5,"standard_spl":94.0,"calibrated":true},'
+        '{"wav_channel_index":0,"v2pa_factor":3.5,"standard_spl":94.0,"calibrated":true}'
+        "]}",
+    )
+
+    assert read_wav_calibration_metadata(path) is None
+
+
+def test_read_ignores_metadata_appended_beyond_declared_riff_size(tmp_path):
+    path = tmp_path / "stale_tail.wav"
+    wavfile.write(path, 48000, np.array([0.1, 0.2], dtype=np.float32))
+    _append_test_info_comment(
+        path,
+        'mic_calibration={"recorded_channels":[{"wav_channel_index":0,"v2pa_factor":2.5,'
+        '"standard_spl":94.0,"calibrated":true}]}',
+        update_riff_size=False,
+    )
+
+    assert read_wav_calibration_metadata(path) is None
+
+
+def test_append_overwrites_stale_bytes_beyond_declared_riff_size(tmp_path):
+    path = tmp_path / "stale_tail_append.wav"
+    wavfile.write(path, 48000, np.array([0.1, 0.2], dtype=np.float32))
+    _append_test_declared_oversize_chunk(path)
+    metadata = {
+        "recorded_channels": [
+            {"wav_channel_index": 0, "v2pa_factor": 3.5, "standard_spl": 94.0, "calibrated": True}
+        ]
+    }
+
+    assert append_wav_calibration_metadata(path, metadata) is True
+
+    assert read_wav_calibration_metadata(path) == metadata
+
+
+def test_append_rejects_riff_size_overflow_without_modifying_file(monkeypatch):
+    messages = []
+    logger = _ListLogger(messages)
+    declared_riff_size = 0xFFFFFFF0
+    original_bytes = b"RIFF" + struct.pack("<I", declared_riff_size) + b"WAVE"
+    fake_file = _LargeRiffFile(original_bytes, file_size=declared_riff_size + 8)
+    metadata = {
+        "recorded_channels": [
+            {"wav_channel_index": 0, "v2pa_factor": 3.5, "standard_spl": 94.0, "calibrated": True}
+        ]
+    }
+
+    monkeypatch.setattr("builtins.open", lambda *args, **kwargs: fake_file)
+    monkeypatch.setattr(wav_metadata, "_scan_declared_riff_chunks", lambda *args, **kwargs: {})
+
+    assert append_wav_calibration_metadata("overflow.wav", metadata, logger=logger) is False
+    assert fake_file.bytes == original_bytes
+    assert fake_file.truncate_calls == []
+    assert fake_file.write_calls == []
+    assert any("RIFF size exceeds 32-bit limit" in message for message in messages)
+
+
+def test_read_logs_structurally_invalid_app_metadata(tmp_path):
+    path = tmp_path / "invalid_app_metadata.wav"
+    messages = []
+    logger = _ListLogger(messages)
+    wavfile.write(path, 48000, np.array([0.1, 0.2], dtype=np.float32))
+    _append_test_info_comment(path, 'mic_calibration={"recorded_channels":[]}')
+
+    assert read_wav_calibration_metadata(path, logger=logger) is None
+    assert messages
+
+
+def test_read_logs_top_level_chunk_declared_beyond_riff_parse_end(tmp_path):
+    path = tmp_path / "truncated_chunk.wav"
+    messages = []
+    logger = _ListLogger(messages)
+    wavfile.write(path, 48000, np.array([0.1, 0.2], dtype=np.float32))
+    _append_test_declared_oversize_chunk(path, update_riff_size=True)
+
+    assert read_wav_calibration_metadata(path, logger=logger) is None
+    assert messages
+
+
+def test_append_rejects_existing_chunk_declared_beyond_riff_parse_end(tmp_path):
+    path = tmp_path / "truncated_chunk_append.wav"
+    messages = []
+    logger = _ListLogger(messages)
+    wavfile.write(path, 48000, np.array([0.1, 0.2], dtype=np.float32))
+    _append_test_declared_oversize_chunk(path, update_riff_size=True)
+    metadata = {
+        "recorded_channels": [
+            {"wav_channel_index": 0, "v2pa_factor": 3.5, "standard_spl": 94.0, "calibrated": True}
+        ]
+    }
+
+    assert append_wav_calibration_metadata(path, metadata, logger=logger) is False
+    assert read_wav_calibration_metadata(path) is None
+    assert messages
+
+
+def test_read_rejects_inflated_riff_size_with_readable_metadata(tmp_path):
+    path = tmp_path / "inflated_riff_size.wav"
+    messages = []
+    logger = _ListLogger(messages)
+    wavfile.write(path, 48000, np.array([0.1, 0.2], dtype=np.float32))
+    _append_test_info_comment(
+        path,
+        'mic_calibration={"recorded_channels":[{"wav_channel_index":0,"v2pa_factor":2.5,'
+        '"standard_spl":94.0,"calibrated":true}]}',
+    )
+    _inflate_test_riff_size(path)
+
+    assert read_wav_calibration_metadata(path, logger=logger) is None
+    assert any("declared RIFF size exceeds file size" in message for message in messages)
+
+
+def test_read_logs_odd_sized_list_missing_top_level_padding(tmp_path):
+    path = tmp_path / "unpadded_list.wav"
+    messages = []
+    logger = _ListLogger(messages)
+    wavfile.write(path, 48000, np.array([0.1, 0.2], dtype=np.float32))
+    _append_test_unpadded_odd_info_list(path)
+
+    assert read_wav_calibration_metadata(path, logger=logger) is None
+    assert messages
+
+
+def test_read_logs_odd_sized_list_nonzero_top_level_padding(tmp_path):
+    path = tmp_path / "nonzero_padded_list.wav"
+    messages = []
+    logger = _ListLogger(messages)
+    wavfile.write(path, 48000, np.array([0.1, 0.2], dtype=np.float32))
+    _append_test_nonzero_padded_odd_list(path)
+
+    assert read_wav_calibration_metadata(path, logger=logger) is None
+    assert any("nonzero padding byte after odd-sized chunk" in message for message in messages)
+
+
+def test_read_logs_list_subchunk_declared_beyond_list_payload(tmp_path):
+    path = tmp_path / "truncated_list_subchunk.wav"
+    messages = []
+    logger = _ListLogger(messages)
+    wavfile.write(path, 48000, np.array([0.1, 0.2], dtype=np.float32))
+    _append_test_truncated_info_comment(path)
+
+    assert read_wav_calibration_metadata(path, logger=logger) is None
+    assert messages
+
+
+def test_read_logs_odd_sized_icmt_missing_list_padding(tmp_path):
+    path = tmp_path / "unpadded_icmt.wav"
+    messages = []
+    logger = _ListLogger(messages)
+    wavfile.write(path, 48000, np.array([0.1, 0.2], dtype=np.float32))
+    _append_test_unpadded_odd_icmt(path)
+
+    assert read_wav_calibration_metadata(path, logger=logger) is None
+    assert messages
+
+
+def test_read_logs_odd_sized_icmt_nonzero_list_padding(tmp_path):
+    path = tmp_path / "nonzero_padded_icmt.wav"
+    messages = []
+    logger = _ListLogger(messages)
+    wavfile.write(path, 48000, np.array([0.1, 0.2], dtype=np.float32))
+    _append_test_nonzero_padded_odd_icmt(path)
+
+    assert read_wav_calibration_metadata(path, logger=logger) is None
+    assert any("nonzero padding byte after odd-sized subchunk" in message for message in messages)
+
+
+def test_read_logs_list_level_trailing_junk_after_valid_metadata(tmp_path):
+    path = tmp_path / "list_trailing_junk.wav"
+    messages = []
+    logger = _ListLogger(messages)
+    wavfile.write(path, 48000, np.array([0.1, 0.2], dtype=np.float32))
+    _append_test_info_comment_with_list_trailing_junk(
+        path,
+        'mic_calibration={"recorded_channels":[{"wav_channel_index":0,"v2pa_factor":2.5,'
+        '"standard_spl":94.0,"calibrated":true}]}',
+    )
+
+    assert read_wav_calibration_metadata(path, logger=logger) is None
+    assert messages
+
+
+def test_read_logs_top_level_trailing_junk_after_valid_metadata(tmp_path):
+    path = tmp_path / "top_level_trailing_junk.wav"
+    messages = []
+    logger = _ListLogger(messages)
+    wavfile.write(path, 48000, np.array([0.1, 0.2], dtype=np.float32))
+    _append_test_info_comment_with_top_level_trailing_junk(
+        path,
+        'mic_calibration={"recorded_channels":[{"wav_channel_index":0,"v2pa_factor":2.5,'
+        '"standard_spl":94.0,"calibrated":true}]}',
+    )
+
+    assert read_wav_calibration_metadata(path, logger=logger) is None
+    assert messages
+
+
+class _ListLogger:
+    def __init__(self, messages):
+        self.messages = messages
+
+    def warning(self, message):
+        self.messages.append(message)
+
+
+class _LargeRiffFile:
+    def __init__(self, data, *, file_size):
+        self._data = bytearray(data)
+        self._file_size = file_size
+        self._position = 0
+        self.truncate_calls = []
+        self.write_calls = []
+
+    @property
+    def bytes(self):
+        return bytes(self._data)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+    def seek(self, offset, whence=0):
+        if whence == 0:
+            self._position = offset
+        elif whence == 1:
+            self._position += offset
+        elif whence == 2:
+            self._position = self._file_size + offset
+        else:
+            raise ValueError("unsupported whence")
+        return self._position
+
+    def tell(self):
+        return self._position
+
+    def read(self, size=-1):
+        if size is None or size < 0:
+            size = len(self._data) - self._position
+        end = min(self._position + size, len(self._data))
+        payload = bytes(self._data[self._position : end])
+        self._position += len(payload)
+        return payload
+
+    def truncate(self, size=None):
+        self.truncate_calls.append(self._position if size is None else size)
+        return self._position if size is None else size
+
+    def write(self, data):
+        self.write_calls.append((self._position, bytes(data)))
+        return len(data)
+
+
+def _append_test_info_comment(path, text, *, update_riff_size=True):
+    payload = text.encode("utf-8") + b"\x00"
+    icmt_chunk = b"ICMT" + struct.pack("<I", len(payload)) + payload
+    if len(payload) % 2:
+        icmt_chunk += b"\x00"
+    list_payload = b"INFO" + icmt_chunk
+    list_chunk = b"LIST" + struct.pack("<I", len(list_payload)) + list_payload
+    if len(list_payload) % 2:
+        list_chunk += b"\x00"
+
+    with open(path, "r+b") as wav_file:
+        wav_file.seek(0, 2)
+        wav_file.write(list_chunk)
+        if update_riff_size:
+            file_size = wav_file.tell()
+            wav_file.seek(4)
+            wav_file.write(struct.pack("<I", file_size - 8))
+
+
+def _inflate_test_riff_size(path, extra_bytes=64):
+    with open(path, "r+b") as wav_file:
+        wav_file.seek(4)
+        riff_size = struct.unpack("<I", wav_file.read(4))[0]
+        wav_file.seek(4)
+        wav_file.write(struct.pack("<I", riff_size + extra_bytes))
+
+
+def _append_test_info_comment_with_list_trailing_junk(path, text):
+    payload = text.encode("utf-8") + b"\x00"
+    icmt_chunk = b"ICMT" + struct.pack("<I", len(payload)) + payload
+    if len(payload) % 2:
+        icmt_chunk += b"\x00"
+    list_payload = b"INFO" + icmt_chunk + b"junk"
+    list_chunk = b"LIST" + struct.pack("<I", len(list_payload)) + list_payload
+    if len(list_payload) % 2:
+        list_chunk += b"\x00"
+
+    with open(path, "r+b") as wav_file:
+        wav_file.seek(0, 2)
+        wav_file.write(list_chunk)
+        file_size = wav_file.tell()
+        wav_file.seek(4)
+        wav_file.write(struct.pack("<I", file_size - 8))
+
+
+def _append_test_info_comment_with_top_level_trailing_junk(path, text):
+    _append_test_info_comment(path, text)
+    with open(path, "r+b") as wav_file:
+        wav_file.seek(0, 2)
+        wav_file.write(b"junk")
+        file_size = wav_file.tell()
+        wav_file.seek(4)
+        wav_file.write(struct.pack("<I", file_size - 8))
+
+
+def _append_test_declared_oversize_chunk(path, *, update_riff_size=False):
+    payload = b"stale"
+    chunk = b"JUNK" + struct.pack("<I", len(payload) + 64) + payload
+    with open(path, "r+b") as wav_file:
+        wav_file.seek(0, 2)
+        wav_file.write(chunk)
+        if update_riff_size:
+            file_size = wav_file.tell()
+            wav_file.seek(4)
+            wav_file.write(struct.pack("<I", file_size - 8))
+
+
+def _append_test_truncated_info_comment(path):
+    payload = b"mic_calibration={not-json"
+    icmt_chunk = b"ICMT" + struct.pack("<I", len(payload) + 16) + payload
+    list_payload = b"INFO" + icmt_chunk
+    list_chunk = b"LIST" + struct.pack("<I", len(list_payload)) + list_payload
+    if len(list_payload) % 2:
+        list_chunk += b"\x00"
+
+    with open(path, "r+b") as wav_file:
+        wav_file.seek(0, 2)
+        wav_file.write(list_chunk)
+        file_size = wav_file.tell()
+        wav_file.seek(4)
+        wav_file.write(struct.pack("<I", file_size - 8))
+
+
+def _append_test_unpadded_odd_info_list(path):
+    payload = (
+        b'mic_calibration={"recorded_channels":[{"wav_channel_index":0,"v2pa_factor":2.5,'
+        b'"standard_spl":94.0,"calibrated":true}]}'
+    )
+    if len(payload) % 2:
+        payload += b"\x00"
+    icmt_chunk = b"ICMT" + struct.pack("<I", len(payload)) + payload
+    list_payload = b"INFO" + icmt_chunk + b"x"
+    assert len(list_payload) % 2 == 1
+    list_chunk = b"LIST" + struct.pack("<I", len(list_payload)) + list_payload
+
+    with open(path, "r+b") as wav_file:
+        wav_file.seek(0, 2)
+        wav_file.write(list_chunk)
+        file_size = wav_file.tell()
+        wav_file.seek(4)
+        wav_file.write(struct.pack("<I", file_size - 8))
+
+
+def _append_test_nonzero_padded_odd_list(path):
+    list_payload = b"adtlx"
+    assert len(list_payload) % 2 == 1
+    list_chunk = b"LIST" + struct.pack("<I", len(list_payload)) + list_payload + b"\x01"
+
+    with open(path, "r+b") as wav_file:
+        wav_file.seek(0, 2)
+        wav_file.write(list_chunk)
+        file_size = wav_file.tell()
+        wav_file.seek(4)
+        wav_file.write(struct.pack("<I", file_size - 8))
+
+
+def _append_test_unpadded_odd_icmt(path):
+    payload = (
+        b'mic_calibration={"recorded_channels":[{"wav_channel_index":0,"v2pa_factor":2.5,'
+        b'"standard_spl":94.0,"calibrated":true}]}'
+    )
+    if len(payload) % 2 == 0:
+        payload += b"\x00"
+    assert len(payload) % 2 == 1
+    icmt_chunk = b"ICMT" + struct.pack("<I", len(payload)) + payload
+    list_payload = b"INFO" + icmt_chunk
+    list_chunk = b"LIST" + struct.pack("<I", len(list_payload)) + list_payload
+    if len(list_payload) % 2:
+        list_chunk += b"\x00"
+
+    with open(path, "r+b") as wav_file:
+        wav_file.seek(0, 2)
+        wav_file.write(list_chunk)
+        file_size = wav_file.tell()
+        wav_file.seek(4)
+        wav_file.write(struct.pack("<I", file_size - 8))
+
+
+def _append_test_nonzero_padded_odd_icmt(path):
+    payload = (
+        b'mic_calibration={"recorded_channels":[{"wav_channel_index":0,"v2pa_factor":2.5,'
+        b'"standard_spl":94.0,"calibrated":true}]}'
+    )
+    if len(payload) % 2 == 0:
+        payload += b"\x00"
+    assert len(payload) % 2 == 1
+    icmt_chunk = b"ICMT" + struct.pack("<I", len(payload)) + payload + b"\x01"
+    list_payload = b"INFO" + icmt_chunk
+    list_chunk = b"LIST" + struct.pack("<I", len(list_payload)) + list_payload
+    if len(list_payload) % 2:
+        list_chunk += b"\x00"
+
+    with open(path, "r+b") as wav_file:
+        wav_file.seek(0, 2)
+        wav_file.write(list_chunk)
+        file_size = wav_file.tell()
+        wav_file.seek(4)
+        wav_file.write(struct.pack("<I", file_size - 8))

--- a/unit_test/ui/test_operation_sequence_recording_delay.py
+++ b/unit_test/ui/test_operation_sequence_recording_delay.py
@@ -1,8 +1,12 @@
+import sys
+from pathlib import Path
 from types import SimpleNamespace
 
 import numpy as np
 import pytest
 from PyQt5.QtWidgets import QApplication
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from ui import operation_sequence
 
@@ -16,7 +20,7 @@ def test_record_golden_sample_converts_configured_recording_start_delay(qapp, mo
     captured = {}
 
     class FakeSoundcardAudioProcessor:
-        def sd_play_rec(self, recorded_dict, stimulus_dict, path):
+        def sd_play_rec(self, recorded_dict, stimulus_dict, path, calibration_metadata=None):
             captured["recorded_dict"] = dict(recorded_dict)
             captured["stimulus_dict"] = dict(stimulus_dict)
             captured["path"] = path

--- a/unit_test/ui/test_operation_sequence_samplerate_authority.py
+++ b/unit_test/ui/test_operation_sequence_samplerate_authority.py
@@ -1,8 +1,11 @@
 import json
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
 import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from ui import operation_sequence
 
@@ -64,7 +67,7 @@ def test_record_golden_sample_uses_duplex_samplerate_not_config(monkeypatch):
     monkeypatch.setattr(
         operation_sequence.SoundcardAudioProcessor,
         "sd_play_rec",
-        lambda self, record, stimulus, path: (1, None),
+        lambda self, record, stimulus, path, calibration_metadata=None: (1, None),
     )
     monkeypatch.setattr(operation_sequence.MessageBox, "warning", lambda *args: None)
     monkeypatch.setattr(operation_sequence.LoadUiConfig, "save_sequence_config_to_json", lambda *args: True)
@@ -89,6 +92,54 @@ def test_record_golden_sample_blocks_mismatched_samplerates(monkeypatch):
     operation_sequence.AnalysisModelSelect.record_golden_sample_btn_clicked(selector)
 
     assert warnings
+
+
+def test_record_golden_sample_passes_wav_calibration_metadata(monkeypatch):
+    selector = _selector({"samplerate": 48000, "hostapi": 1, "hardware_id": "mic-1"}, {"samplerate": 48000, "hostapi": 1})
+    selector.select_list.mic_channels = [2, 4]
+    metadata = {
+        "recorded_channels": [
+            {"wav_channel_index": 0, "v2pa_factor": 2.5, "standard_spl": 94.0, "calibrated": True}
+        ]
+    }
+    build_calls = []
+    record_calls = []
+
+    monkeypatch.setattr(
+        operation_sequence.AnalysisModelSelect,
+        "set_data_struct_stimulus_signal",
+        staticmethod(lambda data_struct, detail, using_config_path=None, logger=None, runtime_sample_rate=None: True),
+    )
+    monkeypatch.setattr(
+        operation_sequence.LoadUiConfig,
+        "get_rec_and_play_dict_base_sequence_dict",
+        lambda data_struct, recording_start_delay_ms=None: (
+            {"sr": data_struct.sample_rate, "data": np.zeros(4, dtype=np.float32), "amplitude": 1.0},
+            {"sample_rate": data_struct.sample_rate, "sr": data_struct.sample_rate},
+        ),
+    )
+    monkeypatch.setattr(operation_sequence.os, "makedirs", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        operation_sequence,
+        "build_recording_wav_calibration_metadata",
+        lambda input_channels, hardware_id=None, logger=None: build_calls.append((list(input_channels), hardware_id))
+        or metadata,
+    )
+
+    def fake_sd_play_rec(self, recorded_dict, stimulus_dict, path, calibration_metadata=None):
+        record_calls.append((list(recorded_dict.get("input_channels", [])), calibration_metadata))
+        return 0, np.zeros(4, dtype=np.float32)
+
+    monkeypatch.setattr(operation_sequence.SoundcardAudioProcessor, "sd_play_rec", fake_sd_play_rec)
+    monkeypatch.setattr(operation_sequence, "get_class_mapping", lambda: {})
+    monkeypatch.setattr(operation_sequence.QFileDialog, "getSaveFileName", lambda *args, **kwargs: ("", ""))
+    monkeypatch.setattr(operation_sequence.MessageBox, "warning", lambda *args: None)
+    selector.set_data_struct_stimulus_signal = operation_sequence.AnalysisModelSelect.set_data_struct_stimulus_signal
+
+    operation_sequence.AnalysisModelSelect.record_golden_sample_btn_clicked(selector)
+
+    assert build_calls == [([2], "mic-1")]
+    assert record_calls == [([2], metadata)]
 
 
 def test_record_golden_sample_cancel_save_restores_shared_runtime_state(monkeypatch):
@@ -132,7 +183,7 @@ def test_record_golden_sample_cancel_save_restores_shared_runtime_state(monkeypa
     monkeypatch.setattr(
         operation_sequence.SoundcardAudioProcessor,
         "sd_play_rec",
-        lambda self, record, stimulus, path: (0, np.zeros(3, dtype=np.float32)),
+        lambda self, record, stimulus, path, calibration_metadata=None: (0, np.zeros(3, dtype=np.float32)),
     )
     monkeypatch.setattr(operation_sequence, "get_class_mapping", lambda: {})
     monkeypatch.setattr(operation_sequence.QFileDialog, "getSaveFileName", lambda *args, **kwargs: ("", ""))
@@ -194,7 +245,7 @@ def test_record_golden_sample_success_saves_runtime_payload_then_restores_shared
     monkeypatch.setattr(
         operation_sequence.SoundcardAudioProcessor,
         "sd_play_rec",
-        lambda self, record, stimulus, path: (0, np.zeros(3, dtype=np.float32)),
+        lambda self, record, stimulus, path, calibration_metadata=None: (0, np.zeros(3, dtype=np.float32)),
     )
     monkeypatch.setattr(operation_sequence, "get_class_mapping", lambda: {})
     monkeypatch.setattr(

--- a/unit_test/ui/test_sequence_channel_calibration.py
+++ b/unit_test/ui/test_sequence_channel_calibration.py
@@ -2,18 +2,21 @@ import ast
 import copy
 import json
 import os
+import sys
 import types
 from datetime import datetime
 from pathlib import Path
 
 import pytest
 
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
 from base.acquisition_recording_defaults import normalize_play_record_detail
 from base import soundcard_calibration_manager as calibration_manager
 from base.soundcard_calibration_manager import MicChannelCalibrationResult
 
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
 SEQUENCE_WIDGET_PATH = REPO_ROOT / "ui" / "sequence" / "sequence_widget.py"
 OPERATION_SEQUENCE_PATH = REPO_ROOT / "ui" / "operation_sequence.py"
 
@@ -51,12 +54,14 @@ def _load_class_method(
 
 
 def _load_record_golden_sample_method(namespace: dict):
+    namespace.setdefault("build_recording_wav_calibration_metadata", lambda *args, **kwargs: {"recorded_channels": []})
     return _load_class_method(
         OPERATION_SEQUENCE_PATH,
         "AnalysisModelSelect",
         "record_golden_sample_btn_clicked",
         namespace,
         helper_names=(
+            "_safe_dialog_attr",
             "_snapshot_golden_sample_runtime_state",
             "_restore_golden_sample_runtime_state",
         ),
@@ -450,6 +455,35 @@ def test_sequence_non_record_only_uses_shared_helper_and_surfaces_fallback_warni
     assert DummyMessageBox.warnings == ["In4 未校准，本次使用 In1 的校准系数。"]
 
 
+@pytest.mark.parametrize("mode", ["IMPORT_AUDIO", "IMPORT_STIMULUS_AUDIO"])
+def test_sequence_import_modes_do_not_pre_resolve_calibration_from_database(mode):
+    resolve_calls = []
+
+    def resolve_impl(raw_channel, warn_callback=None):
+        resolve_calls.append(raw_channel)
+        raise AssertionError("imported WAV analysis should resolve calibration from DataDealStruct")
+
+    window = _build_sequence_window(
+        resolve_impl,
+        mode=mode,
+        analysis_config={"golden_sample_result_path": "golden.json"},
+    )
+
+    params = {"analysis_channel": 3}
+    window.instance_analysis_class("SPL2", "SPL", params)
+
+    assert resolve_calls == []
+    assert len(window.analysis_window) == 1
+    instance = window.analysis_window[0]
+    assert instance.name == "SPL2"
+    assert instance.v2pa_factor is None
+    assert not hasattr(instance, "_use_pre_resolved_v2pa_factor")
+    assert not hasattr(instance, "_v2pa_raw_analysis_channel")
+    assert instance.analysis_config["analysis_channel"] == 3
+    assert instance.analysis_config["golden_sample_result_path"] == "golden.json"
+    assert DummyMessageBox.warnings == []
+
+
 def test_sequence_batch_coalesces_duplicate_uncalibrated_mic_warnings():
     resolve_calls = []
 
@@ -517,7 +551,7 @@ def test_golden_sample_rb_standard_thd_skips_calibration_resolution(tmp_path):
         ),
         "normalize_play_record_detail": normalize_play_record_detail,
         "SoundcardAudioProcessor": lambda: types.SimpleNamespace(
-            sd_play_rec=lambda recorded_dict, stimulus_dict, recorded_wav_path: (0, [0.1, 0.2, 0.3])
+            sd_play_rec=lambda recorded_dict, stimulus_dict, recorded_wav_path, calibration_metadata=None: (0, [0.1, 0.2, 0.3])
         ),
         "get_class_mapping": lambda: {"RB": FakeAnalysis},
         "MessageBox": DummyMessageBox,
@@ -587,7 +621,7 @@ def test_golden_sample_fr_skips_calibration_requirement(tmp_path):
         ),
         "normalize_play_record_detail": normalize_play_record_detail,
         "SoundcardAudioProcessor": lambda: types.SimpleNamespace(
-            sd_play_rec=lambda recorded_dict, stimulus_dict, recorded_wav_path: (0, [0.1, 0.2, 0.3])
+            sd_play_rec=lambda recorded_dict, stimulus_dict, recorded_wav_path, calibration_metadata=None: (0, [0.1, 0.2, 0.3])
         ),
         "get_class_mapping": lambda: {"FR": FakeAnalysis},
         "MessageBox": DummyMessageBox,
@@ -657,7 +691,7 @@ def test_golden_sample_rb_standard_thd_missing_calibration_does_not_warn(tmp_pat
         ),
         "normalize_play_record_detail": normalize_play_record_detail,
         "SoundcardAudioProcessor": lambda: types.SimpleNamespace(
-            sd_play_rec=lambda recorded_dict, stimulus_dict, recorded_wav_path: (0, [0.1, 0.2, 0.3])
+            sd_play_rec=lambda recorded_dict, stimulus_dict, recorded_wav_path, calibration_metadata=None: (0, [0.1, 0.2, 0.3])
         ),
         "get_class_mapping": lambda: {"RB": FakeAnalysis},
         "MessageBox": DummyMessageBox,

--- a/unit_test/ui/test_sequence_import_analysis_sample_rate.py
+++ b/unit_test/ui/test_sequence_import_analysis_sample_rate.py
@@ -1,9 +1,24 @@
+import sys
+from pathlib import Path
 from types import SimpleNamespace
 
 import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from base import stimulus_resolver
 from ui.sequence import sequence_widget
+
+
+@pytest.fixture(autouse=True)
+def _valid_wav_calibration_metadata(monkeypatch):
+    metadata = {
+        "recorded_channels": [
+            {"wav_channel_index": 0, "v2pa_factor": 2.5, "standard_spl": 94.0, "calibrated": True}
+        ]
+    }
+    monkeypatch.setattr(sequence_widget, "read_wav_calibration_metadata", lambda path, logger=None: metadata)
 
 
 class _Button:
@@ -80,11 +95,6 @@ def test_import_stimulus_audio_uses_decoded_rate_for_analysis_reference(monkeypa
 
     monkeypatch.setattr(sequence_widget.QFileDialog, "getOpenFileName", lambda *args, **kwargs: ("recording.wav", ""))
     monkeypatch.setattr(sequence_widget, "load_audio_preserve_rate", _native_audio_loader(load_calls), raising=False)
-    monkeypatch.setattr(
-        sequence_widget.librosa,
-        "load",
-        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("config-rate librosa.load must not be used")),
-    )
 
     def fake_reference(data_struct, detail, using_config_path=None, *, runtime_sample_rate, logger=None):
         reference_calls.append((detail, using_config_path, runtime_sample_rate))
@@ -249,11 +259,6 @@ def test_import_audio_preserves_decoded_rate_without_reference_generation(monkey
 
     monkeypatch.setattr(sequence_widget.QFileDialog, "getOpenFileName", lambda *args, **kwargs: ("recording.wav", ""))
     monkeypatch.setattr(sequence_widget, "load_audio_preserve_rate", _native_audio_loader(load_calls, 22050), raising=False)
-    monkeypatch.setattr(
-        sequence_widget.librosa,
-        "load",
-        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("config-rate librosa.load must not be used")),
-    )
     monkeypatch.setattr(
         sequence_widget,
         "set_data_struct_analysis_reference_signal",

--- a/unit_test/ui/test_sequence_wav_calibration_metadata.py
+++ b/unit_test/ui/test_sequence_wav_calibration_metadata.py
@@ -1,0 +1,457 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from base.data_struct.data_deal_struct import DataDealStruct
+from consts import error_code
+from ui.sequence import sequence_widget
+
+
+class FakeLogger:
+    def __init__(self):
+        self.messages = []
+
+    def info(self, message):
+        self.messages.append(message)
+
+    def warning(self, message):
+        self.messages.append(message)
+
+    def error(self, message):
+        self.messages.append(message)
+
+
+class FakeButton:
+    def __init__(self):
+        self.enabled = None
+
+    def setEnabled(self, value):
+        self.enabled = value
+
+    def setDisabled(self, value):
+        self.enabled = not value
+
+
+def _metadata(factor=2.5):
+    return {
+        "recorded_channels": [
+            {"wav_channel_index": 0, "v2pa_factor": factor, "standard_spl": 94.0, "calibrated": True}
+        ]
+    }
+
+
+def _record_window(mode, metadata=None):
+    data_struct = SimpleNamespace(
+        store_wave_data=None,
+        store_wave_data_multi=None,
+        stimulus_info={"repeat_times": 1},
+        sample_rate=48000,
+    )
+    window = SimpleNamespace(
+        sequence_config=[{"seq1": {"acq": {"mode": mode}}}],
+        recorded_path="record.wav",
+        recorded_signal_info={},
+        data_struct=data_struct,
+        _active_input_channels=[0],
+        _build_current_wav_calibration_metadata=lambda: metadata or _metadata(),
+        plot_waveform_to_workspace=lambda *args: None,
+        _finish_recording_success=lambda sample_rate: None,
+        _finish_recording_failure=lambda error: (_ for _ in ()).throw(error),
+        _recording_output_path=lambda: "record.wav",
+        _finalize_successful_replay_output=lambda: None,
+        _delete_successful_replay_backup=lambda: None,
+        _clear_recording_output_attempt=lambda: None,
+        _run_post_recording_followup=lambda action_name, callback, *args, **kwargs: callback(*args, **kwargs),
+        default_logger=FakeLogger(),
+    )
+    window._normalize_blocking_recorded_data = lambda recorded_data: sequence_widget.SequenceWindow._normalize_blocking_recorded_data(
+        window, recorded_data
+    )
+    return window
+
+
+def _import_window(mode="IMPORT_AUDIO"):
+    return SimpleNamespace(
+        sequence_config=[{"seq1": {"acq": {"mode": mode, "detail": {"sample_rate": 44100}}}}],
+        data_struct=SimpleNamespace(sample_rate=None),
+        analysis_config={"auto_analysis": False},
+        recorded_path=None,
+        recorded_signal_info=None,
+        _clear_plot_area=lambda: None,
+        plot_waveform_to_workspace=lambda *args, **kwargs: None,
+        data_btn=SimpleNamespace(setEnabled=lambda enabled: None),
+        run=lambda: None,
+        using_config_path="configs/sequence.json",
+        default_logger=FakeLogger(),
+    )
+
+
+def _bind_current_metadata_input_channels(window):
+    window._current_metadata_input_channels = sequence_widget.SequenceWindow._current_metadata_input_channels.__get__(
+        window, type(window)
+    )
+    return window
+
+
+def test_build_current_wav_calibration_metadata_uses_selected_mic_and_active_channels(monkeypatch):
+    calls = []
+    expected = _metadata()
+
+    monkeypatch.setattr(
+        sequence_widget,
+        "build_recording_wav_calibration_metadata",
+        lambda input_channels, hardware_id=None, logger=None: calls.append((list(input_channels), hardware_id, logger))
+        or expected,
+    )
+
+    window = _bind_current_metadata_input_channels(
+        SimpleNamespace(mic={"hardware_id": "mic-1"}, _active_input_channels=[2, 4], default_logger=FakeLogger())
+    )
+
+    assert sequence_widget.SequenceWindow._build_current_wav_calibration_metadata(window) is expected
+    assert calls == [([2, 4], "mic-1", window.default_logger)]
+
+
+def test_play_and_record_wav_metadata_uses_only_saved_mono_input_channel(monkeypatch):
+    calls = []
+    expected = _metadata()
+
+    monkeypatch.setattr(
+        sequence_widget,
+        "build_recording_wav_calibration_metadata",
+        lambda input_channels, hardware_id=None, logger=None: calls.append((list(input_channels), hardware_id))
+        or expected,
+    )
+
+    window = _bind_current_metadata_input_channels(
+        SimpleNamespace(
+            mic={"hardware_id": "mic-1"},
+            _active_input_channels=[2, 4],
+            sequence_config=[{"seq1": {"acq": {"mode": "PLAY_AND_RECORD"}}}],
+            default_logger=FakeLogger(),
+        )
+    )
+
+    assert sequence_widget.SequenceWindow._build_current_wav_calibration_metadata(window) is expected
+    assert calls == [([2], "mic-1")]
+
+
+def test_record_only_wav_metadata_keeps_all_saved_input_channels(monkeypatch):
+    calls = []
+    expected = _metadata()
+
+    monkeypatch.setattr(
+        sequence_widget,
+        "build_recording_wav_calibration_metadata",
+        lambda input_channels, hardware_id=None, logger=None: calls.append((list(input_channels), hardware_id))
+        or expected,
+    )
+
+    window = _bind_current_metadata_input_channels(
+        SimpleNamespace(
+            mic={"hardware_id": "mic-1"},
+            _active_input_channels=[2, 4],
+            sequence_config=[{"seq1": {"acq": {"mode": "RECORD_ONLY"}}}],
+            default_logger=FakeLogger(),
+        )
+    )
+
+    assert sequence_widget.SequenceWindow._build_current_wav_calibration_metadata(window) is expected
+    assert calls == [([2, 4], "mic-1")]
+
+
+def test_data_struct_initializes_and_clears_wav_calibration_runtime_fields():
+    data_struct = DataDealStruct()
+    assert data_struct.wav_calibration_metadata is None
+    assert data_struct.wav_calibration_metadata_authoritative is False
+    assert data_struct.wav_calibration_warning_shown is False
+
+    data_struct.wav_calibration_metadata = _metadata()
+    data_struct.wav_calibration_metadata_authoritative = True
+    data_struct.wav_calibration_warning_shown = True
+
+    data_struct.clear_data()
+
+    assert data_struct.wav_calibration_metadata is None
+    assert data_struct.wav_calibration_metadata_authoritative is False
+    assert data_struct.wav_calibration_warning_shown is False
+
+
+def test_import_audio_reads_wav_calibration_metadata(monkeypatch):
+    window = _import_window("IMPORT_AUDIO")
+    warnings = []
+    metadata = _metadata()
+    monkeypatch.setattr(sequence_widget.QFileDialog, "getOpenFileName", lambda *args, **kwargs: ("input.wav", ""))
+    monkeypatch.setattr(
+        sequence_widget,
+        "load_audio_preserve_rate",
+        lambda path, mono=False: (np.array([0.1, 0.2], dtype=np.float32), 48000),
+    )
+    monkeypatch.setattr(sequence_widget, "read_wav_calibration_metadata", lambda path, logger=None: metadata)
+    monkeypatch.setattr(sequence_widget.MessageBox, "warning", lambda parent, title, message: warnings.append(message))
+
+    sequence_widget.SequenceWindow.import_audio_and_analyze(window)
+
+    assert window.data_struct.wav_calibration_metadata == metadata
+    assert window.data_struct.wav_calibration_metadata_authoritative is True
+    assert window.data_struct.wav_calibration_warning_shown is False
+    assert warnings == []
+
+
+def test_import_audio_missing_metadata_warns_once_and_marks_authoritative(monkeypatch):
+    window = _import_window("IMPORT_AUDIO")
+    warnings = []
+    monkeypatch.setattr(sequence_widget.QFileDialog, "getOpenFileName", lambda *args, **kwargs: ("input.wav", ""))
+    monkeypatch.setattr(
+        sequence_widget,
+        "load_audio_preserve_rate",
+        lambda path, mono=False: (np.array([0.1, 0.2], dtype=np.float32), 48000),
+    )
+    monkeypatch.setattr(sequence_widget, "read_wav_calibration_metadata", lambda path, logger=None: None)
+    monkeypatch.setattr(sequence_widget.MessageBox, "warning", lambda parent, title, message: warnings.append(message))
+
+    sequence_widget.SequenceWindow.import_audio_and_analyze(window)
+
+    assert window.data_struct.wav_calibration_metadata is None
+    assert window.data_struct.wav_calibration_metadata_authoritative is True
+    assert window.data_struct.wav_calibration_warning_shown is True
+    assert warnings == ["该音频文件未包含有效校准数据，分析结果仅供参考。"]
+
+
+def test_import_stimulus_audio_reads_metadata_and_preserves_decoded_rate_reference(monkeypatch):
+    window = _import_window("IMPORT_STIMULUS_AUDIO")
+    metadata = _metadata()
+    reference_calls = []
+    monkeypatch.setattr(sequence_widget.QFileDialog, "getOpenFileName", lambda *args, **kwargs: ("input.wav", ""))
+    monkeypatch.setattr(
+        sequence_widget,
+        "load_audio_preserve_rate",
+        lambda path, mono=False: (np.array([0.1, 0.2], dtype=np.float32), 32000),
+    )
+    monkeypatch.setattr(sequence_widget, "read_wav_calibration_metadata", lambda path, logger=None: metadata)
+
+    def fake_reference(data_struct, detail, using_config_path=None, *, runtime_sample_rate, logger=None):
+        reference_calls.append(runtime_sample_rate)
+        data_struct.stimulus_data = np.zeros(2, dtype=np.float32)
+        data_struct.stimulus_info = {"sample_rate": runtime_sample_rate}
+        return True
+
+    monkeypatch.setattr(sequence_widget, "set_data_struct_analysis_reference_signal", fake_reference, raising=False)
+
+    sequence_widget.SequenceWindow.import_audio_and_analyze(window)
+
+    assert window.data_struct.wav_calibration_metadata == metadata
+    assert window.data_struct.wav_calibration_metadata_authoritative is True
+    assert window.data_struct.sample_rate == 32000
+    assert reference_calls == [32000]
+
+
+def test_blocking_record_only_saves_metadata(monkeypatch):
+    calls = []
+    metadata = _metadata()
+    window = _record_window("RECORD_ONLY", metadata)
+
+    monkeypatch.setattr(
+        sequence_widget.SoundcardAudioProcessor,
+        "sd_rec",
+        staticmethod(lambda recorded_dict: (error_code.OK, np.array([0.1, 0.2], dtype=np.float32))),
+    )
+    monkeypatch.setattr(
+        sequence_widget,
+        "save_audio_with_calibration_metadata",
+        lambda path, data, sr, calibration_metadata=None, logger=None, bit_depth=None: calls.append(
+            (path, sr, calibration_metadata)
+        ),
+    )
+    monkeypatch.setattr(
+        sequence_widget.RecordingManager,
+        "save_signal_info_to_db",
+        lambda self, info, stimulus: (error_code.OK, "ok"),
+    )
+
+    sequence_widget.SequenceWindow._start_blocking_recording(window, {}, {"sample_rate": 48000}, 48000)
+
+    assert calls == [("record.wav", 48000, metadata)]
+
+
+def test_blocking_play_and_record_passes_metadata(monkeypatch):
+    calls = []
+    metadata = _metadata()
+    window = _record_window("PLAY_AND_RECORD", metadata)
+
+    def fake_sd_play_rec(self, recorded_dict, stimulus_dict, path, calibration_metadata=None):
+        calls.append((path, calibration_metadata, recorded_dict.get("wav_calibration_metadata")))
+        return error_code.OK, np.array([0.1, 0.2], dtype=np.float32)
+
+    monkeypatch.setattr(sequence_widget.SoundcardAudioProcessor, "sd_play_rec", fake_sd_play_rec)
+    monkeypatch.setattr(
+        sequence_widget.RecordingManager,
+        "save_signal_info_to_db",
+        lambda self, info, stimulus: (error_code.OK, "ok"),
+    )
+
+    sequence_widget.SequenceWindow._start_blocking_recording(
+        window,
+        {"sr": 48000, "data": np.zeros(2, dtype=np.float32), "amplitude": 1.0},
+        {"sample_rate": 48000, "sr": 48000},
+        48000,
+    )
+
+    assert calls == [("record.wav", metadata, metadata)]
+
+
+def test_streaming_record_only_appends_metadata_after_finalize(monkeypatch):
+    calls = []
+    metadata = _metadata()
+    writer = SimpleNamespace(finalize=lambda: calls.append(("finalize", None)))
+    processor = SimpleNamespace(
+        target_samples=2,
+        get_recorded_data=lambda: np.array([0.1, 0.2], dtype=np.float32),
+        get_recorded_data_multi=lambda: np.array([[0.1], [0.2]], dtype=np.float32),
+    )
+    window = _stream_window("record_only", processor, writer, metadata)
+
+    monkeypatch.setattr(
+        sequence_widget,
+        "append_wav_calibration_metadata",
+        lambda path, calibration_metadata, logger=None: calls.append((path, calibration_metadata)) or True,
+    )
+    monkeypatch.setattr(
+        sequence_widget.RecordingManager,
+        "save_signal_info_to_db",
+        lambda self, info, stimulus: (error_code.OK, "ok"),
+    )
+
+    sequence_widget.SequenceWindow._on_streaming_complete(window)
+
+    assert ("finalize", None) in calls
+    assert ("record.wav", metadata) in calls
+
+
+def test_streaming_play_and_record_rewrites_final_wav_with_metadata(monkeypatch):
+    calls = []
+    metadata = _metadata()
+    writer = SimpleNamespace(finalize=lambda: None)
+    processor = SimpleNamespace(
+        target_samples=2,
+        get_recorded_data=lambda: np.array([0.1, 0.2], dtype=np.float32),
+    )
+    window = _stream_window("play_record", processor, writer, metadata)
+    window.streaming_stimulus_data = np.array([0.1, 0.2], dtype=np.float32)
+
+    monkeypatch.setattr(
+        sequence_widget.AlignmentProcessing,
+        "align_play_and_rec_data_using_gccphat",
+        staticmethod(lambda stimulus, recorded: np.array([0.1, 0.2], dtype=np.float32)),
+    )
+    monkeypatch.setattr(
+        sequence_widget,
+        "save_audio_with_calibration_metadata",
+        lambda path, data, sr, calibration_metadata=None, logger=None, bit_depth=None: calls.append(
+            (path, sr, calibration_metadata)
+        ),
+    )
+    monkeypatch.setattr(sequence_widget.os.path, "exists", lambda path: False)
+    monkeypatch.setattr(
+        sequence_widget.RecordingManager,
+        "save_signal_info_to_db",
+        lambda self, info, stimulus: (error_code.OK, "ok"),
+    )
+
+    sequence_widget.SequenceWindow._on_streaming_complete(window)
+
+    assert calls == [("record.wav", 48000, metadata)]
+
+
+def test_streaming_play_and_record_saves_first_retained_channel_for_single_channel_metadata(monkeypatch):
+    calls = []
+    alignment_inputs = []
+    metadata = _metadata(7.0)
+    writer = SimpleNamespace(finalize=lambda: None)
+    processor = SimpleNamespace(
+        target_samples=2,
+        get_recorded_data=lambda: np.array([2.0, 2.5], dtype=np.float32),
+        get_recorded_data_multi=lambda: np.array([[1.0, 3.0], [1.5, 3.5]], dtype=np.float32),
+    )
+    window = _stream_window("play_record", processor, writer, metadata)
+    window._active_input_channels = [2, 4]
+    window.streaming_stimulus_data = np.array([0.0, 0.0], dtype=np.float32)
+
+    def fake_align(stimulus, recorded):
+        alignment_inputs.append(np.asarray(recorded, dtype=np.float32).copy())
+        return np.asarray(recorded, dtype=np.float32)
+
+    monkeypatch.setattr(
+        sequence_widget.AlignmentProcessing,
+        "align_play_and_rec_data_using_gccphat",
+        staticmethod(fake_align),
+    )
+    monkeypatch.setattr(
+        sequence_widget,
+        "save_audio_with_calibration_metadata",
+        lambda path, data, sr, calibration_metadata=None, logger=None, bit_depth=None: calls.append(
+            (path, np.asarray(data, dtype=np.float32).copy(), sr, calibration_metadata)
+        ),
+    )
+    monkeypatch.setattr(sequence_widget.os.path, "exists", lambda path: False)
+    monkeypatch.setattr(
+        sequence_widget.RecordingManager,
+        "save_signal_info_to_db",
+        lambda self, info, stimulus: (error_code.OK, "ok"),
+    )
+
+    sequence_widget.SequenceWindow._on_streaming_complete(window)
+
+    np.testing.assert_allclose(alignment_inputs[0], np.array([1.0, 1.5], dtype=np.float32))
+    assert calls[0][0] == "record.wav"
+    np.testing.assert_allclose(calls[0][1], np.array([1.0, 1.5], dtype=np.float32))
+    assert calls[0][2] == 48000
+    assert calls[0][3] == metadata
+    assert len(calls[0][3]["recorded_channels"]) == 1
+
+
+def _stream_window(mode, processor, writer, metadata):
+    return SimpleNamespace(
+        streaming_processor=processor,
+        streaming_mode=mode,
+        streaming_wav_writer=writer,
+        streaming_stimulus_data=None,
+        streaming_plot_item=None,
+        streaming_temp_path="record_temp.wav",
+        recorded_path="record.wav",
+        recorded_signal_info={},
+        data_struct=SimpleNamespace(
+            sample_rate=48000,
+            store_wave_data=None,
+            store_wave_data_multi=None,
+            stimulus_info={"repeat_times": 1},
+        ),
+        _active_input_channels=[0],
+        _build_current_wav_calibration_metadata=lambda: metadata,
+        _recording_output_path=lambda: "record.wav",
+        _finalize_successful_replay_output=lambda: None,
+        _commit_pending_recorded_count=lambda: None,
+        _clear_pending_recorded_count=lambda: None,
+        _delete_successful_replay_backup=lambda: None,
+        _clear_recording_output_attempt=lambda: None,
+        _delete_failed_streaming_outputs=lambda: None,
+        _run_post_recording_followup=lambda action_name, callback, *args, **kwargs: callback(*args, **kwargs),
+        default_logger=FakeLogger(),
+        data_btn=FakeButton(),
+        replayer_btn=FakeButton(),
+        barcode_scanner_box=SimpleNamespace(isChecked=lambda: False),
+        analysis_config={"auto_analysis": False},
+        _set_sn_input_recording_read_only=lambda value: None,
+        update_player_btn_is_paused=lambda: None,
+        run=lambda: None,
+        _awaiting_ok_ng=False,
+        _sn_clear_on_next_scan=False,
+        player_status_flag=True,
+        _record_workflow_busy=True,
+    )

--- a/unit_test/ui/test_sequence_widget_sample_rate_authority.py
+++ b/unit_test/ui/test_sequence_widget_sample_rate_authority.py
@@ -1,6 +1,10 @@
+import sys
+from pathlib import Path
 from types import SimpleNamespace
 
 import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from base import play_and_record
 from ui.sequence import sequence_widget
@@ -30,6 +34,7 @@ def _window(mode, detail, mic=_DEFAULT_DEVICE, speaker=_DEFAULT_DEVICE):
     obj.lineedit_count = SimpleNamespace(text=lambda: "1")
     obj.lineedit_s_or_n = SimpleNamespace(text=lambda: "")
     obj._active_input_channels = []
+    obj._build_current_wav_calibration_metadata = lambda: {"recorded_channels": []}
     obj.using_config_path = "sequence.json"
     return obj
 
@@ -296,7 +301,13 @@ def test_import_audio_preserves_file_native_samplerate(monkeypatch):
     win.data_btn = SimpleNamespace(setEnabled=lambda enabled: None)
     win.analysis_config = {"auto_analysis": False}
     load_calls = []
+    metadata = {
+        "recorded_channels": [
+            {"wav_channel_index": 0, "v2pa_factor": 2.5, "standard_spl": 94.0, "calibrated": True}
+        ]
+    }
     monkeypatch.setattr(sequence_widget.QFileDialog, "getOpenFileName", lambda *args, **kwargs: ("input.wav", ""))
+    monkeypatch.setattr(sequence_widget, "read_wav_calibration_metadata", lambda path, logger=None: metadata)
     monkeypatch.setattr(
         sequence_widget,
         "load_audio_preserve_rate",
@@ -319,7 +330,13 @@ def test_import_stimulus_audio_generates_temporary_reference_at_recording_rate(m
     win.data_btn = SimpleNamespace(setEnabled=lambda enabled: None)
     win.analysis_config = {"auto_analysis": False}
     calls = []
+    metadata = {
+        "recorded_channels": [
+            {"wav_channel_index": 0, "v2pa_factor": 2.5, "standard_spl": 94.0, "calibrated": True}
+        ]
+    }
     monkeypatch.setattr(sequence_widget.QFileDialog, "getOpenFileName", lambda *args, **kwargs: ("input.wav", ""))
+    monkeypatch.setattr(sequence_widget, "read_wav_calibration_metadata", lambda path, logger=None: metadata)
     monkeypatch.setattr(
         sequence_widget,
         "load_audio_preserve_rate",

--- a/unit_test/ui/test_sequence_widget_sn_lock.py
+++ b/unit_test/ui/test_sequence_widget_sn_lock.py
@@ -63,6 +63,8 @@ TARGET_METHODS = {
     "_should_use_streaming_recording",
     "_start_streaming_recording",
     "_normalize_blocking_recorded_data",
+    "_build_current_wav_calibration_metadata",
+    "_current_metadata_input_channels",
     "_finish_recording_success",
     "_finish_recording_failure",
     "_start_blocking_recording",
@@ -73,6 +75,7 @@ TARGET_METHODS = {
 }
 TARGET_MODULE_HELPERS = {
     "_clear_data_struct_stimulus_runtime_state",
+    "_clear_wav_calibration_runtime_state",
     "_clear_sequence_stimulus_runtime_state",
     "_resolve_runtime_sample_rate_for_mode",
 }
@@ -227,6 +230,21 @@ def _build_method_namespace():
         "SplitRepeatSignal": lambda: types.SimpleNamespace(split_repeat_signal=lambda data, sample_rate, **kwargs: []),
         "error_code": types.SimpleNamespace(OK="OK"),
         "save_audio_simple": lambda *args, **kwargs: None,
+        "save_audio_with_calibration_metadata": lambda save_path, audio, sr=44100, calibration_metadata=None, logger=None, bit_depth=32: namespace[
+            "save_audio_simple"
+        ](save_path, audio, sr, bit_depth=bit_depth),
+        "append_wav_calibration_metadata": lambda *args, **kwargs: True,
+        "build_recording_wav_calibration_metadata": lambda input_channels, hardware_id=None, logger=None: {
+            "recorded_channels": [
+                {
+                    "wav_channel_index": wav_channel_index,
+                    "v2pa_factor": None,
+                    "standard_spl": None,
+                    "calibrated": False,
+                }
+                for wav_channel_index, _channel in enumerate(input_channels)
+            ]
+        },
         "save_recorded_data_to_json": lambda *args, **kwargs: None,
         "normalize_float_bit_depth": normalize_float_bit_depth,
         "normalize_play_record_detail": normalize_play_record_detail,
@@ -387,16 +405,22 @@ class FakeButton:
     def __init__(self):
         self.disabled = None
         self.enabled = None
+        self._enabled_state = True
         self.disabled_values = []
         self.icon_values = []
         self.icon_size_values = []
 
     def setDisabled(self, value):
         self.disabled = value
+        self._enabled_state = not bool(value)
         self.disabled_values.append(bool(value))
 
     def setEnabled(self, value):
         self.enabled = value
+        self._enabled_state = bool(value)
+
+    def isEnabled(self):
+        return self._enabled_state
 
     def setIcon(self, value):
         self.icon_values.append(value)
@@ -739,6 +763,10 @@ def _build_fake_window(namespace, *, use_streaming=True, mode="RECORD_ONLY", res
     window._should_use_streaming_recording = _bind_method(window, namespace, "_should_use_streaming_recording")
     window._start_streaming_recording = _bind_method(window, namespace, "_start_streaming_recording")
     window._normalize_blocking_recorded_data = _bind_method(window, namespace, "_normalize_blocking_recorded_data")
+    window._build_current_wav_calibration_metadata = _bind_method(
+        window, namespace, "_build_current_wav_calibration_metadata"
+    )
+    window._current_metadata_input_channels = _bind_method(window, namespace, "_current_metadata_input_channels")
     window._finish_recording_success = _bind_method(window, namespace, "_finish_recording_success")
     window._finish_recording_failure = _bind_method(window, namespace, "_finish_recording_failure")
     window._start_blocking_recording = _bind_method(window, namespace, "_start_blocking_recording")
@@ -1027,7 +1055,7 @@ def test_existing_sequence_config_without_recording_delay_runs_to_blocking_start
             captured["recorded_dict"] = dict(recorded_dict)
             return namespace["error_code"].OK, np.array([1.0, 2.0], dtype=np.float32)
 
-        def sd_play_rec(self, recorded_dict, stimulus_dict, path):
+        def sd_play_rec(self, recorded_dict, stimulus_dict, path, calibration_metadata=None):
             captured["recorded_dict"] = dict(recorded_dict)
             captured["stimulus_dict"] = dict(stimulus_dict)
             return namespace["error_code"].OK, np.array([1.0, 2.0], dtype=np.float32)
@@ -2019,6 +2047,66 @@ def test_streaming_start_failure_restores_sn_editability():
     assert window.paused_updates == 1
 
 
+def test_replay_streaming_start_failure_restores_buttons_after_disable():
+    namespace = _build_method_namespace()
+    namespace["StreamingWavWriter"] = FakeWavWriter
+
+    def _raise_start_error(*args, **kwargs):
+        raise RuntimeError("stream start failed")
+
+    namespace["stream_record_without_play"] = _raise_start_error
+
+    window = _build_fake_window(namespace, use_streaming=True, mode="RECORD_ONLY")
+
+    window.judge_play_and_record(is_replay=True)
+
+    assert window.replayer_btn.disabled_values == [True]
+    assert window.data_btn.disabled_values == [True]
+    assert window.replayer_btn.enabled is True
+    assert window.data_btn.enabled is True
+    assert window._record_workflow_busy is False
+    assert window.player_status_flag is False
+    assert window.lineedit_s_or_n.isReadOnly() is False
+    assert window.paused_updates == 1
+
+
+@pytest.mark.parametrize("failure_kind", ["reset_exception", "empty_stimulus", "stream_start_exception"])
+def test_replay_startup_failure_preserves_previously_disabled_buttons(failure_kind):
+    namespace = _build_method_namespace()
+    namespace["StreamingWavWriter"] = FakeWavWriter
+    namespace["stream_play_and_record"] = lambda *args, **kwargs: (FakeStreamingProcessor(), [1, 2, 3], None)
+    namespace["stream_record_without_play"] = lambda *args, **kwargs: (FakeStreamingProcessor(), None)
+
+    reset_result = (None, None, None) if failure_kind == "empty_stimulus" else None
+    window = _build_fake_window(namespace, use_streaming=True, mode="RECORD_ONLY", reset_result=reset_result)
+    window.data_btn.setEnabled(False)
+    window.replayer_btn.setEnabled(False)
+
+    if failure_kind == "reset_exception":
+
+        def _raise_reset_error(label, count=None):
+            raise RuntimeError("reset failed")
+
+        window.reset_work_pram = _raise_reset_error
+    elif failure_kind == "stream_start_exception":
+
+        def _raise_start_error(*args, **kwargs):
+            raise RuntimeError("stream start failed")
+
+        namespace["stream_record_without_play"] = _raise_start_error
+
+    window.judge_play_and_record(is_replay=True)
+
+    assert window.replayer_btn.disabled_values == [True]
+    assert window.data_btn.disabled_values == [True]
+    assert window.replayer_btn.enabled is False
+    assert window.data_btn.enabled is False
+    assert window._record_workflow_busy is False
+    assert window.player_status_flag is False
+    assert window.lineedit_s_or_n.isReadOnly() is False
+    assert window.paused_updates == 1
+
+
 def test_missing_streaming_flag_uses_blocking_recording():
     namespace = _build_method_namespace()
     calls = {"stream": 0, "blocking": 0}
@@ -2081,7 +2169,7 @@ def test_play_record_missing_streaming_flag_uses_blocking_recording():
     )
 
     class FakeSoundcardAudioProcessor:
-        def sd_play_rec(self, recorded_dict, stimulus_dict, path):
+        def sd_play_rec(self, recorded_dict, stimulus_dict, path, calibration_metadata=None):
             calls["playrec"] += 1
             return namespace["error_code"].OK, np.array([1.0, 2.0], dtype=np.float32)
 
@@ -2115,6 +2203,9 @@ def test_reset_failure_and_empty_stimulus_restore_sn_editability():
     assert reset_error_window.lineedit_s_or_n.isReadOnly() is False
     assert reset_error_window.barcode_scanner_box.isEnabled() is True
     assert reset_error_window._record_workflow_busy is False
+    assert reset_error_window.player_status_flag is False
+    assert reset_error_window.data_btn.enabled is True
+    assert reset_error_window.replayer_btn.enabled is True
 
     empty_stimulus_window = _build_fake_window(
         namespace,
@@ -2127,6 +2218,9 @@ def test_reset_failure_and_empty_stimulus_restore_sn_editability():
     assert empty_stimulus_window.lineedit_s_or_n.isReadOnly() is False
     assert empty_stimulus_window.barcode_scanner_box.isEnabled() is True
     assert empty_stimulus_window._record_workflow_busy is False
+    assert empty_stimulus_window.player_status_flag is False
+    assert empty_stimulus_window.data_btn.enabled is True
+    assert empty_stimulus_window.replayer_btn.enabled is True
 
 
 def test_streaming_completion_error_restores_sn_editability():
@@ -2453,7 +2547,7 @@ def test_normal_blocking_post_db_split_failure_keeps_output_and_commits_count(tm
     )
 
     class FakeSoundcardAudioProcessor:
-        def sd_play_rec(self, recorded_dict, stimulus_dict, path):
+        def sd_play_rec(self, recorded_dict, stimulus_dict, path, calibration_metadata=None):
             Path(path).write_bytes(b"successful-recording")
             return namespace["error_code"].OK, np.array([1.0, 2.0, 3.0], dtype=np.float32)
 
@@ -2502,7 +2596,7 @@ def test_blocking_replay_post_db_split_failure_keeps_new_output_and_deletes_temp
     )
 
     class FakeSoundcardAudioProcessor:
-        def sd_play_rec(self, recorded_dict, stimulus_dict, path):
+        def sd_play_rec(self, recorded_dict, stimulus_dict, path, calibration_metadata=None):
             Path(path).write_bytes(b"new-replay")
             return namespace["error_code"].OK, np.array([1.0, 2.0, 3.0], dtype=np.float32)
 
@@ -2663,8 +2757,10 @@ def test_blocking_record_only_multi_channel_stores_multi_and_mean_mono():
         save_signal_info_to_db=lambda *args, **kwargs: (namespace["error_code"].OK, "saved")
     )
     saved_audio = []
-    namespace["save_audio_simple"] = lambda path, data, sample_rate: saved_audio.append(
-        (path, np.asarray(data), sample_rate)
+    namespace["save_audio_with_calibration_metadata"] = (
+        lambda path, data, sample_rate, calibration_metadata=None, logger=None, bit_depth=None: saved_audio.append(
+            (path, np.asarray(data), sample_rate, calibration_metadata)
+        )
     )
 
     window = _build_fake_window(namespace, use_streaming=False, mode="RECORD_ONLY")
@@ -2684,7 +2780,7 @@ def test_blocking_play_record_normalizes_frames_by_channels_output():
     recorded = np.array([[1.0, 3.0], [2.0, 4.0]], dtype=np.float32)
 
     class FakeSoundcardAudioProcessor:
-        def sd_play_rec(self, recorded_dict, stimulus_dict, path):
+        def sd_play_rec(self, recorded_dict, stimulus_dict, path, calibration_metadata=None):
             return namespace["error_code"].OK, recorded
 
     namespace["SoundcardAudioProcessor"] = FakeSoundcardAudioProcessor
@@ -2707,7 +2803,7 @@ def test_blocking_play_record_transposes_channel_by_frames_output():
     recorded_transposed = np.array([[1.0, 2.0, 3.0], [11.0, 12.0, 13.0]], dtype=np.float32)
 
     class FakeSoundcardAudioProcessor:
-        def sd_play_rec(self, recorded_dict, stimulus_dict, path):
+        def sd_play_rec(self, recorded_dict, stimulus_dict, path, calibration_metadata=None):
             return namespace["error_code"].OK, recorded_transposed
 
     namespace["SoundcardAudioProcessor"] = FakeSoundcardAudioProcessor

--- a/unit_test/ui/test_signal_analysis_v2pa_resolution.py
+++ b/unit_test/ui/test_signal_analysis_v2pa_resolution.py
@@ -1,10 +1,16 @@
 import os
+import sys
 import types
+from pathlib import Path
 
 import numpy as np
 import pytest
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from PyQt5.QtWidgets import QApplication
 
@@ -13,6 +19,10 @@ from ui import signal_analysis_window as saw
 
 @pytest.fixture
 def qapp():
+    data_struct = saw.DataDealStruct()
+    data_struct.wav_calibration_metadata = None
+    data_struct.wav_calibration_metadata_authoritative = False
+    data_struct.wav_calibration_warning_shown = False
     return QApplication.instance() or QApplication([])
 
 
@@ -208,6 +218,73 @@ def test_resolver_failure_does_not_reuse_stale_v2pa_factor(qapp, monkeypatch):
     assert warnings == ["registered microphone hardware_id is required for calibration"]
 
 
+def test_imported_wav_metadata_factor_is_used_without_database(qapp, monkeypatch):
+    warnings = []
+    widget = saw.Spl("SPL")
+    widget.data_struct.sample_rate = 48000
+    widget.data_struct.store_wave_data_multi = np.ones((8, 1), dtype=np.float32)
+    widget.data_struct.wav_calibration_metadata_authoritative = True
+    widget.data_struct.wav_calibration_metadata = {
+        "recorded_channels": [
+            {"wav_channel_index": 0, "v2pa_factor": 2.5, "standard_spl": 94.0, "calibrated": True}
+        ]
+    }
+    widget.analysis_config = {"analysis_channel": 0}
+    monkeypatch.setattr(saw.MessageBox, "warning", lambda parent, title, message: warnings.append(message))
+    monkeypatch.setattr(
+        saw,
+        "resolve_analysis_v2pa_factor_for_channel",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("database resolver must not be called")),
+    )
+
+    assert widget._resolve_v2pa_factor_for_analysis() is True
+    assert widget.v2pa_factor == 2.5
+
+
+def test_imported_wav_missing_metadata_uses_one_without_database(qapp, monkeypatch):
+    warnings = []
+    widget = saw.Spl("SPL")
+    widget.data_struct.wav_calibration_metadata_authoritative = True
+    widget.data_struct.wav_calibration_metadata = None
+    widget.data_struct.wav_calibration_warning_shown = True
+    widget.analysis_config = {"analysis_channel": 0}
+    monkeypatch.setattr(saw.MessageBox, "warning", lambda parent, title, message: warnings.append(message))
+    monkeypatch.setattr(
+        saw,
+        "resolve_analysis_v2pa_factor_for_channel",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("database resolver must not be called")),
+    )
+
+    assert widget._resolve_v2pa_factor_for_analysis() is True
+    assert widget.v2pa_factor == 1.0
+    assert warnings == []
+
+
+def test_imported_wav_uncalibrated_channel_warns_once_without_database(qapp, monkeypatch):
+    warnings = []
+    widget = saw.Spl("SPL")
+    widget.data_struct.wav_calibration_metadata_authoritative = True
+    widget.data_struct.wav_calibration_metadata = {
+        "recorded_channels": [
+            {"wav_channel_index": 0, "v2pa_factor": None, "standard_spl": None, "calibrated": False}
+        ]
+    }
+    widget.data_struct.wav_calibration_warning_shown = False
+    widget.analysis_config = {"analysis_channel": 0}
+    monkeypatch.setattr(saw.MessageBox, "warning", lambda parent, title, message: warnings.append(message))
+    monkeypatch.setattr(
+        saw,
+        "resolve_analysis_v2pa_factor_for_channel",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("database resolver must not be called")),
+    )
+
+    assert widget._resolve_v2pa_factor_for_analysis() is True
+    assert widget.v2pa_factor == 1.0
+    assert widget.data_struct.wav_calibration_warning_shown is True
+    assert widget._resolve_v2pa_factor_for_analysis() is True
+    assert warnings == ["该音频文件未包含有效校准数据，分析结果仅供参考。"]
+
+
 def test_distortion_standard_thd_does_not_resolve_v2pa(qapp, monkeypatch):
     warnings = []
     plot_calls = []
@@ -370,6 +447,48 @@ def test_peak_detection_direct_analysis_passes_resolved_v2pa(qapp, monkeypatch):
     assert result["spl_db_series"].tolist() == [60.0, 61.0]
 
 
+def test_peak_detection_imported_wav_uses_selected_channel_signal_and_metadata(qapp, monkeypatch):
+    captured = {}
+    channel_0 = np.array([0.0, 10.0, 20.0, 30.0], dtype=np.float64)
+    channel_1 = np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float64)
+
+    def fake_peak_detection(recorded_signal, sample_rate, analysis_config, *, v2pa_factor):
+        captured["recorded_signal"] = np.asarray(recorded_signal)
+        captured["v2pa_factor"] = v2pa_factor
+        captured["analysis_config"] = dict(analysis_config)
+        return {
+            "peaks_index": [],
+            "peaks_time_sec": [],
+            "spl_db_series": np.array([60.0, 61.0, 62.0, 63.0]),
+        }
+
+    widget = saw.PeakDetection("PD")
+    widget.data_struct.sample_rate = 48000
+    widget.data_struct.store_wave_data_multi = np.column_stack([channel_0, channel_1])
+    widget.data_struct.store_wave_data = np.mean(widget.data_struct.store_wave_data_multi, axis=1)
+    widget.data_struct.wav_calibration_metadata_authoritative = True
+    widget.data_struct.wav_calibration_metadata = {
+        "recorded_channels": [
+            {"wav_channel_index": 1, "v2pa_factor": 7.25, "standard_spl": 94.0, "calibrated": True}
+        ]
+    }
+    widget.analysis_config = {"analysis_channel": 1}
+
+    monkeypatch.setattr(saw, "peak_detection", fake_peak_detection)
+    monkeypatch.setattr(
+        saw,
+        "resolve_analysis_v2pa_factor_for_channel",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("database resolver must not be called")),
+    )
+
+    result = widget.calculate_peak_detection()
+
+    np.testing.assert_allclose(captured["recorded_signal"], channel_1)
+    assert captured["v2pa_factor"] == 7.25
+    assert captured["analysis_config"] == {"analysis_channel": 1}
+    assert result["spl_db_series"].tolist() == [60.0, 61.0, 62.0, 63.0]
+
+
 @pytest.mark.parametrize(
     "factor, resolver_warning, expected_warnings",
     [
@@ -418,6 +537,162 @@ def test_pipeline_pd_pm_passes_resolved_v2pa_to_embedded_peak_detection(
     assert result["total"] == 0
 
 
+def test_pipeline_pd_pm_imported_wav_metadata_factor_is_used_without_database(qapp, monkeypatch):
+    warnings = []
+    captured = {}
+
+    class FakePatternMatch:
+        pass
+
+    def fake_peak_detection(recorded_signal, sample_rate, analysis_config, *, v2pa_factor):
+        captured["v2pa_factor"] = v2pa_factor
+        return {
+            "peaks_index": [],
+            "peaks_time_sec": [],
+            "spl_db_series": np.array([60.0, 61.0]),
+        }
+
+    widget = saw.PipelinePdPm("PD+PM")
+    widget.data_struct.sample_rate = 48000
+    widget.data_struct.store_wave_data = np.ones(32, dtype=np.float64)
+    widget.data_struct.wav_calibration_metadata_authoritative = True
+    widget.data_struct.wav_calibration_metadata = {
+        "recorded_channels": [
+            {"wav_channel_index": 3, "v2pa_factor": 3.75, "standard_spl": 94.0, "calibrated": True}
+        ]
+    }
+    widget.analysis_config = {
+        "head": {"config": {"analysis_channel": 3}},
+        "tail": {"config": {}},
+        "pass_condition": {},
+    }
+
+    monkeypatch.setattr(saw, "peak_detection", fake_peak_detection)
+    monkeypatch.setattr(saw, "get_class_mapping", lambda: {"PD": saw.PeakDetection, "PM": FakePatternMatch})
+    monkeypatch.setattr(saw.MessageBox, "warning", lambda parent, title, message: warnings.append(message))
+    monkeypatch.setattr(
+        saw,
+        "resolve_analysis_v2pa_factor_for_channel",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("database resolver must not be called")),
+    )
+
+    result = widget.calculate_pipeline_pd_pm()
+
+    assert captured["v2pa_factor"] == 3.75
+    assert warnings == []
+    assert result["total"] == 0
+
+
+def test_pipeline_pd_pm_imported_wav_uses_selected_channel_signal_and_metadata(qapp, monkeypatch):
+    warnings = []
+    captured = {}
+    channel_0 = np.array([0.0, 10.0, 20.0, 30.0, 40.0, 50.0], dtype=np.float64)
+    channel_1 = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], dtype=np.float64)
+
+    class FakePatternMatch:
+        def __init__(self, title_name):
+            self.title_name = title_name
+
+        def calculate_pattern_match(self, target_data, analysis_config):
+            captured["pm_target_data"] = np.asarray(target_data)
+            captured["pm_config"] = dict(analysis_config)
+            return {"is_match": True, "score": 0.9, "threshold": 0.5}
+
+    def fake_peak_detection(recorded_signal, sample_rate, analysis_config, *, v2pa_factor):
+        captured["pd_recorded_signal"] = np.asarray(recorded_signal)
+        captured["v2pa_factor"] = v2pa_factor
+        captured["analysis_config"] = dict(analysis_config)
+        return {
+            "peaks_index": [2],
+            "peaks_time_sec": [2 / sample_rate],
+            "spl_db_series": np.array([60.0, 61.0, 62.0, 63.0, 64.0, 65.0]),
+        }
+
+    widget = saw.PipelinePdPm("PD+PM")
+    widget.data_struct.sample_rate = 48000
+    widget.data_struct.store_wave_data_multi = np.column_stack([channel_0, channel_1])
+    widget.data_struct.store_wave_data = np.mean(widget.data_struct.store_wave_data_multi, axis=1)
+    widget.data_struct.wav_calibration_metadata_authoritative = True
+    widget.data_struct.wav_calibration_metadata = {
+        "recorded_channels": [
+            {"wav_channel_index": 1, "v2pa_factor": 3.75, "standard_spl": 94.0, "calibrated": True}
+        ]
+    }
+    widget.analysis_config = {
+        "head": {"config": {"analysis_channel": 1}},
+        "tail": {"config": {"threshold": 0.5}},
+        "left_grid": 1,
+        "right_grid": 2,
+        "pass_condition": {},
+    }
+
+    monkeypatch.setattr(saw, "peak_detection", fake_peak_detection)
+    monkeypatch.setattr(saw, "get_class_mapping", lambda: {"PD": saw.PeakDetection, "PM": FakePatternMatch})
+    monkeypatch.setattr(saw.MessageBox, "warning", lambda parent, title, message: warnings.append(message))
+    monkeypatch.setattr(
+        saw,
+        "resolve_analysis_v2pa_factor_for_channel",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("database resolver must not be called")),
+    )
+
+    result = widget.calculate_pipeline_pd_pm()
+
+    np.testing.assert_allclose(captured["pd_recorded_signal"], channel_1)
+    np.testing.assert_allclose(captured["pm_target_data"], channel_1[1:4])
+    assert captured["v2pa_factor"] == 3.75
+    assert captured["analysis_config"] == {"analysis_channel": 1}
+    assert captured["pm_config"] == {"threshold": 0.5}
+    assert warnings == []
+    assert result["total"] == 1
+    assert result["matched"] == 1
+
+
+def test_pipeline_pd_pm_imported_wav_missing_metadata_warns_once_without_database(qapp, monkeypatch):
+    warnings = []
+    captured = {}
+
+    class FakePatternMatch:
+        pass
+
+    def fake_peak_detection(recorded_signal, sample_rate, analysis_config, *, v2pa_factor):
+        captured["v2pa_factor"] = v2pa_factor
+        return {
+            "peaks_index": [],
+            "peaks_time_sec": [],
+            "spl_db_series": np.array([60.0, 61.0]),
+        }
+
+    widget = saw.PipelinePdPm("PD+PM")
+    widget.data_struct.sample_rate = 48000
+    widget.data_struct.store_wave_data = np.ones(32, dtype=np.float64)
+    widget.data_struct.wav_calibration_metadata_authoritative = True
+    widget.data_struct.wav_calibration_metadata = None
+    widget.data_struct.wav_calibration_warning_shown = False
+    widget.analysis_config = {
+        "head": {"config": {"analysis_channel": 0}},
+        "tail": {"config": {}},
+        "pass_condition": {},
+    }
+
+    monkeypatch.setattr(saw, "peak_detection", fake_peak_detection)
+    monkeypatch.setattr(saw, "get_class_mapping", lambda: {"PD": saw.PeakDetection, "PM": FakePatternMatch})
+    monkeypatch.setattr(saw.MessageBox, "warning", lambda parent, title, message: warnings.append(message))
+    monkeypatch.setattr(
+        saw,
+        "resolve_analysis_v2pa_factor_for_channel",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("database resolver must not be called")),
+    )
+
+    first = widget.calculate_pipeline_pd_pm()
+    second = widget.calculate_pipeline_pd_pm()
+
+    assert captured["v2pa_factor"] == 1.0
+    assert first["total"] == 0
+    assert second["total"] == 0
+    assert widget.data_struct.wav_calibration_warning_shown is True
+    assert warnings == ["该音频文件未包含有效校准数据，分析结果仅供参考。"]
+
+
 def test_frequency_band_analysis_direct_analysis_passes_resolved_v2pa(qapp, monkeypatch):
     resolver_calls = _install_resolver(monkeypatch, factor=6.5)
     captured = {}
@@ -448,3 +723,110 @@ def test_frequency_band_analysis_direct_analysis_passes_resolved_v2pa(qapp, monk
     assert resolver_calls == [7]
     assert captured["v2pa_factor"] == 6.5
     assert result["band_levels_db"] == [70.0]
+
+
+def _install_loudness_result(monkeypatch, captured):
+    def fake_run_sound_quality(recorded_signal, sample_rate, *, project_v2pa_factor, sq_config):
+        captured["project_v2pa_factor"] = project_v2pa_factor
+        raw = types.SimpleNamespace(
+            time_s=np.array([0.0], dtype=np.float64),
+            loudness_sone=np.array([1.0], dtype=np.float64),
+            loudness_level_phon=np.array([40.0], dtype=np.float64),
+            metadata={},
+        )
+        return types.SimpleNamespace(
+            loudness=types.SimpleNamespace(
+                enabled=True,
+                raw_result=raw,
+                summary={},
+                display_payload={},
+                skipped_reason=None,
+            ),
+            skipped_reason=None,
+        )
+
+    monkeypatch.setattr(saw, "run_sound_quality", fake_run_sound_quality)
+    monkeypatch.setattr(saw.LoudnessAnalysis, "_plot_loudness_curve", lambda *args, **kwargs: None)
+    monkeypatch.setattr(saw.LoudnessAnalysis, "_apply_loudness_limits", lambda *args, **kwargs: None)
+
+
+def test_loudness_imported_wav_metadata_factor_is_used_without_database(qapp, monkeypatch):
+    warnings = []
+    captured = {}
+    _install_loudness_result(monkeypatch, captured)
+
+    widget = _recording_widget(saw.LoudnessAnalysis("LOUD"), analysis_channel=0)
+    widget.data_struct.wav_calibration_metadata_authoritative = True
+    widget.data_struct.wav_calibration_metadata = {
+        "recorded_channels": [
+            {"wav_channel_index": 0, "v2pa_factor": 2.25, "standard_spl": 94.0, "calibrated": True}
+        ]
+    }
+    monkeypatch.setattr(saw.MessageBox, "warning", lambda parent, title, message: warnings.append(message))
+    monkeypatch.setattr(
+        saw,
+        "resolve_analysis_v2pa_factor_for_channel",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("database resolver must not be called")),
+    )
+
+    result = widget.calculate_loudness()
+
+    assert captured["project_v2pa_factor"] == 2.25
+    assert widget.v2pa_factor == 2.25
+    assert result["loudness_sone"] == [1.0]
+    assert warnings == []
+
+
+def test_loudness_imported_wav_uncalibrated_metadata_uses_one_and_warns_once(qapp, monkeypatch):
+    warnings = []
+    captured = {}
+    _install_loudness_result(monkeypatch, captured)
+
+    widget = _recording_widget(saw.LoudnessAnalysis("LOUD"), analysis_channel=0)
+    widget.data_struct.wav_calibration_metadata_authoritative = True
+    widget.data_struct.wav_calibration_metadata = {
+        "recorded_channels": [
+            {"wav_channel_index": 0, "v2pa_factor": None, "standard_spl": None, "calibrated": False}
+        ]
+    }
+    widget.data_struct.wav_calibration_warning_shown = False
+    monkeypatch.setattr(saw.MessageBox, "warning", lambda parent, title, message: warnings.append(message))
+    monkeypatch.setattr(
+        saw,
+        "resolve_analysis_v2pa_factor_for_channel",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("database resolver must not be called")),
+    )
+
+    first = widget.calculate_loudness()
+    second = widget.calculate_loudness()
+
+    assert captured["project_v2pa_factor"] == 1.0
+    assert widget.v2pa_factor == 1.0
+    assert first["loudness_sone"] == [1.0]
+    assert second["loudness_sone"] == [1.0]
+    assert widget.data_struct.wav_calibration_warning_shown is True
+    assert warnings == ["该音频文件未包含有效校准数据，分析结果仅供参考。"]
+
+
+def test_loudness_imported_wav_missing_metadata_uses_one_without_database(qapp, monkeypatch):
+    warnings = []
+    captured = {}
+    _install_loudness_result(monkeypatch, captured)
+
+    widget = _recording_widget(saw.LoudnessAnalysis("LOUD"), analysis_channel=0)
+    widget.data_struct.wav_calibration_metadata_authoritative = True
+    widget.data_struct.wav_calibration_metadata = None
+    widget.data_struct.wav_calibration_warning_shown = True
+    monkeypatch.setattr(saw.MessageBox, "warning", lambda parent, title, message: warnings.append(message))
+    monkeypatch.setattr(
+        saw,
+        "resolve_analysis_v2pa_factor_for_channel",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("database resolver must not be called")),
+    )
+
+    result = widget.calculate_loudness()
+
+    assert captured["project_v2pa_factor"] == 1.0
+    assert widget.v2pa_factor == 1.0
+    assert result["loudness_sone"] == [1.0]
+    assert warnings == []


### PR DESCRIPTION
## Summary
- Add WAV calibration metadata read/write support for recorded audio files.
- Persist calibration snapshots through blocking and streaming recording flows.
- Use imported WAV calibration metadata during SPL, peak detection, pipeline, and loudness analysis.
- Add regression coverage for metadata serialization, channel projection, recording/replay flows, and imported-WAV analysis resolution.

## Test Plan
- `$env:QT_QPA_PLATFORM='offscreen'; python -m pytest --basetemp 'D:\dongyuan_ditting\pytest_tmp\speaker-anomaly' unit_test/base/test_alignment_processing.py unit_test/base/test_play_and_record_channel_forwarding.py unit_test/base/test_recording_calibration_snapshot.py unit_test/base/test_soundcard_audio_processor.py unit_test/base/test_wav_calibration_metadata.py unit_test/ui/test_operation_sequence_recording_delay.py unit_test/ui/test_operation_sequence_samplerate_authority.py unit_test/ui/test_sequence_channel_calibration.py unit_test/ui/test_sequence_import_analysis_sample_rate.py unit_test/ui/test_sequence_wav_calibration_metadata.py unit_test/ui/test_sequence_widget_sample_rate_authority.py unit_test/ui/test_sequence_widget_sn_lock.py unit_test/ui/test_signal_analysis_v2pa_resolution.py` -> 310 passed, 18 warnings
- `git diff --cached --check` -> passed before commit

Closes #765