### PR TITLE
US20260713-integrate-manual-limits-and-audio-runtime-fixes

### DIFF
--- a/base/recording_management.py
+++ b/base/recording_management.py
@@ -31,6 +31,33 @@ def _frequency_stepped_insert_metadata(insert_values):
     return json.loads(insert_data["stimulus_metadata_json"])
 
 
+def _is_blank_stimulus_name(value):
+    return value is None or not str(value).strip()
+
+
+def _frequency_stepped_auto_stimulus_name(row_data):
+    stimulus_id = str(row_data.get("stimulus_id") or "")
+    stimulus_type = row_data.get("stimulus_type") or "frequency_stepped"
+    start_freq = row_data.get("start_freq")
+    stop_freq = row_data.get("stop_freq")
+    num_steps = row_data.get("num_steps")
+    id_prefix = stimulus_id.split("-")[0] if stimulus_id else "auto"
+    return f"step_sc-{stimulus_type}-{start_freq}-{stop_freq}-{num_steps}-{id_prefix}"
+
+
+def _frequency_stepped_row_with_fallback_name(generated_row):
+    row_data = dict(zip(model_consts.DB_STIMULUS_COLUMNS, generated_row))
+    if not _is_blank_stimulus_name(row_data.get("stimulus_name")):
+        return generated_row
+
+    stimulus_name = _frequency_stepped_auto_stimulus_name(row_data)
+    metadata = json.loads(row_data["stimulus_metadata_json"])
+    metadata["stimulus_name"] = stimulus_name
+    row_data["stimulus_name"] = stimulus_name
+    row_data["stimulus_metadata_json"] = json.dumps(metadata, ensure_ascii=False)
+    return tuple(row_data[column] for column in model_consts.DB_STIMULUS_COLUMNS)
+
+
 class RecordingManager(object):
     def __init__(self):
         self._db_path_override = None
@@ -150,6 +177,7 @@ class RecordingManager(object):
         is_default = database.set_default("stimulus_signal_table")
         stimulus_data = frequency_stepped_insert_values(stimulus_parameter, is_default)
         stimulus_data = database.get_data_id([stimulus_data], 0)
+        stimulus_data = [_frequency_stepped_row_with_fallback_name(stimulus_data[0])]
         return stimulus_data, True
 
     @staticmethod

--- a/main_window.py
+++ b/main_window.py
@@ -102,7 +102,6 @@ class MainWindow(QMainWindow):
     def set_title(self):
         # hide the window title bar and reset the window title bar
         self.setWindowFlags(Qt.FramelessWindowHint)
-        self.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
         title_layout = QHBoxLayout()
         title_btn_layout = self.set_title_btn()
         icon_label = Label()

--- a/main_window.py
+++ b/main_window.py
@@ -94,8 +94,9 @@ class MainWindow(QMainWindow):
         self.on_access_lvl_changed()
         self.show_statusbar_layout()
         self.showMaximized()
-        self.on_login_window_init()
-        self._schedule_startup_device_recovery_if_needed()
+        login_succeeded = self.on_login_window_init()
+        if login_succeeded:
+            self._schedule_startup_device_recovery_if_needed()
         self.sequence_window.refresh_channel_windows()
 
     def set_title(self):
@@ -410,11 +411,13 @@ class MainWindow(QMainWindow):
         # check the user info, if the user info is correct, then show the main window
         dlg = LoginWindow()
         access_lvl, user_name = dlg.on_exec()
-        if access_lvl is not None:
+        login_succeeded = access_lvl is not None
+        if login_succeeded:
             self.access_lvl, self.user_name = access_lvl, user_name
             self.sequence_window.show()
             self.update_statusbar()
         self.on_access_lvl_changed()
+        return login_succeeded
 
     @staticmethod
     def on_add_account_window_init():

--- a/main_window_Launcher.py
+++ b/main_window_Launcher.py
@@ -1,6 +1,7 @@
 import sys
 
 from PyQt5.QtCore import QThread, QFile, QTextStream
+from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import QApplication
 from ui.splash_screen_window import Splash, LoaderThread
 
@@ -11,6 +12,7 @@ from ui.ui_src import ui_resources
 class MainWindowLauncher(object):
     def __init__(self):
         self.app = QApplication(sys.argv)
+        self.app.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
         qss = self.load_qss()
         self.app.setStyleSheet(qss)
         self.splash = Splash()

--- a/ui/acquisition_config_window.py
+++ b/ui/acquisition_config_window.py
@@ -4,7 +4,6 @@ from copy import deepcopy
 from base.log_manager import LogManager
 
 from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QGridLayout, QApplication, QSizePolicy
 
 
@@ -29,7 +28,6 @@ from ui.custom_ui_widget.widgets import (
     MessageBox,
 )
 from ui.stimulus_window import StimulusWindow
-from ui.ui_src import ui_resources
 
 
 class BaseConfigWindow(QDialog):
@@ -43,7 +41,6 @@ class BaseConfigWindow(QDialog):
 
     def setup_ui(self):
         self.setWindowFlag(Qt.WindowContextHelpButtonHint, False)
-        self.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
         self.setMinimumSize(200, 270)
         self.resize(350, 350)
         self.main_layout = QVBoxLayout(self)

--- a/ui/ai_window.py
+++ b/ui/ai_window.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 from PyQt5.QtCore import QEventLoop, QThread, QTimer, Qt, pyqtSignal
-from PyQt5.QtGui import QIcon, QTextCursor
+from PyQt5.QtGui import QTextCursor
 from PyQt5.QtWidgets import (
     QApplication,
     QDialog,
@@ -24,7 +24,6 @@ from consts.running_consts import DEFAULT_DIR
 from ui.custom_ui_widget.widgets import PushButton, GroupBox, Label, LineEdit, ComboBox, RadioButton, MessageBox
 from ui.model_manager_widget import ModelInfoList
 from ui.ai_select_audio_data import SelectAudioDataView
-from ui.ui_src import ui_resources
 
 default_log = LogManager.set_log_handler("train")
 
@@ -64,7 +63,6 @@ class AiWindow(QDialog):
         Connect signals and slots.
         """
         self.setObjectName("AiWindow")
-        self.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
         self.setWindowTitle("AI训练窗口")
         self.setWindowFlag(Qt.WindowContextHelpButtonHint, False)
         window_width = ui_style_const.scale_size_px(730)
@@ -816,7 +814,6 @@ class AiBrainModelStructure(QDialog):
 
     def init_ui(self):
         self.setWindowTitle("AI模型结构")
-        self.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
         self.setWindowFlag(Qt.WindowContextHelpButtonHint, False)
         layout = self.create_text_edit()
         self.setLayout(layout)
@@ -851,7 +848,6 @@ class Process_Widget(QDialog):
 
     def init_ui(self):
         self.setWindowTitle("训练评估")
-        self.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
         layout = self.create_text_edit()
         self.setLayout(layout)
 

--- a/ui/calibration_window.py
+++ b/ui/calibration_window.py
@@ -3,7 +3,6 @@ import threading
 
 import numpy as np
 from PyQt5.QtCore import Qt, QTimer
-from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import QApplication, QDialog, QGridLayout, QHBoxLayout, QVBoxLayout, QWidget
 
 from base.audio_sample_rate import resolve_input_sample_rate
@@ -33,7 +32,6 @@ from ui.custom_ui_widget.widgets import (
     GroupBox,
     MessageBox,
 )
-from ui.ui_src import ui_resources
 
 
 class CalibrationWindow(QDialog):
@@ -49,7 +47,6 @@ class CalibrationWindow(QDialog):
         and creates tabs for output and input calibration.
         """
         self.setObjectName("CalibrationWindow")
-        self.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
         self.setWindowTitle("校准窗口")
         self.setWindowFlag(Qt.WindowContextHelpButtonHint, False)
         self.setMinimumSize(500, 550)

--- a/ui/custom_ui_widget/audio_clip_extraction_dialog.py
+++ b/ui/custom_ui_widget/audio_clip_extraction_dialog.py
@@ -3,7 +3,7 @@ import sys
 import librosa
 import numpy as np
 from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QCursor, QIcon
+from PyQt5.QtGui import QCursor
 from PyQt5.QtWidgets import QDialog, QHBoxLayout, QToolTip, QVBoxLayout, QApplication, QFileDialog
 import pyqtgraph as pg
 
@@ -12,7 +12,6 @@ from base.save_data import save_audio_simple
 from consts.running_consts import DEFAULT_DIR
 from ui.custom_ui_widget.widgets import PushButton, LineEdit, CheckBox, DoubleSpinBox, MessageBox
 from ui.graph_widget import DraggablePlotWidget
-from ui.ui_src import ui_resources
 
 
 class AudioClipExtractionDialog(QDialog):
@@ -44,7 +43,6 @@ class AudioClipExtractionDialog(QDialog):
 
     def init_ui(self):
         self.setWindowTitle(self.dialog_title)
-        self.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
         self.setWindowFlags(Qt.WindowCloseButtonHint | Qt.WindowMinimizeButtonHint)
         self.open_file_layout = self.create_open_file_layout()
         self.plot_widget = self.create_plot_widget()

--- a/ui/custom_ui_widget/audio_data_manage_dialog.py
+++ b/ui/custom_ui_widget/audio_data_manage_dialog.py
@@ -32,16 +32,13 @@ import copy
 from re import fullmatch
 
 from PyQt5.QtCore import Qt, pyqtSignal
-from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout
 
 from base.log_manager import LogManager
 from base.recording_management import RecordingManager
 from consts import error_code
-from consts.running_consts import DEFAULT_DIR
 from ui.custom_ui_widget.custom_table_widget import DataManageDialog
 from ui.custom_ui_widget.widgets import PushButton, CheckBox, GroupBox, ComboBox, MessageBox
-from ui.ui_src import ui_resources
 
 
 class AudioDataManageDialog(DataManageDialog):
@@ -264,7 +261,6 @@ class FilterAudioDialog(QDialog):
 
     def init_ui(self):
         self.setWindowTitle("筛选")
-        self.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
         self.setWindowFlags(Qt.WindowCloseButtonHint | Qt.WindowMinimizeButtonHint)
         self.resize(300, 300)
 

--- a/ui/custom_ui_widget/custom_plot_layout_widget.py
+++ b/ui/custom_ui_widget/custom_plot_layout_widget.py
@@ -1,10 +1,8 @@
 import pyqtgraph as pg
-from PyQt5.QtGui import QIcon, QFont
+from PyQt5.QtGui import QFont
 from PyQt5.QtWidgets import QVBoxLayout, QWidget
 
-from consts.running_consts import DEFAULT_DIR
 from ui.graph_widget import custom_log_tick_strings
-from ui.ui_src import ui_resources
 
 
 class AnalysisGraphWidget(QWidget):
@@ -18,8 +16,6 @@ class AnalysisGraphWidget(QWidget):
         self.init_ui()
 
     def init_ui(self):
-        self.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
-
         self.analysis_plot.setBackground("white")
 
         layout = QVBoxLayout()

--- a/ui/custom_ui_widget/custom_table_widget.py
+++ b/ui/custom_ui_widget/custom_table_widget.py
@@ -74,13 +74,10 @@
 """
 
 from PyQt5.QtCore import Qt, pyqtSignal
-from PyQt5.QtGui import QIcon, QStandardItemModel, QStandardItem
+from PyQt5.QtGui import QStandardItemModel, QStandardItem
 from PyQt5.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QHeaderView
 
-from base.log_manager import LogManager
-from consts.running_consts import DEFAULT_DIR
 from ui.custom_ui_widget.widgets import MessageBox, TableView, Label
-from ui.ui_src import ui_resources
 
 
 class DataManageDialog(QDialog):
@@ -97,7 +94,6 @@ class DataManageDialog(QDialog):
         self.column_alignment = dict()
 
     def init_ui_layout(self, row: int, column: int, editable_column: list[int]):
-        self.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
         self.setWindowFlags(Qt.WindowCloseButtonHint | Qt.WindowMinimizeButtonHint)
         self.resize(900, 350)
 

--- a/ui/custom_ui_widget/widgets.py
+++ b/ui/custom_ui_widget/widgets.py
@@ -342,9 +342,14 @@ class TableWidget(QTableWidget):
         self.font = QFont()
         self.font.setFamily("SimSun")
         self.font.setPixelSize(self.font_size)
+        self._apply_font()
+
+    def _apply_font(self):
         self.setFont(self.font)
+        self.horizontalHeader().setFont(self.font)
+        self.verticalHeader().setFont(self.font)
 
     def set_font_size(self, font_size):
         self.font_size = scale_size_px(font_size)
         self.font.setPixelSize(self.font_size)
-        self.setFont(self.font)
+        self._apply_font()

--- a/ui/hardware_window.py
+++ b/ui/hardware_window.py
@@ -3,7 +3,6 @@ from dataclasses import dataclass
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from PyQt5.QtCore import Qt, pyqtSignal
-from PyQt5.QtGui import QIcon
 from PyQt5.QtGui import QStandardItemModel, QStandardItem
 from PyQt5.QtWidgets import QDialog, QHeaderView, QHBoxLayout, QVBoxLayout
 
@@ -266,7 +265,6 @@ class HardwareSelectionView(QDialog):
         self._init_ui()
 
     def _init_ui(self) -> None:
-        self.setWindowIcon(QIcon(DEFAULT_DIR + "ui/ui_pic/logo_pic/ting.ico"))
         self.setWindowTitle("硬件选择")
         self.setWindowFlags(Qt.WindowCloseButtonHint | Qt.WindowMinimizeButtonHint)
 

--- a/ui/login_window.py
+++ b/ui/login_window.py
@@ -2,7 +2,7 @@ import hashlib
 import sys
 
 from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QColor, QIcon, QPainter, QPixmap
+from PyQt5.QtGui import QColor, QPainter, QPixmap
 from PyQt5.QtWidgets import QApplication, QDialog, QHBoxLayout, QSizePolicy, QVBoxLayout
 
 from base.db_manager import DataSave, ensure_system_database_ready
@@ -11,7 +11,6 @@ from base.log_manager import LogManager
 from consts import error_code, model_consts
 from consts.running_consts import DEFAULT_DIR
 from ui.custom_ui_widget.widgets import PushButton, ComboBox, LineEdit, Label, MessageBox
-from ui.ui_src import ui_resources
 
 
 ACCESS_LVL_DICT = {"管理员": "Admin", "工程师": "Engineer", "操作员": "Operator"}
@@ -28,7 +27,6 @@ class LoginWindow(QDialog):
         self.init_ui()
 
     def init_ui(self):
-        self.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
         self.setWindowTitle("登录")
         self.setMaximumSize(600, 600)
         self.setMinimumSize(300, 400)
@@ -208,7 +206,6 @@ class AddAccountWindow(QDialog):
         self.init_ui()
 
     def init_ui(self):
-        self.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
         self.setWindowTitle("添加账号")
         self.setFixedSize(350, 240)
         layout = QVBoxLayout()
@@ -317,7 +314,6 @@ class ChangePwdWindow(QDialog):
         self.init_ui()
 
     def init_ui(self):
-        self.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
         self.setWindowTitle("修改密码")
         self.setFixedSize(350, 200)
 

--- a/ui/model_manager_widget.py
+++ b/ui/model_manager_widget.py
@@ -4,7 +4,7 @@ import os
 import sys
 
 from PyQt5.QtCore import Qt, QSize
-from PyQt5.QtGui import QStandardItemModel, QIcon
+from PyQt5.QtGui import QStandardItemModel
 from PyQt5.QtWidgets import QApplication, QFileDialog, QDialog, QVBoxLayout, QHBoxLayout, QSizePolicy
 
 from base.file_ops import FileOps
@@ -15,7 +15,6 @@ from consts.running_consts import DEFAULT_DIR
 from machine_learning.model_builder import build_and_save_model_from_config
 from ui.custom_ui_widget.custom_table_widget import DataManageDialog
 from ui.custom_ui_widget.widgets import PushButton, ComboBox, LineEdit, Label, GroupBox, MessageBox
-from ui.ui_src import ui_resources
 
 
 def setdata(model, index, value, role=Qt.EditRole):
@@ -341,7 +340,6 @@ class SetModelConfig(QDialog):
     def init_ui(self):
         self.setWindowTitle("设置模型信息")
         self.setMinimumWidth(600)
-        self.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
         self.setWindowFlag(Qt.WindowContextHelpButtonHint, False)
         if self.dim:
             self.input_dim_left = self.dim["input_left"]

--- a/ui/operation_sequence.py
+++ b/ui/operation_sequence.py
@@ -208,7 +208,6 @@ class AnalysisModelSelect(QDialog):
 
     def init_ui(self):
         self.setObjectName("OperationSequenceDialog")
-        self.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
         self.setWindowFlag(Qt.WindowContextHelpButtonHint, False)
         self.setWindowTitle("测试队列")
 

--- a/ui/sequence/sequence_widget.py
+++ b/ui/sequence/sequence_widget.py
@@ -100,9 +100,12 @@ def _missing_file_calibration_warning_text():
     return "该音频文件未包含有效校准数据，分析结果仅供参考。"
 
 
-def _clear_sequence_stimulus_runtime_state(window, *, clear_sample_rate: bool = True) -> None:
+def _clear_sequence_stimulus_runtime_state(
+    window, *, clear_sample_rate: bool = True, clear_wav_calibration: bool = True
+) -> None:
     _clear_data_struct_stimulus_runtime_state(getattr(window, "data_struct", None), clear_sample_rate=clear_sample_rate)
-    _clear_wav_calibration_runtime_state(getattr(window, "data_struct", None))
+    if clear_wav_calibration:
+        _clear_wav_calibration_runtime_state(getattr(window, "data_struct", None))
     if hasattr(window, "streaming_stimulus_data"):
         window.streaming_stimulus_data = None
 
@@ -787,7 +790,9 @@ class SequenceWindow(QWidget):
             return
         acq_config = self.sequence_config[0]["seq1"]["acq"]
         if acq_config["mode"] in ["IMPORT_AUDIO", "IMPORT_STIMULUS_AUDIO"]:
-            _clear_sequence_stimulus_runtime_state(self, clear_sample_rate=True)
+            _clear_sequence_stimulus_runtime_state(
+                self, clear_sample_rate=False, clear_wav_calibration=False
+            )
             return
         if acq_config["mode"] == "PLAY_AND_RECORD":
             result = _resolve_runtime_sample_rate_for_mode(self, acq_config["mode"], acq_config["detail"])

--- a/ui/sequence/sequence_widget.py
+++ b/ui/sequence/sequence_widget.py
@@ -116,7 +116,7 @@ def _commit_analysis_reference_state(data_struct, staged_reference) -> None:
         data_struct.alignment_sample_count = staged_reference.alignment_sample_count
 
 
-def _clear_import_analysis_runtime_state(window) -> None:
+def _clear_import_analysis_runtime_state(window, *, clear_plot: bool = True) -> None:
     data_struct = getattr(window, "data_struct", None)
     if data_struct is not None:
         data_struct.store_wave_data = None
@@ -133,10 +133,11 @@ def _clear_import_analysis_runtime_state(window) -> None:
     data_btn = getattr(window, "data_btn", None)
     if data_btn is not None:
         data_btn.setEnabled(False)
-    try:
-        window._clear_plot_area()
-    except Exception:
-        pass
+    if clear_plot:
+        try:
+            window._clear_plot_area()
+        except Exception:
+            pass
 
 
 def _resolve_runtime_sample_rate_for_mode(window, acq_mode, acq_detail):
@@ -402,6 +403,112 @@ class SequenceWindow(QWidget):
         self._show_external_trigger_mode_warning(trigger_source, current_mode)
         return False
 
+    def _is_positive_runtime_integer(self, value):
+        return (
+            not isinstance(value, (bool, np.bool_))
+            and isinstance(value, (int, np.integer))
+            and int(value) > 0
+        )
+
+    def _has_runtime_samples(self, value):
+        if value is None:
+            return False
+        try:
+            return np.asarray(value).size > 0
+        except (TypeError, ValueError):
+            return False
+
+    def _has_imported_recording_runtime_state(self):
+        data_struct = self.data_struct
+        return (
+            SequenceWindow._is_positive_runtime_integer(self, getattr(data_struct, "sample_rate", None))
+            and SequenceWindow._is_positive_runtime_integer(self, getattr(data_struct, "audio_lenth", None))
+            and SequenceWindow._has_runtime_samples(self, getattr(data_struct, "store_wave_data", None))
+            and SequenceWindow._has_runtime_samples(self, getattr(data_struct, "store_wave_data_multi", None))
+        )
+
+    def _has_import_stimulus_runtime_reference(self):
+        data_struct = self.data_struct
+        stimulus_info = getattr(data_struct, "stimulus_info", None)
+        if not isinstance(stimulus_info, dict):
+            return False
+        recording_rate = getattr(data_struct, "sample_rate", None)
+        reference_rate = stimulus_info.get("sample_rate")
+        return (
+            SequenceWindow._is_positive_runtime_integer(self, recording_rate)
+            and SequenceWindow._is_positive_runtime_integer(self, reference_rate)
+            and int(recording_rate) == int(reference_rate)
+            and SequenceWindow._has_runtime_samples(self, getattr(data_struct, "stimulus_data", None))
+        )
+
+    def _validate_import_stimulus_analysis_readiness(self):
+        readiness_message = (
+            "分析参考激励尚未就绪或采样率与导入音频不一致，请检查激励配置后重试。"
+        )
+        if not (
+            SequenceWindow._has_imported_recording_runtime_state(self)
+            and SequenceWindow._has_import_stimulus_runtime_reference(self)
+        ):
+            MessageBox.warning(self, "提示", readiness_message)
+            return False
+
+        stimulus_info = self.data_struct.stimulus_info
+        total_time = stimulus_info.get("total_time")
+        if isinstance(total_time, (bool, np.bool_)) or not isinstance(
+            total_time,
+            (int, float, np.integer, np.floating),
+        ):
+            MessageBox.warning(self, "提示", readiness_message)
+            return False
+
+        total_time = float(total_time)
+        if not np.isfinite(total_time) or total_time <= 0:
+            MessageBox.warning(self, "提示", readiness_message)
+            return False
+
+        stimulus_length = round(total_time * int(stimulus_info["sample_rate"]))
+        if int(self.data_struct.audio_lenth) != stimulus_length:
+            MessageBox.warning(
+                self,
+                "音频长度校验失败",
+                f"导入音频长度({self.data_struct.audio_lenth})\n"
+                f"与激励信号长度({stimulus_length})不一致！无法分析！",
+            )
+            return False
+        return True
+
+    def _refresh_import_stimulus_analysis_reference(self, acq_detail):
+        if not self._has_imported_recording_runtime_state():
+            self.data_btn.setEnabled(False)
+            return False
+
+        runtime_sample_rate = int(self.data_struct.sample_rate)
+        staged_reference = SimpleNamespace(sample_rate=runtime_sample_rate)
+        try:
+            reference_ready = set_data_struct_analysis_reference_signal(
+                staged_reference,
+                acq_detail,
+                using_config_path=self.using_config_path,
+                runtime_sample_rate=runtime_sample_rate,
+                logger=LogManager.set_log_handler("core"),
+            )
+        except Exception as exc:
+            _clear_data_struct_stimulus_runtime_state(self.data_struct, clear_sample_rate=False)
+            self.data_btn.setEnabled(False)
+            MessageBox.warning(self, "提示", f"加载分析参考激励失败: {str(exc)[:200]}")
+            return False
+
+        if not reference_ready:
+            _clear_data_struct_stimulus_runtime_state(self.data_struct, clear_sample_rate=False)
+            self.data_btn.setEnabled(False)
+            MessageBox.warning(self, "提示", "加载分析参考激励失败，请检查激励配置。")
+            return False
+
+        _commit_analysis_reference_state(self.data_struct, staged_reference)
+        self.data_struct.sample_rate = runtime_sample_rate
+        self.data_btn.setEnabled(True)
+        return True
+
     def on_sequence_config_updated(self, *_):
         """
         Called when the test-queue window confirms config changes.
@@ -410,17 +517,44 @@ class SequenceWindow(QWidget):
         main window immediately reflects newly saved/imported entries.
         """
         try:
-            old_mode = self.mode
+            from copy import deepcopy
+
+            old_acq = (
+                deepcopy(self.sequence_config[0]["seq1"]["acq"])
+                if self.sequence_config
+                else None
+            )
+            old_mode = old_acq.get("mode") if old_acq else None
+            old_detail = old_acq.get("detail") if old_acq else None
             self.update_using_file_combobox()
             self.get_sequence_config_from_json()
-            new_mode = self.mode
+            new_acq = self.sequence_config[0]["seq1"]["acq"] if self.sequence_config else None
+            new_mode = new_acq.get("mode") if new_acq else None
+            new_detail = new_acq.get("detail") if new_acq else None
             mode_changed = old_mode != new_mode
 
             if mode_changed:
                 self._clear_plot_area()
                 self.data_struct.clear_data()
+                import_modes = {"IMPORT_AUDIO", "IMPORT_STIMULUS_AUDIO"}
+                if old_mode in import_modes or new_mode in import_modes:
+                    _clear_import_analysis_runtime_state(self, clear_plot=False)
                 self.refresh_channel_windows()
-            self.init_data_struct_stimulus_config()
+
+            preserve_import_runtime = not mode_changed and new_mode == "IMPORT_STIMULUS_AUDIO"
+            if preserve_import_runtime:
+                if old_detail != new_detail:
+                    if self._has_imported_recording_runtime_state():
+                        self._refresh_import_stimulus_analysis_reference(new_detail)
+                    else:
+                        _clear_import_analysis_runtime_state(self)
+                elif not (
+                    self._has_imported_recording_runtime_state()
+                    and self._has_import_stimulus_runtime_reference()
+                ):
+                    self.data_btn.setEnabled(False)
+            else:
+                self.init_data_struct_stimulus_config()
             self.init_fft_and_stft_flag()
 
             if self.count_board:
@@ -2295,20 +2429,12 @@ class SequenceWindow(QWidget):
         the respective calculations for each instance and displays the windows. The window positions are
         adjusted based on the screen size to ensure they do not overlap.
         """
-        # Only reflect THIS run(): clear previous summary results first
-        self.data_struct.analysis_result_dict.clear()
         if self.sequence_config[0]["seq1"]["acq"]["mode"] == "IMPORT_STIMULUS_AUDIO":
-            stimulus_length = round(
-                self.data_struct.stimulus_info.get("total_time") * self.data_struct.stimulus_info.get("sample_rate")
-            )
-            if self.data_struct.audio_lenth != stimulus_length:
-                MessageBox.warning(
-                    self,
-                    "音频长度校验失败",
-                    f"导入音频长度({self.data_struct.audio_lenth})\n"
-                    f"与激励信号长度({stimulus_length})不一致！无法分析！",
-                )
+            if not SequenceWindow._validate_import_stimulus_analysis_readiness(self):
                 return
+
+        # Only reflect THIS successful run(): clear previous summary results after readiness gates pass.
+        self.data_struct.analysis_result_dict.clear()
         if self.analysis_window:
             self.analysis_window = []
         if self._analysis_result_summary_window:

--- a/ui/sequence/sequence_widget.py
+++ b/ui/sequence/sequence_widget.py
@@ -116,7 +116,7 @@ def _commit_analysis_reference_state(data_struct, staged_reference) -> None:
         data_struct.alignment_sample_count = staged_reference.alignment_sample_count
 
 
-def _clear_import_analysis_runtime_state(window, *, clear_plot: bool = True) -> None:
+def _clear_import_analysis_runtime_state(window, clear_plot: bool = True) -> None:
     data_struct = getattr(window, "data_struct", None)
     if data_struct is not None:
         data_struct.store_wave_data = None

--- a/ui/sequence/sequence_widget.py
+++ b/ui/sequence/sequence_widget.py
@@ -324,7 +324,6 @@ class SequenceWindow(QWidget):
         their respective handlers and applies style sheets to the widgets.
         """
         self.setObjectName("SequenceWindow")
-        self.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
         self.setMinimumHeight(600)
         waveform_layout = self.create_waveform_layout()
 

--- a/ui/sequence/sn_regex_manage_dialog.py
+++ b/ui/sequence/sn_regex_manage_dialog.py
@@ -2,13 +2,11 @@ import copy
 import uuid
 
 from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import QAbstractItemView, QDialog, QHBoxLayout, QHeaderView, QMessageBox, QVBoxLayout
 
 from base.load_config import LoadUiConfig
 from ui.custom_ui_widget.custom_table_widget import DataManageDialog
 from ui.custom_ui_widget.widgets import Label, LineEdit, MessageBox, PushButton
-from ui.ui_src import ui_resources
 
 
 ENABLE_COLUMN = 0
@@ -49,7 +47,6 @@ class AddSnRegexRuleDialog(QDialog):
     def init_ui(self):
         self.setObjectName("SnRegexRuleInputDialog")
         self.setWindowTitle("新增 SN 规则")
-        self.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
         self.setWindowFlags(Qt.WindowCloseButtonHint)
         self.resize(640, 180)
 

--- a/ui/signal_analysis_window.py
+++ b/ui/signal_analysis_window.py
@@ -12,7 +12,7 @@ from librosa.feature import spectral
 from librosa.sequence import dtw
 from pyqtgraph import mkPen
 from PyQt5.QtCore import Qt, QModelIndex
-from PyQt5.QtGui import QIcon, QTextCursor, QTextCharFormat, QColor, QFont
+from PyQt5.QtGui import QTextCursor, QTextCharFormat, QColor, QFont
 from PyQt5.QtWidgets import (
     QApplication,
     QHBoxLayout,
@@ -60,7 +60,6 @@ from ui.ui_analysis_config.manual_limit_segments import (
     ManualLimitValidationError,
     limits_from_manual_segments,
 )
-from ui.ui_src import ui_resources
 
 
 def get_class_mapping():
@@ -313,7 +312,6 @@ class AnalysisResultSummaryWindow(QWidget):
     def __init__(self, result_dict: dict[str, bool], title: str = "分析结果汇总"):
         super().__init__()
         self.setWindowTitle(title)
-        self.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
 
         self._overall_label = Label(self)
         self._overall_label.setObjectName("overallResultLabel")
@@ -410,7 +408,6 @@ class AnalysisGraphWidget(QWidget):
         self.init_ui()
 
     def init_ui(self):
-        self.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
 
         self.analysis_plot.setBackground("white")
 
@@ -1712,7 +1709,6 @@ class AI(QWidget):
         self.setWindowTitle(title_name)
 
     def init_ui(self):
-        self.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
         ai_analyse_layout = self.create_ai_analyse_layout()
         self.setLayout(ai_analyse_layout)
 
@@ -1838,7 +1834,6 @@ class Spectrogram(QWidget):
         self.setWindowTitle(title_name)
 
     def init_ui(self):
-        self.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
         self.main_layout = QVBoxLayout(self)
 
         self.plot_container = QWidget()
@@ -2233,7 +2228,6 @@ class PatternMatch(QWidget):
         self.setWindowTitle(title_name)
 
     def init_ui(self):
-        self.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
         self.main_layout = QVBoxLayout(self)
         self.result_display = TextEdit()
         self.result_display.setReadOnly(True)
@@ -2383,7 +2377,6 @@ class PipelinePdPm(QWidget):
         return seg_len, left_point, right_point
 
     def _init_ui(self):
-        self.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
         self.main_layout = QVBoxLayout(self)
         # plot area for summary
         self.plot_widget = pg.PlotWidget(background="white")

--- a/ui/signal_analysis_window.py
+++ b/ui/signal_analysis_window.py
@@ -1073,6 +1073,9 @@ class Spl(AnalysisGraphWidget):
             MessageBox.warning(self, "提示", str(e))
             return False
         sample_rate = self.data_struct.sample_rate
+        if recorded_signal is None or sample_rate is None:
+            MessageBox.warning(self, "提示", "声压级分析失败：没有可用录音数据。")
+            return False
         if not self._resolve_v2pa_factor_for_analysis():
             return False
         reference_pressure = 20e-6

--- a/ui/signal_analysis_window.py
+++ b/ui/signal_analysis_window.py
@@ -56,6 +56,10 @@ from consts.running_consts import DEFAULT_DIR
 from ui.custom_ui_widget.widgets import MessageBox, TextEdit, Label, TableWidget
 from ui.graph_widget import plot_2d_image, custom_log_tick_strings, LimitPlotUtils
 from ui.reference_spectrum_analysis_window import ReferenceSpectrumCompareWindow
+from ui.ui_analysis_config.manual_limit_segments import (
+    ManualLimitValidationError,
+    limits_from_manual_segments,
+)
 from ui.ui_src import ui_resources
 
 
@@ -287,6 +291,16 @@ def _has_duplicate_finite_frequency_points(frequencies) -> bool:
     if freq.size <= 1:
         return False
     return np.unique(freq).size != freq.size
+
+
+def _sorted_finite_positive_x_for_limits(x_values, y_values):
+    x_arr = np.asarray(x_values, dtype=float)
+    y_arr = np.asarray(y_values, dtype=float)
+    mask = np.isfinite(x_arr) & np.isfinite(y_arr) & (x_arr > 0)
+    x_valid = x_arr[mask]
+    if x_valid.size > 1:
+        x_valid = x_valid[np.argsort(x_valid)]
+    return x_valid
 
 
 class AnalysisResultSummaryWindow(QWidget):
@@ -601,14 +615,13 @@ class Distortion(AnalysisGraphWidget):
         if analysis_config and analysis_config.get("limit_checked"):
             limit_mode = str(analysis_config.get("limit_mode", "csv") or "csv").lower()
             if limit_mode == "manual" and valid_data:
-                n = len(freq_value)
-                upper_ok = bool(analysis_config.get("manual_upper_enabled", True))
-                lower_ok = bool(analysis_config.get("manual_lower_enabled", False))
-                upper = float(analysis_config.get("manual_upper", 0.0) or 0.0)
-                lower = float(analysis_config.get("manual_lower", 0.0) or 0.0)
-                csv_freq_list = freq_value
-                csv_upper_list = (np.full(n, upper) if upper_ok else np.full(n, np.nan)).tolist()
-                csv_lower_list = (np.full(n, lower) if lower_ok else np.full(n, np.nan)).tolist()
+                try:
+                    csv_freq_list, csv_upper_list, csv_lower_list = limits_from_manual_segments(
+                        analysis_config, freq_value
+                    )
+                except ManualLimitValidationError as exc:
+                    MessageBox.warning(self, "提示", str(exc))
+                    return
             else:
                 result = analysis_config.get("limit_data")
                 if not result:
@@ -633,7 +646,14 @@ class Distortion(AnalysisGraphWidget):
                 if self.selected_label is not None:
                     self.analysis_plot.setTitle(f"The Distortion of {self.selected_label.text()} order")
                 # Highlight out-of-limit segments
-                self._highlight_out_of_range_curve(freq_value, thd, csv_freq_list, csv_upper_list, csv_lower_list)
+                self._highlight_out_of_range_curve(
+                    freq_value,
+                    thd,
+                    csv_freq_list,
+                    csv_upper_list,
+                    csv_lower_list,
+                    covered_limit_margins_only=(limit_mode == "manual"),
+                )
                 return
 
         # === Without limit config: original logic ===
@@ -647,7 +667,16 @@ class Distortion(AnalysisGraphWidget):
         self.analysis_plot.setLogMode(x=True, y=False)
         self.analysis_plot.showGrid(x=True, y=True)
 
-    def _highlight_out_of_range_curve(self, freq_value, y_data, csv_freq_list, csv_upper_list, csv_lower_list):
+    def _highlight_out_of_range_curve(
+        self,
+        freq_value,
+        y_data,
+        csv_freq_list,
+        csv_upper_list,
+        csv_lower_list,
+        *,
+        covered_limit_margins_only=False,
+    ):
         """
         Highlight out-of-limit segments in THD curve.
 
@@ -666,6 +695,8 @@ class Distortion(AnalysisGraphWidget):
         freq_arr = np.asarray(freq_value)
         y_arr = np.asarray(y_data)
         csv_freq_arr = np.asarray(csv_freq_list)
+        csv_upper_arr = np.asarray(csv_upper_list, dtype=float)
+        csv_lower_arr = np.asarray(csv_lower_list, dtype=float)
 
         max_csv_freq = max(csv_freq_list)
         min_csv_freq = min(csv_freq_list)
@@ -678,6 +709,9 @@ class Distortion(AnalysisGraphWidget):
         out_mask = np.zeros(freq_arr_capacity, dtype=bool)
 
         for i, f in enumerate(freq_arr):
+            if covered_limit_margins_only and (not np.isfinite(f) or not np.isfinite(y_arr[i])):
+                continue
+
             # Find nearest CSV frequency point
             table_index = int(np.argmin(np.abs(csv_freq_arr - f)))
             if (i + 1) != freq_arr_capacity:
@@ -691,18 +725,24 @@ class Distortion(AnalysisGraphWidget):
             if f > max_csv_freq and table_index == next_table_index:
                 continue
 
-            upper_val = csv_upper_list[table_index]
-            lower_val = csv_lower_list[table_index]
+            upper_val = csv_upper_arr[table_index]
+            lower_val = csv_lower_arr[table_index]
+            if covered_limit_margins_only:
+                has_upper_limit = np.isfinite(upper_val)
+                has_lower_limit = np.isfinite(lower_val)
+            else:
+                has_upper_limit = not np.isnan(upper_val)
+                has_lower_limit = not np.isnan(lower_val)
 
             is_out = False
-            if not np.isnan(upper_val) and y_arr[i] > upper_val:
+            if has_upper_limit and y_arr[i] > upper_val:
                 if no_deviation_flag:
                     deviation = 0.0
                     no_deviation_flag = False
                 deviation = max(deviation, abs(y_arr[i] - upper_val))
                 is_out = True
 
-            if not np.isnan(lower_val) and y_arr[i] < lower_val:
+            if has_lower_limit and y_arr[i] < lower_val:
                 if no_deviation_flag:
                     deviation = 0.0
                     no_deviation_flag = False
@@ -711,8 +751,18 @@ class Distortion(AnalysisGraphWidget):
 
             out_mask[i] = is_out
 
-            if not is_out and no_deviation_flag:
-                # THD special logic: calculate distance using current point's limits
+            if not is_out and no_deviation_flag and covered_limit_margins_only:
+                # Manual segment arrays use NaN gaps; uncovered samples must not influence margins.
+                margins = []
+                if has_upper_limit:
+                    margins.append(abs(y_arr[i] - upper_val))
+                if has_lower_limit:
+                    margins.append(abs(y_arr[i] - lower_val))
+                if margins:
+                    deviation_value = min(margins)
+                    deviation = min(deviation, deviation_value) if deviation > 0 else deviation_value
+            elif not is_out and no_deviation_flag:
+                # Legacy CSV behavior: compare every data point to both matched table limits.
                 deviation_value = min(min(np.abs(y_arr - upper_val)), min(np.abs(y_arr - lower_val)))
                 deviation = min(deviation, deviation_value) if deviation > 0 else deviation_value
 
@@ -914,14 +964,13 @@ class PerceptualRubAndBuzz(RubAndBuzz):
         if analysis_config and analysis_config.get("limit_checked"):
             limit_mode = str(analysis_config.get("limit_mode", "csv") or "csv").lower()
             if limit_mode == "manual" and valid_data:
-                n = len(freq_value)
-                upper_ok = bool(analysis_config.get("manual_upper_enabled", True))
-                lower_ok = bool(analysis_config.get("manual_lower_enabled", False))
-                upper = float(analysis_config.get("manual_upper", 0.0) or 0.0)
-                lower = float(analysis_config.get("manual_lower", 0.0) or 0.0)
-                csv_freq_list = freq_value
-                csv_upper_list = (np.full(n, upper) if upper_ok else np.full(n, np.nan)).tolist()
-                csv_lower_list = (np.full(n, lower) if lower_ok else np.full(n, np.nan)).tolist()
+                try:
+                    csv_freq_list, csv_upper_list, csv_lower_list = limits_from_manual_segments(
+                        analysis_config, freq_value
+                    )
+                except ManualLimitValidationError as exc:
+                    MessageBox.warning(self, "提示", str(exc))
+                    return
             else:
                 result = analysis_config.get("limit_data")
                 if not result:
@@ -950,7 +999,12 @@ class PerceptualRubAndBuzz(RubAndBuzz):
                 # 2) Use parent's _highlight_out_of_range_curve() for limit check + highlight
                 #    This uses nearest-neighbor matching and highlights on original data points
                 self._highlight_out_of_range_curve(
-                    freq_value, perceptual_loudness, csv_freq_list, csv_upper_list, csv_lower_list
+                    freq_value,
+                    perceptual_loudness,
+                    csv_freq_list,
+                    csv_upper_list,
+                    csv_lower_list,
+                    covered_limit_margins_only=(limit_mode == "manual"),
                 )
                 return
 
@@ -1057,14 +1111,13 @@ class Spl(AnalysisGraphWidget):
         if limit_checked:
             limit_mode = str(self.analysis_config.get("limit_mode", "csv") or "csv").lower()
             if limit_mode == "manual":
-                n = len(signal_duration)
-                upper_ok = bool(self.analysis_config.get("manual_upper_enabled", True))
-                lower_ok = bool(self.analysis_config.get("manual_lower_enabled", False))
-                upper = float(self.analysis_config.get("manual_upper", 0.0) or 0.0)
-                lower = float(self.analysis_config.get("manual_lower", 0.0) or 0.0)
-                csv_time_list = signal_duration
-                csv_upper_list = (np.full(n, upper) if upper_ok else np.full(n, np.nan)).tolist()
-                csv_lower_list = (np.full(n, lower) if lower_ok else np.full(n, np.nan)).tolist()
+                try:
+                    csv_time_list, csv_upper_list, csv_lower_list = limits_from_manual_segments(
+                        self.analysis_config, signal_duration
+                    )
+                except ManualLimitValidationError as exc:
+                    MessageBox.warning(self, "提示", str(exc))
+                    return False
             else:
                 result = self.analysis_config.get("limit_data")
                 if not result:
@@ -1265,14 +1318,14 @@ class SplFrequency(AnalysisGraphWidget):
         if limit_checked:
             limit_mode = str(analysis_config.get("limit_mode", "csv") or "csv").lower()
             if limit_mode == "manual":
-                n = len(frequency_list)
-                upper_ok = bool(analysis_config.get("manual_upper_enabled", True))
-                lower_ok = bool(analysis_config.get("manual_lower_enabled", False))
-                upper = float(analysis_config.get("manual_upper", 0.0) or 0.0)
-                lower = float(analysis_config.get("manual_lower", 0.0) or 0.0)
-                csv_freq_list = frequency_list
-                csv_upper_list = (np.full(n, upper) if upper_ok else np.full(n, np.nan)).tolist()
-                csv_lower_list = (np.full(n, lower) if lower_ok else np.full(n, np.nan)).tolist()
+                try:
+                    manual_limit_x = _sorted_finite_positive_x_for_limits(frequency_list, spl_db)
+                    csv_freq_list, csv_upper_list, csv_lower_list = limits_from_manual_segments(
+                        analysis_config, manual_limit_x
+                    )
+                except ManualLimitValidationError as exc:
+                    MessageBox.warning(self, "提示", str(exc))
+                    return False
             else:
                 result = analysis_config.get("limit_data")
                 if not result:
@@ -1453,18 +1506,18 @@ class Frequency(AnalysisGraphWidget):
                 MessageBox.warning(self, "提示", "未找到黄金样本基准文件或基准数据，已按原始曲线分析")
         limit_checked = analysis_config.get("limit_checked")
         if limit_checked:
-            limit_mode = str(self.analysis_config.get("limit_mode", "csv") or "csv").lower()
+            limit_mode = str(analysis_config.get("limit_mode", "csv") or "csv").lower()
             if limit_mode == "manual":
-                n = len(frequency_list)
-                upper_ok = bool(self.analysis_config.get("manual_upper_enabled", True))
-                lower_ok = bool(self.analysis_config.get("manual_lower_enabled", False))
-                upper = float(self.analysis_config.get("manual_upper", 0.0) or 0.0)
-                lower = float(self.analysis_config.get("manual_lower", 0.0) or 0.0)
-                csv_freq_list = frequency_list
-                csv_upper_list = (np.full(n, upper) if upper_ok else np.full(n, np.nan)).tolist()
-                csv_lower_list = (np.full(n, lower) if lower_ok else np.full(n, np.nan)).tolist()
+                try:
+                    manual_limit_x = _sorted_finite_positive_x_for_limits(frequency_list, fr)
+                    csv_freq_list, csv_upper_list, csv_lower_list = limits_from_manual_segments(
+                        analysis_config, manual_limit_x
+                    )
+                except ManualLimitValidationError as exc:
+                    MessageBox.warning(self, "提示", str(exc))
+                    return False
             else:
-                result = self.analysis_config.get("limit_data")
+                result = analysis_config.get("limit_data")
                 if not result:
                     return False
                 csv_freq_list, csv_upper_list, csv_lower_list = result

--- a/ui/splash_screen_window.py
+++ b/ui/splash_screen_window.py
@@ -3,7 +3,7 @@ import importlib
 
 from PyQt5.QtCore import Qt, QObject, pyqtSignal, QRect
 from PyQt5.QtWidgets import QWidget, QProgressBar, QLabel
-from consts.running_consts import DEFAULT_DIR, MODULES_LOAD
+from consts.running_consts import MODULES_LOAD
 from PyQt5.QtGui import QPixmap
 from ui.ui_src import ui_resources
 

--- a/ui/stimulus_window.py
+++ b/ui/stimulus_window.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 import numpy as np
 import pyqtgraph
 from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QIcon, QFont
+from PyQt5.QtGui import QFont
 from PyQt5.QtWidgets import QDialog, QFileDialog, QSizePolicy, QGridLayout, QHBoxLayout, QVBoxLayout
 
 from base.file_ops import FileOps
@@ -40,7 +40,6 @@ from ui.custom_ui_widget.widgets import (
     MessageBox,
 )
 from ui.load_stimulus_dialog import LoadStimulusDialog
-from ui.ui_src import ui_resources
 
 
 class PreferredFrequencySpinBox(DoubleSpinBox):
@@ -256,7 +255,6 @@ class StimulusWindow(QDialog):
     def init_ui(self):
         # set window titlebar style
         self.setObjectName("StimulusWindow")
-        self.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
         self.setWindowTitle("激励信号")
         self.setWindowFlag(Qt.WindowContextHelpButtonHint, False)
         # if ui_style_const._FONT_SCALE < 0.8:
@@ -2718,7 +2716,6 @@ class StimulusWindow(QDialog):
                 return
             if self.start_custom_check_status:
                 self.set_ai_popup()
-            # elif self.load_wav_path != self.load_stimulus_signal_path:
             elif not self._paths_reference_same_file(self.load_wav_path, self.load_stimulus_signal_path):
                 self.set_ai_popup()
             self.load_stimulus_signal_path = self.load_wav_path
@@ -2837,7 +2834,6 @@ class SetConfigName(QDialog):
 
     def init_ui(self):
         self.setWindowTitle("设置配置名称")
-        self.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
 
         congfig_name_layout = self.config_name_layout()
         btn_layout = self.btn_layout()

--- a/ui/tcp_config_dialog.py
+++ b/ui/tcp_config_dialog.py
@@ -1,12 +1,9 @@
 import re
 
 from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import QVBoxLayout, QHBoxLayout, QDialog
 
-from consts.running_consts import DEFAULT_DIR
 from ui.custom_ui_widget.widgets import PushButton, LineEdit, CheckBox, GroupBox, MessageBox
-from ui.ui_src import ui_resources
 
 
 class TcpConfigDialog(QDialog):
@@ -35,7 +32,6 @@ class TcpConfigDialog(QDialog):
 
     def init_ui(self):
         self.setWindowTitle("TCP配置")
-        self.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
         self.setWindowFlags(Qt.WindowCloseButtonHint | Qt.WindowMinimizeButtonHint)
         self.setMinimumSize(300, 200)
         self.resize(300, 250)

--- a/ui/ui_analysis_config/ai_config_dialog.py
+++ b/ui/ui_analysis_config/ai_config_dialog.py
@@ -5,11 +5,9 @@ from PyQt5.QtWidgets import QHBoxLayout, QSizePolicy
 
 from base.training_model_management import TrainingModelManagement
 from consts import error_code
-from consts.running_consts import DEFAULT_DIR
 from ui.custom_ui_widget.popuputils import PopupUtils
 from ui.custom_ui_widget.widgets import ComboBox, Label, GroupBox, MessageBox
 from ui.ui_analysis_config.common_widgets import ChannelSelectorWidget, SemanticAnalysisConfigDialogBase
-from ui.ui_src import ui_resources
 
 
 class AIConfigWindow(SemanticAnalysisConfigDialogBase):

--- a/ui/ui_analysis_config/common_widgets.py
+++ b/ui/ui_analysis_config/common_widgets.py
@@ -6,7 +6,6 @@ from functools import partial
 from typing import Any, Callable
 
 from PyQt5.QtCore import Qt, pyqtSignal
-from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import (
     QButtonGroup,
     QDialog,
@@ -28,7 +27,6 @@ from ui.ui_analysis_config.config_normalization import (
     normalize_weighting,
     weighting_to_display_label,
 )
-from ui.ui_src import ui_resources
 
 
 OCTAVE_SMOOTHING_LABELS = {
@@ -70,7 +68,6 @@ class AnalysisConfigDialogBase(QDialog):
         if disable_close_button:
             self.setWindowFlag(Qt.WindowCloseButtonHint, False)
         self.setWindowFlag(Qt.WindowContextHelpButtonHint, False)
-        self.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
 
     def create_standard_button_layout(self, default_callback, ok_callback) -> QHBoxLayout:
         btn_layout = QHBoxLayout()

--- a/ui/ui_analysis_config/excel_config_dialog.py
+++ b/ui/ui_analysis_config/excel_config_dialog.py
@@ -6,7 +6,6 @@ from consts.running_consts import DEFAULT_DIR
 from ui.custom_ui_widget.popuputils import PopupUtils
 from ui.custom_ui_widget.widgets import PushButton, Label, GroupBox, CheckBox, LineEdit, SpinBox, MessageBox
 from ui.ui_analysis_config.common_widgets import SemanticAnalysisConfigDialogBase
-from ui.ui_src import ui_resources
 
 
 class ExcelConfigWindow(SemanticAnalysisConfigDialogBase):

--- a/ui/ui_analysis_config/fba_config_dialog.py
+++ b/ui/ui_analysis_config/fba_config_dialog.py
@@ -2,7 +2,6 @@ import re
 from typing import List, Optional
 from PyQt5.QtWidgets import QHBoxLayout, QVBoxLayout, QSizePolicy, QWidget
 
-from consts.running_consts import DEFAULT_DIR
 from ui.custom_ui_widget.popuputils import PopupUtils
 
 # 确保这里导入的是你项目中正确的 ThresholdConfigWidget 路径
@@ -13,7 +12,6 @@ from ui.ui_analysis_config.common_widgets import (
 )
 from ui.ui_analysis_config.threshold_config_widget import ThresholdConfigWidget
 from ui.custom_ui_widget.widgets import ComboBox, Label, GroupBox, DoubleSpinBox, PlainTextEdit, MessageBox
-from ui.ui_src import ui_resources
 
 
 class FbaConfigWindow(SemanticAnalysisConfigDialogBase):

--- a/ui/ui_analysis_config/fr_config_dialog.py
+++ b/ui/ui_analysis_config/fr_config_dialog.py
@@ -2,7 +2,6 @@
 FR (Frequency Response) 分析配置对话框
 """
 
-from consts.running_consts import DEFAULT_DIR
 from ui.custom_ui_widget.popuputils import PopupUtils
 from ui.ui_analysis_config.common_widgets import (
     GoldenSampleWidget,
@@ -10,7 +9,6 @@ from ui.ui_analysis_config.common_widgets import (
     SemanticAnalysisConfigDialogBase,
 )
 from ui.ui_analysis_config.threshold_config_widget import ThresholdConfigWidget
-from ui.ui_src import ui_resources
 
 
 class FrConfigWindow(SemanticAnalysisConfigDialogBase):

--- a/ui/ui_analysis_config/fr_config_dialog.py
+++ b/ui/ui_analysis_config/fr_config_dialog.py
@@ -42,6 +42,7 @@ class FrConfigWindow(SemanticAnalysisConfigDialogBase):
             parent=self,
             load_config=self.load_config,
             model_type=self.model_type,
+            allow_manual_limits=True,
         )
 
         self.add_semantic_section("compute", widget=self.smoothing_selector)

--- a/ui/ui_analysis_config/hd_config_dialog.py
+++ b/ui/ui_analysis_config/hd_config_dialog.py
@@ -50,6 +50,7 @@ class HdConfigWindow(SemanticAnalysisConfigDialogBase):
             parent=self,
             load_config=self.load_config,
             model_type=self.model_type,
+            allow_manual_limits=True,
         )
 
         self.add_semantic_section("detection", widget=harmonic_group_box)

--- a/ui/ui_analysis_config/hd_config_dialog.py
+++ b/ui/ui_analysis_config/hd_config_dialog.py
@@ -4,7 +4,6 @@ HD (Harmonic Distortion / THD) 分析配置对话框
 
 from PyQt5.QtWidgets import QVBoxLayout
 
-from consts.running_consts import DEFAULT_DIR
 from ui.custom_ui_widget.popuputils import PopupUtils
 from ui.ui_analysis_config.common_widgets import (
     GoldenSampleWidget,
@@ -13,7 +12,6 @@ from ui.ui_analysis_config.common_widgets import (
 )
 from ui.ui_analysis_config.threshold_config_widget import ThresholdConfigWidget
 from ui.custom_ui_widget.widgets import GroupBox, MessageBox
-from ui.ui_src import ui_resources
 
 
 class HdConfigWindow(SemanticAnalysisConfigDialogBase):

--- a/ui/ui_analysis_config/lp_config_dialog.py
+++ b/ui/ui_analysis_config/lp_config_dialog.py
@@ -3,11 +3,9 @@ from typing import List, Optional
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QHBoxLayout, QVBoxLayout
 
-from consts.running_consts import DEFAULT_DIR
 from ui.custom_ui_widget.popuputils import PopupUtils
 from ui.custom_ui_widget.widgets import GroupBox, Label, SpinBox
 from ui.ui_analysis_config.common_widgets import ChannelSelectorWidget, SemanticAnalysisConfigDialogBase
-from ui.ui_src import ui_resources
 
 
 class LPConfigWindow(SemanticAnalysisConfigDialogBase):

--- a/ui/ui_analysis_config/manual_limit_segments.py
+++ b/ui/ui_analysis_config/manual_limit_segments.py
@@ -13,31 +13,40 @@ class ManualLimitValidationError(ValueError):
     pass
 
 
+_FIELD_LABELS = {
+    "start_x": "起始X",
+    "start_y": "起始Y",
+    "end_x": "截止X",
+    "end_y": "截止Y",
+}
+
+
 def normalize_segments(raw_segments) -> list[dict[str, float]]:
     if raw_segments is None:
         return []
     if isinstance(raw_segments, (str, bytes)) or not isinstance(raw_segments, Sequence):
-        raise ManualLimitValidationError("manual limit segments must be a sequence")
+        raise ManualLimitValidationError("手动上下限段配置必须是列表")
 
     normalized = []
     for index, raw_segment in enumerate(raw_segments, start=1):
         if not isinstance(raw_segment, Mapping):
-            raise ManualLimitValidationError(f"segment {index} must be a mapping")
+            raise ManualLimitValidationError(f"第{index}段必须是配置对象")
 
         segment = {}
         for key in ("start_x", "start_y", "end_x", "end_y"):
+            field_label = _FIELD_LABELS[key]
             try:
                 raw_value = raw_segment[key]
             except KeyError as exc:
-                raise ManualLimitValidationError(f"segment {index} is missing {key}") from exc
+                raise ManualLimitValidationError(f"第{index}段缺少{field_label}") from exc
             if isinstance(raw_value, (bool, np.bool_)):
-                raise ManualLimitValidationError(f"segment {index} {key} must be numeric")
+                raise ManualLimitValidationError(f"第{index}段{field_label}必须是数字")
             try:
                 value = float(raw_value)
             except (TypeError, ValueError) as exc:
-                raise ManualLimitValidationError(f"segment {index} {key} must be numeric") from exc
+                raise ManualLimitValidationError(f"第{index}段{field_label}必须是数字") from exc
             if not math.isfinite(value):
-                raise ManualLimitValidationError(f"segment {index} {key} must be finite")
+                raise ManualLimitValidationError(f"第{index}段{field_label}必须是有限数字")
             segment[key] = value
         normalized.append(segment)
     return normalized
@@ -71,7 +80,7 @@ def _normalized_enabled_segments(config: dict | None):
     upper_enabled = bool(config.get("manual_upper_enabled", True))
     lower_enabled = bool(config.get("manual_lower_enabled", False))
     if not upper_enabled and not lower_enabled:
-        raise ManualLimitValidationError("at least one manual limit must be enabled")
+        raise ManualLimitValidationError("手动上下限至少需要启用一个")
 
     upper_segments = []
     lower_segments = []
@@ -89,19 +98,19 @@ def _normalized_enabled_segments(config: dict | None):
 
 def _validate_normalized_segments(segments: list[dict[str, float]], *, label: str) -> None:
     if not segments:
-        raise ManualLimitValidationError(f"{label} must include at least one segment")
+        raise ManualLimitValidationError(f"{label}至少需要包含一段配置")
     if segments[0]["start_x"] < 0:
-        raise ManualLimitValidationError(f"{label} segment 1 start_x must be non-negative")
+        raise ManualLimitValidationError(f"{label}第1段起始X必须大于或等于0")
 
     previous_end_x = None
     for index, segment in enumerate(segments, start=1):
         start_x = segment["start_x"]
         end_x = segment["end_x"]
         if end_x <= start_x:
-            raise ManualLimitValidationError(f"{label} segment {index} end_x must be greater than start_x")
+            raise ManualLimitValidationError(f"{label}第{index}段截止X必须大于起始X")
         if previous_end_x is not None and start_x < previous_end_x:
             raise ManualLimitValidationError(
-                f"{label} segment {index} start_x must be greater than or equal to the previous end_x"
+                f"{label}第{index}段起始X必须大于或等于上一段截止X"
             )
         previous_end_x = end_x
 
@@ -117,17 +126,12 @@ def _validate_lower_not_above_upper(
             if right <= left:
                 continue
 
-            checks = (
-                (left, "immediately right of the overlap start"),
-                (right, "at the overlap end"),
-            )
-            for x_value, position in checks:
+            for x_value in (left, right):
                 upper_y = _segment_value_at(upper_segment, x_value)
                 lower_y = _segment_value_at(lower_segment, x_value)
                 if lower_y > upper_y:
                     raise ManualLimitValidationError(
-                        "下限 cannot be greater than 上限 "
-                        f"{position} for upper segment {upper_index} and lower segment {lower_index}"
+                        f"下限不能大于上限：上限第{upper_index}段与下限第{lower_index}段在重叠区间内不合法"
                     )
 
 

--- a/ui/ui_analysis_config/manual_limit_segments.py
+++ b/ui/ui_analysis_config/manual_limit_segments.py
@@ -9,9 +9,6 @@ from typing import Any
 import numpy as np
 
 
-SEGMENT_KEYS = ("start_x", "start_y", "end_x", "end_y")
-
-
 class ManualLimitValidationError(ValueError):
     pass
 
@@ -28,7 +25,7 @@ def normalize_segments(raw_segments) -> list[dict[str, float]]:
             raise ManualLimitValidationError(f"segment {index} must be a mapping")
 
         segment = {}
-        for key in SEGMENT_KEYS:
+        for key in ("start_x", "start_y", "end_x", "end_y"):
             try:
                 raw_value = raw_segment[key]
             except KeyError as exc:

--- a/ui/ui_analysis_config/manual_limit_segments.py
+++ b/ui/ui_analysis_config/manual_limit_segments.py
@@ -1,0 +1,149 @@
+"""Pure helpers for manual upper/lower limit line segments."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import numpy as np
+
+
+SEGMENT_KEYS = ("start_x", "start_y", "end_x", "end_y")
+
+
+class ManualLimitValidationError(ValueError):
+    pass
+
+
+def normalize_segments(raw_segments) -> list[dict[str, float]]:
+    if raw_segments is None:
+        return []
+    if isinstance(raw_segments, (str, bytes)) or not isinstance(raw_segments, Sequence):
+        raise ManualLimitValidationError("manual limit segments must be a sequence")
+
+    normalized = []
+    for index, raw_segment in enumerate(raw_segments, start=1):
+        if not isinstance(raw_segment, Mapping):
+            raise ManualLimitValidationError(f"segment {index} must be a mapping")
+
+        segment = {}
+        for key in SEGMENT_KEYS:
+            try:
+                raw_value = raw_segment[key]
+            except KeyError as exc:
+                raise ManualLimitValidationError(f"segment {index} is missing {key}") from exc
+            if isinstance(raw_value, (bool, np.bool_)):
+                raise ManualLimitValidationError(f"segment {index} {key} must be numeric")
+            try:
+                value = float(raw_value)
+            except (TypeError, ValueError) as exc:
+                raise ManualLimitValidationError(f"segment {index} {key} must be numeric") from exc
+            if not math.isfinite(value):
+                raise ManualLimitValidationError(f"segment {index} {key} must be finite")
+            segment[key] = value
+        normalized.append(segment)
+    return normalized
+
+
+def validate_manual_segments(segments: list[dict[str, float]], *, label: str) -> None:
+    normalized = normalize_segments(segments)
+    _validate_normalized_segments(normalized, label=label)
+
+
+def validate_manual_limit_config(config: dict) -> None:
+    _normalized_enabled_segments(config)
+
+
+def limits_from_manual_segments(config: dict, target_x) -> tuple[list[float], list[float], list[float]]:
+    upper_enabled, lower_enabled, upper_segments, lower_segments = _normalized_enabled_segments(config)
+    x_values = np.asarray(target_x, dtype=float)
+    upper_values = np.full(x_values.shape, np.nan, dtype=float)
+    lower_values = np.full(x_values.shape, np.nan, dtype=float)
+
+    if upper_enabled:
+        _apply_segments(upper_values, x_values, upper_segments)
+    if lower_enabled:
+        _apply_segments(lower_values, x_values, lower_segments)
+
+    return x_values.tolist(), upper_values.tolist(), lower_values.tolist()
+
+
+def _normalized_enabled_segments(config: dict | None):
+    config = config or {}
+    upper_enabled = bool(config.get("manual_upper_enabled", True))
+    lower_enabled = bool(config.get("manual_lower_enabled", False))
+    if not upper_enabled and not lower_enabled:
+        raise ManualLimitValidationError("at least one manual limit must be enabled")
+
+    upper_segments = []
+    lower_segments = []
+    if upper_enabled:
+        upper_segments = normalize_segments(config.get("manual_upper_segments", []))
+        _validate_normalized_segments(upper_segments, label="上限")
+    if lower_enabled:
+        lower_segments = normalize_segments(config.get("manual_lower_segments", []))
+        _validate_normalized_segments(lower_segments, label="下限")
+    if upper_enabled and lower_enabled:
+        _validate_lower_not_above_upper(upper_segments, lower_segments)
+
+    return upper_enabled, lower_enabled, upper_segments, lower_segments
+
+
+def _validate_normalized_segments(segments: list[dict[str, float]], *, label: str) -> None:
+    if not segments:
+        raise ManualLimitValidationError(f"{label} must include at least one segment")
+    if segments[0]["start_x"] < 0:
+        raise ManualLimitValidationError(f"{label} segment 1 start_x must be non-negative")
+
+    previous_end_x = None
+    for index, segment in enumerate(segments, start=1):
+        start_x = segment["start_x"]
+        end_x = segment["end_x"]
+        if end_x <= start_x:
+            raise ManualLimitValidationError(f"{label} segment {index} end_x must be greater than start_x")
+        if previous_end_x is not None and start_x < previous_end_x:
+            raise ManualLimitValidationError(
+                f"{label} segment {index} start_x must be greater than or equal to the previous end_x"
+            )
+        previous_end_x = end_x
+
+
+def _validate_lower_not_above_upper(
+    upper_segments: list[dict[str, float]],
+    lower_segments: list[dict[str, float]],
+) -> None:
+    for upper_index, upper_segment in enumerate(upper_segments, start=1):
+        for lower_index, lower_segment in enumerate(lower_segments, start=1):
+            left = max(upper_segment["start_x"], lower_segment["start_x"])
+            right = min(upper_segment["end_x"], lower_segment["end_x"])
+            if right <= left:
+                continue
+
+            checks = (
+                (left, "immediately right of the overlap start"),
+                (right, "at the overlap end"),
+            )
+            for x_value, position in checks:
+                upper_y = _segment_value_at(upper_segment, x_value)
+                lower_y = _segment_value_at(lower_segment, x_value)
+                if lower_y > upper_y:
+                    raise ManualLimitValidationError(
+                        "下限 cannot be greater than 上限 "
+                        f"{position} for upper segment {upper_index} and lower segment {lower_index}"
+                    )
+
+
+def _apply_segments(
+    output_values: np.ndarray,
+    x_values: np.ndarray,
+    segments: list[dict[str, float]],
+) -> None:
+    for segment in segments:
+        mask = (x_values > segment["start_x"]) & (x_values <= segment["end_x"])
+        output_values[mask] = _segment_value_at(segment, x_values[mask])
+
+
+def _segment_value_at(segment: Mapping[str, float], x_value: Any):
+    ratio = (x_value - segment["start_x"]) / (segment["end_x"] - segment["start_x"])
+    return segment["start_y"] + ratio * (segment["end_y"] - segment["start_y"])

--- a/ui/ui_analysis_config/pattern_match_config_dialog.py
+++ b/ui/ui_analysis_config/pattern_match_config_dialog.py
@@ -33,7 +33,6 @@ from ui.custom_ui_widget.widgets import (
     MessageBox,
 )
 from ui.ui_analysis_config.common_widgets import AnalysisConfigDialogBase
-from ui.ui_src import ui_resources
 
 
 class PatternMatchConfigWindow(AnalysisConfigDialogBase):

--- a/ui/ui_analysis_config/pd_config_dialog.py
+++ b/ui/ui_analysis_config/pd_config_dialog.py
@@ -1,7 +1,5 @@
-from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QHBoxLayout, QVBoxLayout
 
-from consts.running_consts import DEFAULT_DIR
 from ui.custom_ui_widget.popuputils import PopupUtils
 from ui.custom_ui_widget.widgets import (
     GroupBox,
@@ -14,7 +12,6 @@ from ui.custom_ui_widget.widgets import (
     CheckBox,
 )
 from ui.ui_analysis_config.common_widgets import AnalysisConfigDialogBase, TimeSmoothingWidget
-from ui.ui_src import ui_resources
 
 
 class PDConfigWindow(AnalysisConfigDialogBase):

--- a/ui/ui_analysis_config/perceptual_rb_config_dialog.py
+++ b/ui/ui_analysis_config/perceptual_rb_config_dialog.py
@@ -8,12 +8,10 @@ PRB 使用固定谐波范围 (2阶-35阶) 结合 SoundCheck/Listen (SC) 心理�
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QVBoxLayout
 
-from consts.running_consts import DEFAULT_DIR
 from ui.custom_ui_widget.popuputils import PopupUtils
 from ui.ui_analysis_config.common_widgets import GoldenSampleWidget, SemanticAnalysisConfigDialogBase
 from ui.ui_analysis_config.threshold_config_widget import ThresholdConfigWidget
 from ui.custom_ui_widget.widgets import GroupBox, Label, ComboBox
-from ui.ui_src import ui_resources
 
 
 class PerceptualRbConfigWindow(SemanticAnalysisConfigDialogBase):

--- a/ui/ui_analysis_config/perceptual_rb_config_dialog.py
+++ b/ui/ui_analysis_config/perceptual_rb_config_dialog.py
@@ -75,6 +75,7 @@ class PerceptualRbConfigWindow(SemanticAnalysisConfigDialogBase):
             parent=self,
             load_config=self.load_config,
             model_type=self.model_type,
+            allow_manual_limits=True,
         )
 
         self.add_semantic_section("compute", widget=group)

--- a/ui/ui_analysis_config/pipeline_pd_pm_config.py
+++ b/ui/ui_analysis_config/pipeline_pd_pm_config.py
@@ -1,7 +1,6 @@
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QDialog, QHBoxLayout, QVBoxLayout
 
-from consts.running_consts import DEFAULT_DIR
 from ui.ui_analysis_config.ai_config_dialog import AIConfigWindow
 from ui.ui_analysis_config.fr_config_dialog import FrConfigWindow
 from ui.ui_analysis_config.hd_config_dialog import HdConfigWindow
@@ -14,7 +13,6 @@ from ui.ui_analysis_config.spec_config_dialog import SpecConfigWindow
 from ui.ui_analysis_config.spl_config_dialog import SplConfigWindow
 from ui.custom_ui_widget.widgets import GroupBox, Label, PushButton, CheckBox, SpinBox, MessageBox
 from ui.ui_analysis_config.common_widgets import AnalysisConfigDialogBase
-from ui.ui_src import ui_resources
 
 
 class PipelineConfigWindow(AnalysisConfigDialogBase):

--- a/ui/ui_analysis_config/rb_config_dialog.py
+++ b/ui/ui_analysis_config/rb_config_dialog.py
@@ -6,7 +6,6 @@ Rub & Buzz 使用高阶谐波失真 (10阶-35阶) 来检测扬声器的摩擦和
 
 from PyQt5.QtWidgets import QVBoxLayout
 
-from consts.running_consts import DEFAULT_DIR
 from ui.custom_ui_widget.popuputils import PopupUtils
 from ui.custom_ui_widget.widgets import GroupBox, MessageBox
 from ui.ui_analysis_config.common_widgets import (
@@ -15,7 +14,6 @@ from ui.ui_analysis_config.common_widgets import (
     SemanticAnalysisConfigDialogBase,
 )
 from ui.ui_analysis_config.threshold_config_widget import ThresholdConfigWidget
-from ui.ui_src import ui_resources
 
 
 class RbConfigWindow(SemanticAnalysisConfigDialogBase):

--- a/ui/ui_analysis_config/rb_config_dialog.py
+++ b/ui/ui_analysis_config/rb_config_dialog.py
@@ -57,6 +57,7 @@ class RbConfigWindow(SemanticAnalysisConfigDialogBase):
             parent=self,
             load_config=self.load_config,
             model_type=self.model_type,
+            allow_manual_limits=True,
         )
 
         self.add_semantic_section("detection", widget=harmonic_group_box)

--- a/ui/ui_analysis_config/spec_config_dialog.py
+++ b/ui/ui_analysis_config/spec_config_dialog.py
@@ -3,11 +3,9 @@ from typing import List, Optional
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QHBoxLayout, QVBoxLayout
 
-from consts.running_consts import DEFAULT_DIR
 from ui.custom_ui_widget.popuputils import PopupUtils
 from ui.custom_ui_widget.widgets import CheckBox, GroupBox, Label, ComboBox, SpinBox, MessageBox
 from ui.ui_analysis_config.common_widgets import ChannelSelectorWidget, SemanticAnalysisConfigDialogBase
-from ui.ui_src import ui_resources
 
 
 class SpecConfigWindow(SemanticAnalysisConfigDialogBase):

--- a/ui/ui_analysis_config/spl_config_dialog.py
+++ b/ui/ui_analysis_config/spl_config_dialog.py
@@ -7,7 +7,6 @@ from typing import List, Optional
 
 from PyQt5.QtWidgets import QHBoxLayout, QVBoxLayout, QWidget
 
-from consts.running_consts import DEFAULT_DIR
 from ui.custom_ui_widget.popuputils import PopupUtils
 from ui.custom_ui_widget.widgets import CheckBox, ComboBox, DoubleSpinBox, GroupBox, Label, RadioButton, SpinBox
 from ui.ui_analysis_config.common_widgets import (
@@ -20,7 +19,6 @@ from ui.ui_analysis_config.common_widgets import (
     WeightingSelectorWidget,
 )
 from ui.ui_analysis_config.threshold_config_widget import ThresholdConfigWidget
-from ui.ui_src import ui_resources
 
 
 class ConfigSubsectionWidget(GroupBox):

--- a/ui/ui_analysis_config/spl_config_dialog.py
+++ b/ui/ui_analysis_config/spl_config_dialog.py
@@ -165,7 +165,7 @@ class SplConfigWindow(SemanticAnalysisConfigDialogBase):
             parent=self,
             load_config=self.load_config,
             model_type=self.model_type,
-            allow_manual_limits=self.model_type != "SPLF",
+            allow_manual_limits=True,
         )
 
         self.weighting_selector = WeightingSelectorWidget(self.load_config, parent=self)

--- a/ui/ui_analysis_config/threshold_config_widget.py
+++ b/ui/ui_analysis_config/threshold_config_widget.py
@@ -13,12 +13,25 @@ import numpy as np
 
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtGui import QIcon
-from PyQt5.QtWidgets import QWidget, QFileDialog, QHBoxLayout, QVBoxLayout
+from PyQt5.QtWidgets import (
+    QWidget,
+    QFileDialog,
+    QHBoxLayout,
+    QVBoxLayout,
+    QHeaderView,
+    QTableWidgetItem,
+    QSizePolicy,
+    QLayout,
+)
 from pyqtgraph import PlotWidget, mkPen
 
 from consts.running_consts import DEFAULT_DIR
-from ui.custom_ui_widget.widgets import CheckBox, DoubleSpinBox, GroupBox, Label, LineEdit, MessageBox, RadioButton
+from ui.custom_ui_widget.widgets import CheckBox, GroupBox, LineEdit, MessageBox, RadioButton, TableWidget
+from ui.ui_analysis_config.manual_limit_segments import ManualLimitValidationError, validate_manual_limit_config
 from ui.ui_src import ui_resources
+
+class _ManualTableValidationError(ValueError):
+    pass
 
 
 class ThresholdConfigWidget(QWidget):
@@ -28,6 +41,9 @@ class ThresholdConfigWidget(QWidget):
     Attributes:
         config_changed: 配置变更信号
     """
+
+    MANUAL_SEGMENT_KEYS = ("start_x", "start_y", "end_x", "end_y")
+    MANUAL_SEGMENT_ROW_LABELS = ("起始X", "起始Y", "截止X", "截止Y")
 
     config_changed = pyqtSignal()
 
@@ -60,6 +76,7 @@ class ThresholdConfigWidget(QWidget):
     def _init_ui(self):
         """初始化 UI 组件"""
         self
+        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)
         # 创建阈值复选框
         self.limit_checkbox = CheckBox("阈值", self)
         self.limit_checkbox.setChecked(self.load_config.get("limit_checked", False))
@@ -67,9 +84,8 @@ class ThresholdConfigWidget(QWidget):
 
         # 创建阈值选项组
         self.limit_group_box = GroupBox("选择阈值", self)
-        self.limit_group_box.setMinimumSize(180, 180)
-        if not self.limit_checkbox.isChecked():
-            self.limit_group_box.setDisabled(True)
+        self.limit_group_box.setMinimumWidth(400)
+        self.limit_group_box.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)
 
         # 配置数据展示
         self.limit_graph = PlotWidget()
@@ -87,6 +103,7 @@ class ThresholdConfigWidget(QWidget):
 
         # 组合布局
         group_layout = QVBoxLayout()
+        group_layout.setSizeConstraint(QLayout.SetMinimumSize)
         if self.allow_manual_limits:
             mode_layout = QHBoxLayout()
             mode_layout.addWidget(self.csv_mode_radio)
@@ -101,7 +118,6 @@ class ThresholdConfigWidget(QWidget):
 
         main_layout = QVBoxLayout()
         main_layout.addWidget(self.limit_checkbox)
-        main_layout.addStretch()
         main_layout.addWidget(self.limit_group_box)
         main_layout.setSpacing(10)
         main_layout.setContentsMargins(0, 0, 0, 0)
@@ -112,8 +128,6 @@ class ThresholdConfigWidget(QWidget):
         """创建配置文件选择布局"""
         self.config_dir_box = LineEdit()
         self.config_dir_box.setReadOnly(True)
-        if not self.limit_checkbox.isChecked():
-            self.config_dir_box.setDisabled(True)
         self.config_dir_box.textChanged.connect(self.config_changed.emit)
 
         icon_path = ":/ui/icon/folder-s.png"
@@ -126,6 +140,7 @@ class ThresholdConfigWidget(QWidget):
             self.config_dir_box.setText("已加载")
 
     def _create_manual_limit_controls(self) -> None:
+        self._syncing_manual_table = False
         limit_mode = str(self.load_config.get("limit_mode", "csv") or "csv").lower()
         self.csv_mode_radio = RadioButton("CSV阈值曲线")
         self.manual_mode_radio = RadioButton("手动上下限")
@@ -137,56 +152,123 @@ class ThresholdConfigWidget(QWidget):
         self.manual_mode_radio.toggled.connect(self._on_limit_mode_changed)
 
         self.manual_widget = QWidget(self)
+        self.manual_widget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)
         manual_layout = QVBoxLayout(self.manual_widget)
         manual_layout.setContentsMargins(0, 0, 0, 0)
 
         upper_row = QHBoxLayout()
         self.manual_upper_check = CheckBox("上限")
         self.manual_upper_check.setChecked(bool(self.load_config.get("manual_upper_enabled", True)))
-        self.manual_upper_spin = DoubleSpinBox()
-        self.manual_upper_spin.setRange(-300.0, 300.0)
-        self.manual_upper_spin.setDecimals(2)
-        self.manual_upper_spin.setSingleStep(1.0)
-        self.manual_upper_spin.setValue(float(self.load_config.get("manual_upper", 0.0) or 0.0))
         upper_row.addWidget(self.manual_upper_check)
-        upper_row.addWidget(self.manual_upper_spin)
-        upper_row.addWidget(Label("dB"))
         upper_row.addStretch()
+        self.manual_upper_table = self._create_manual_segment_table()
+        self._load_manual_segments(self.manual_upper_table, self.load_config.get("manual_upper_segments", []))
 
         lower_row = QHBoxLayout()
         self.manual_lower_check = CheckBox("下限")
         self.manual_lower_check.setChecked(bool(self.load_config.get("manual_lower_enabled", False)))
-        self.manual_lower_spin = DoubleSpinBox()
-        self.manual_lower_spin.setRange(-300.0, 300.0)
-        self.manual_lower_spin.setDecimals(2)
-        self.manual_lower_spin.setSingleStep(1.0)
-        self.manual_lower_spin.setValue(float(self.load_config.get("manual_lower", 0.0) or 0.0))
         lower_row.addWidget(self.manual_lower_check)
-        lower_row.addWidget(self.manual_lower_spin)
-        lower_row.addWidget(Label("dB"))
         lower_row.addStretch()
+        self.manual_lower_table = self._create_manual_segment_table()
+        self._load_manual_segments(self.manual_lower_table, self.load_config.get("manual_lower_segments", []))
 
         manual_layout.addLayout(upper_row)
+        manual_layout.addWidget(self.manual_upper_table)
         manual_layout.addLayout(lower_row)
+        manual_layout.addWidget(self.manual_lower_table)
 
         for widget in (
             self.manual_upper_check,
-            self.manual_upper_spin,
             self.manual_lower_check,
-            self.manual_lower_spin,
         ):
             if hasattr(widget, "stateChanged"):
                 widget.stateChanged.connect(self._on_manual_limit_changed)
-            if hasattr(widget, "valueChanged"):
-                widget.valueChanged.connect(self._on_manual_limit_changed)
+
+    def _create_manual_segment_table(self) -> TableWidget:
+        table = TableWidget(self.manual_widget)
+        table.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        table.setRowCount(len(self.MANUAL_SEGMENT_ROW_LABELS))
+        table.setColumnCount(1)
+        table.setVerticalHeaderLabels(self.MANUAL_SEGMENT_ROW_LABELS)
+        table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
+        table.verticalHeader().setSectionResizeMode(QHeaderView.ResizeToContents)
+        table.setMinimumWidth(360)
+        table.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self._ensure_manual_table_items(table)
+        self._update_manual_table_headers(table)
+        table.horizontalScrollBar().rangeChanged.connect(
+            lambda _minimum, _maximum, current_table=table: self._fit_manual_table_height(current_table)
+        )
+        self._fit_manual_table_height(table)
+        table.itemChanged.connect(lambda _item, current_table=table: self._on_manual_table_item_changed(current_table))
+        return table
+
+    def _fit_manual_table_height(self, table: TableWidget) -> None:
+        table.resizeRowsToContents()
+        height = (
+            table.horizontalHeader().height()
+            + sum(table.rowHeight(row) for row in range(table.rowCount()))
+            + table.frameWidth() * 2
+        )
+        scroll_bar = table.horizontalScrollBar()
+        if scroll_bar.maximum() > scroll_bar.minimum():
+            height += scroll_bar.sizeHint().height()
+        table.setFixedHeight(height)
+
+    def _load_manual_segments(self, table: TableWidget, raw_segments) -> None:
+        segments = raw_segments if isinstance(raw_segments, list) else []
+        column_count = max(len(segments) + 1, 1)
+        self._syncing_manual_table = True
+        try:
+            table.setColumnCount(column_count)
+            self._ensure_manual_table_items(table)
+            for column, segment in enumerate(segments):
+                if not isinstance(segment, dict):
+                    continue
+                for row, key in enumerate(self.MANUAL_SEGMENT_KEYS):
+                    value = segment.get(key, "")
+                    table.item(row, column).setText("" if value is None else str(value))
+            self._update_manual_table_headers(table)
+            self._fit_manual_table_height(table)
+        finally:
+            self._syncing_manual_table = False
+
+    def _ensure_manual_table_items(self, table: TableWidget) -> None:
+        for row in range(table.rowCount()):
+            for column in range(table.columnCount()):
+                if table.item(row, column) is None:
+                    table.setItem(row, column, QTableWidgetItem(""))
+
+    def _update_manual_table_headers(self, table: TableWidget) -> None:
+        table.setHorizontalHeaderLabels([str(index + 1) for index in range(table.columnCount())])
+
+    def _on_manual_table_item_changed(self, table: TableWidget) -> None:
+        if self._syncing_manual_table:
+            return
+        self._syncing_manual_table = True
+        try:
+            self._ensure_trailing_blank_manual_column(table)
+        finally:
+            self._syncing_manual_table = False
+        self._on_manual_limit_changed()
+
+    def _ensure_trailing_blank_manual_column(self, table: TableWidget) -> None:
+        if table.columnCount() == 0:
+            table.setColumnCount(1)
+            self._ensure_manual_table_items(table)
+            self._update_manual_table_headers(table)
+            self._fit_manual_table_height(table)
+            return
+        state, _segment = self._manual_table_column_state(table, table.columnCount() - 1)
+        if state == "complete":
+            table.insertColumn(table.columnCount())
+            self._ensure_manual_table_items(table)
+            self._update_manual_table_headers(table)
+            self._fit_manual_table_height(table)
 
     def _on_limit_checkbox_changed(self, state):
         """阈值复选框状态变更处理"""
         self.config_changed.emit()
-        if state == Qt.Checked:
-            self.limit_group_box.setDisabled(False)
-        else:
-            self.limit_group_box.setDisabled(True)
         self._sync_limit_mode_controls()
 
     def _on_limit_mode_changed(self, *args):
@@ -195,8 +277,60 @@ class ThresholdConfigWidget(QWidget):
 
     def _on_manual_limit_changed(self, *args):
         self.config_changed.emit()
-        if self.allow_manual_limits and self.current_limit_mode() == "manual":
-            self.draw_limit_curve(self._manual_limit_preview_data())
+        if self.allow_manual_limits:
+            self._sync_limit_mode_controls()
+
+    def _manual_table_column_texts(self, table: TableWidget, column: int) -> list[str]:
+        values = []
+        for row in range(len(self.MANUAL_SEGMENT_KEYS)):
+            item = table.item(row, column)
+            values.append(item.text().strip() if item is not None else "")
+        return values
+
+    def _manual_table_column_state(self, table: TableWidget, column: int) -> tuple[str, dict[str, float] | None]:
+        values = self._manual_table_column_texts(table, column)
+        if all(value == "" for value in values):
+            return "blank", None
+        if any(value == "" for value in values):
+            return "partial", None
+        try:
+            numeric_values = [float(value) for value in values]
+        except ValueError:
+            return "invalid", None
+        if not np.all(np.isfinite(numeric_values)):
+            return "invalid", None
+        return "complete", dict(zip(self.MANUAL_SEGMENT_KEYS, numeric_values))
+
+    def _manual_table_has_nonblank_column_after(self, table: TableWidget, column: int) -> bool:
+        for later_column in range(column + 1, table.columnCount()):
+            state, _segment = self._manual_table_column_state(table, later_column)
+            if state != "blank":
+                return True
+        return False
+
+    def _manual_table_segments_for_validation(self, table: TableWidget, label: str) -> list[dict[str, float]]:
+        segments = []
+        for column in range(table.columnCount()):
+            state, segment = self._manual_table_column_state(table, column)
+            column_label = column + 1
+            if state == "blank":
+                if self._manual_table_has_nonblank_column_after(table, column):
+                    raise _ManualTableValidationError(f"{label}第{column_label}列为空，但后续列存在数据")
+                continue
+            if state == "partial":
+                raise _ManualTableValidationError(f"{label}第{column_label}列未填写完整")
+            if state == "invalid":
+                raise _ManualTableValidationError(f"{label}第{column_label}列必须填写有限数字")
+            segments.append(segment)
+        return segments
+
+    def _complete_manual_table_segments(self, table: TableWidget) -> list[dict[str, float]]:
+        segments = []
+        for column in range(table.columnCount()):
+            state, segment = self._manual_table_column_state(table, column)
+            if state == "complete":
+                segments.append(segment)
+        return segments
 
     def current_limit_mode(self) -> str:
         if self.allow_manual_limits and hasattr(self, "manual_mode_radio") and self.manual_mode_radio.isChecked():
@@ -205,31 +339,69 @@ class ThresholdConfigWidget(QWidget):
 
     def _sync_limit_mode_controls(self) -> None:
         enabled = self.limit_checkbox.isChecked()
+        self.limit_group_box.setEnabled(True)
+        self.config_dir_box.setEnabled(True)
+        self.limit_group_box.setVisible(enabled)
+        self.limit_graph.setVisible(enabled)
         if not self.allow_manual_limits:
-            self.config_dir_box.setDisabled(not enabled)
+            self.config_dir_box.setVisible(enabled)
             return
 
         manual = enabled and self.current_limit_mode() == "manual"
         csv = enabled and not manual
-        self.config_dir_box.setDisabled(not csv)
+        self.csv_mode_radio.setVisible(enabled)
+        self.manual_mode_radio.setVisible(enabled)
+        self.config_dir_box.setVisible(csv)
         if self.manual_widget is not None:
-            self.manual_widget.setDisabled(not manual)
+            self.manual_widget.setEnabled(True)
+            self.manual_widget.setVisible(manual)
+            self.manual_upper_table.setVisible(manual and self.manual_upper_check.isChecked())
+            self.manual_lower_table.setVisible(manual and self.manual_lower_check.isChecked())
         if manual:
             self.draw_limit_curve(self._manual_limit_preview_data())
         else:
             self.draw_limit_curve(self.limit_data)
+        self._refresh_parent_scroll_layout()
+
+    def _refresh_parent_scroll_layout(self) -> None:
+        self.updateGeometry()
+        parent = self.parentWidget()
+        while parent is not None:
+            parent.updateGeometry()
+            refresh = getattr(parent, "_refresh_section_container_minimum_height", None)
+            if callable(refresh):
+                refresh()
+                return
+            parent = parent.parentWidget()
 
     def _manual_limit_preview_data(self):
         upper_enabled = bool(self.manual_upper_check.isChecked())
         lower_enabled = bool(self.manual_lower_check.isChecked())
-        upper = float(self.manual_upper_spin.value())
-        lower = float(self.manual_lower_spin.value())
-        x_values = [0.0, 1.0]
-        return (
-            x_values,
-            [upper, upper] if upper_enabled else [np.nan, np.nan],
-            [lower, lower] if lower_enabled else [np.nan, np.nan],
-        )
+        upper_segments = self._complete_manual_table_segments(self.manual_upper_table) if upper_enabled else []
+        lower_segments = self._complete_manual_table_segments(self.manual_lower_table) if lower_enabled else []
+        x_values, upper_values, lower_values = [], [], []
+
+        def append_gap_if_needed():
+            if x_values:
+                x_values.append(np.nan)
+                upper_values.append(np.nan)
+                lower_values.append(np.nan)
+
+        for segment in upper_segments:
+            append_gap_if_needed()
+            x_values.extend([segment["start_x"], segment["end_x"]])
+            upper_values.extend([segment["start_y"], segment["end_y"]])
+            lower_values.extend([np.nan, np.nan])
+
+        for segment in lower_segments:
+            append_gap_if_needed()
+            x_values.extend([segment["start_x"], segment["end_x"]])
+            upper_values.extend([np.nan, np.nan])
+            lower_values.extend([segment["start_y"], segment["end_y"]])
+
+        if not x_values:
+            return ([0.0], [np.nan], [np.nan])
+        return (x_values, upper_values, lower_values)
 
     def _on_config_dir_btn_clicked(self):
         """配置文件选择按钮点击处理"""
@@ -281,10 +453,10 @@ class ThresholdConfigWidget(QWidget):
         Args:
             result_data: 包含横坐标、上限和下限数据的元组
         """
+        self.limit_graph.clear()
         if not result_data:
             return
         duration, upper_limit, lower_limit = result_data
-        self.limit_graph.clear()
         if upper_limit is not None and not np.all(np.isnan(upper_limit)):
             self.limit_graph.plot(duration, upper_limit, pen=mkPen(color="r", width=2), name="Upper Limit")
         if lower_limit is not None and not np.all(np.isnan(lower_limit)):
@@ -310,9 +482,23 @@ class ThresholdConfigWidget(QWidget):
         return {
             "limit_mode": self.current_limit_mode(),
             "manual_upper_enabled": self.manual_upper_check.isChecked(),
-            "manual_upper": float(self.manual_upper_spin.value()),
             "manual_lower_enabled": self.manual_lower_check.isChecked(),
-            "manual_lower": float(self.manual_lower_spin.value()),
+            "manual_upper_segments": self._complete_manual_table_segments(self.manual_upper_table),
+            "manual_lower_segments": self._complete_manual_table_segments(self.manual_lower_table),
+        }
+
+    def _manual_limit_config_for_validation(self) -> dict:
+        upper_enabled = self.manual_upper_check.isChecked()
+        lower_enabled = self.manual_lower_check.isChecked()
+        return {
+            "manual_upper_enabled": upper_enabled,
+            "manual_lower_enabled": lower_enabled,
+            "manual_upper_segments": (
+                self._manual_table_segments_for_validation(self.manual_upper_table, "上限") if upper_enabled else []
+            ),
+            "manual_lower_segments": (
+                self._manual_table_segments_for_validation(self.manual_lower_table, "下限") if lower_enabled else []
+            ),
         }
 
     def validate(self) -> bool:
@@ -324,13 +510,10 @@ class ThresholdConfigWidget(QWidget):
         """
         if self.limit_checkbox.isChecked():
             if self.allow_manual_limits and self.current_limit_mode() == "manual":
-                upper_enabled = self.manual_upper_check.isChecked()
-                lower_enabled = self.manual_lower_check.isChecked()
-                if not upper_enabled and not lower_enabled:
-                    MessageBox.warning(self, "提示", "请至少启用一个手动阈值！")
-                    return False
-                if upper_enabled and lower_enabled and self.manual_lower_spin.value() > self.manual_upper_spin.value():
-                    MessageBox.warning(self, "提示", "手动阈值下限不能大于上限！")
+                try:
+                    validate_manual_limit_config(self._manual_limit_config_for_validation())
+                except (_ManualTableValidationError, ManualLimitValidationError) as exc:
+                    MessageBox.warning(self, "提示", str(exc))
                     return False
             elif not self.limit_data:
                 MessageBox.warning(self, "提示", "请先选择 CSV 配置文件！")

--- a/ui/ui_analysis_config/threshold_config_widget.py
+++ b/ui/ui_analysis_config/threshold_config_widget.py
@@ -68,6 +68,7 @@ def _draw_limit_curve(plot_widget: PlotWidget, result_data: tuple) -> None:
 class _ManualLimitEditorWidget(QWidget):
     MANUAL_SEGMENT_KEYS = ("start_x", "start_y", "end_x", "end_y")
     MANUAL_SEGMENT_ROW_LABELS = ("起始X", "起始Y", "截止X", "截止Y")
+    MANUAL_SEGMENT_COLUMN_WIDTH = 80
 
     config_changed = pyqtSignal()
 
@@ -175,7 +176,7 @@ class _ManualLimitEditorWidget(QWidget):
         table.setRowCount(len(self.MANUAL_SEGMENT_ROW_LABELS))
         table.setColumnCount(1)
         table.setVerticalHeaderLabels(self.MANUAL_SEGMENT_ROW_LABELS)
-        table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
+        self._configure_manual_table_columns(table)
         table.verticalHeader().setSectionResizeMode(QHeaderView.ResizeToContents)
         table.setMinimumWidth(360)
         table.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
@@ -200,6 +201,15 @@ class _ManualLimitEditorWidget(QWidget):
             height += scroll_bar.sizeHint().height()
         table.setFixedHeight(height)
 
+    def _configure_manual_table_columns(self, table: TableWidget) -> None:
+        header = table.horizontalHeader()
+        header.setSectionResizeMode(QHeaderView.Interactive)
+        header.setMinimumSectionSize(self.MANUAL_SEGMENT_COLUMN_WIDTH)
+        header.setDefaultSectionSize(self.MANUAL_SEGMENT_COLUMN_WIDTH)
+        for column in range(table.columnCount()):
+            if table.columnWidth(column) < self.MANUAL_SEGMENT_COLUMN_WIDTH:
+                table.setColumnWidth(column, self.MANUAL_SEGMENT_COLUMN_WIDTH)
+
     def _load_manual_segments(self, table: TableWidget, raw_segments) -> None:
         segments = raw_segments if isinstance(raw_segments, list) else []
         column_count = max(len(segments) + 1, 1)
@@ -218,6 +228,7 @@ class _ManualLimitEditorWidget(QWidget):
                     value = segment.get(key, "")
                     table.item(row, column).setText("" if value is None else str(value))
             self._update_manual_table_headers(table)
+            self._configure_manual_table_columns(table)
             self._fit_manual_table_height(table)
         finally:
             self._syncing_manual_table = previous_syncing
@@ -246,6 +257,7 @@ class _ManualLimitEditorWidget(QWidget):
             table.setColumnCount(1)
             self._ensure_manual_table_items(table)
             self._update_manual_table_headers(table)
+            self._configure_manual_table_columns(table)
             self._fit_manual_table_height(table)
             return
         state, _segment = self._manual_table_column_state(table, table.columnCount() - 1)
@@ -253,6 +265,7 @@ class _ManualLimitEditorWidget(QWidget):
             table.insertColumn(table.columnCount())
             self._ensure_manual_table_items(table)
             self._update_manual_table_headers(table)
+            self._configure_manual_table_columns(table)
             self._fit_manual_table_height(table)
 
     def _on_manual_check_changed(self, *args) -> None:

--- a/ui/ui_analysis_config/threshold_config_widget.py
+++ b/ui/ui_analysis_config/threshold_config_widget.py
@@ -69,6 +69,8 @@ class _ManualLimitEditorWidget(QWidget):
     MANUAL_SEGMENT_KEYS = ("start_x", "start_y", "end_x", "end_y")
     MANUAL_SEGMENT_ROW_LABELS = ("起始X", "起始Y", "截止X", "截止Y")
     MANUAL_SEGMENT_COLUMN_WIDTH = 80
+    MANUAL_SEGMENT_STRETCH_COLUMN_LIMIT = 7
+    MANUAL_SEGMENT_STRETCH_MINIMUM_SECTION_SIZE = 0
 
     config_changed = pyqtSignal()
 
@@ -203,6 +205,11 @@ class _ManualLimitEditorWidget(QWidget):
 
     def _configure_manual_table_columns(self, table: TableWidget) -> None:
         header = table.horizontalHeader()
+        if table.columnCount() <= self.MANUAL_SEGMENT_STRETCH_COLUMN_LIMIT:
+            header.setMinimumSectionSize(self.MANUAL_SEGMENT_STRETCH_MINIMUM_SECTION_SIZE)
+            header.setSectionResizeMode(QHeaderView.Stretch)
+            return
+
         header.setSectionResizeMode(QHeaderView.Interactive)
         header.setMinimumSectionSize(self.MANUAL_SEGMENT_COLUMN_WIDTH)
         header.setDefaultSectionSize(self.MANUAL_SEGMENT_COLUMN_WIDTH)

--- a/ui/ui_analysis_config/threshold_config_widget.py
+++ b/ui/ui_analysis_config/threshold_config_widget.py
@@ -15,6 +15,7 @@ from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import (
     QWidget,
+    QDialog,
     QFileDialog,
     QHBoxLayout,
     QVBoxLayout,
@@ -26,12 +27,350 @@ from PyQt5.QtWidgets import (
 from pyqtgraph import PlotWidget, mkPen
 
 from consts.running_consts import DEFAULT_DIR
-from ui.custom_ui_widget.widgets import CheckBox, GroupBox, LineEdit, MessageBox, RadioButton, TableWidget
+from ui.custom_ui_widget.widgets import CheckBox, GroupBox, LineEdit, MessageBox, PushButton, RadioButton, TableWidget
 from ui.ui_analysis_config.manual_limit_segments import ManualLimitValidationError, validate_manual_limit_config
 from ui.ui_src import ui_resources
 
 class _ManualTableValidationError(ValueError):
     pass
+
+
+def _set_graph_label_until(plot_widget: PlotWidget, model_type: str) -> None:
+    model_type = model_type or ""
+    if "SPLF" in model_type:
+        plot_widget.setLabel("left", "SPLF (dB)")
+        plot_widget.setLabel("bottom", "Frequency (Hz)")
+    elif "SPL" in model_type:
+        plot_widget.setLabel("left", "SPL (dB)")
+        plot_widget.setLabel("bottom", "Time (s)")
+    elif "FR" in model_type:
+        plot_widget.setLabel("left", "Amplitude (dB)")
+        plot_widget.setLabel("bottom", "Frequency (Hz)")
+    elif "PRB" in model_type:
+        plot_widget.setLabel("left", "phon")
+        plot_widget.setLabel("bottom", "Frequency (Hz)")
+    elif "RB" in model_type or "HD" in model_type:
+        plot_widget.setLabel("left", "Distortion (%)")
+        plot_widget.setLabel("bottom", "Frequency (Hz)")
+
+
+def _draw_limit_curve(plot_widget: PlotWidget, result_data: tuple) -> None:
+    plot_widget.clear()
+    if not result_data:
+        return
+    duration, upper_limit, lower_limit = result_data
+    if upper_limit is not None and not np.all(np.isnan(upper_limit)):
+        plot_widget.plot(duration, upper_limit, pen=mkPen(color="r", width=2), name="Upper Limit")
+    if lower_limit is not None and not np.all(np.isnan(lower_limit)):
+        plot_widget.plot(duration, lower_limit, pen=mkPen(color="b", width=2), name="Lower Limit")
+
+
+class _ManualLimitEditorWidget(QWidget):
+    MANUAL_SEGMENT_KEYS = ("start_x", "start_y", "end_x", "end_y")
+    MANUAL_SEGMENT_ROW_LABELS = ("起始X", "起始Y", "截止X", "截止Y")
+
+    config_changed = pyqtSignal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._syncing_manual_table = False
+
+        self.manual_upper_check = CheckBox("上限", self)
+        self.manual_lower_check = CheckBox("下限", self)
+        self.manual_upper_table = self._create_manual_segment_table()
+        self.manual_lower_table = self._create_manual_segment_table()
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        upper_row = QHBoxLayout()
+        upper_row.addWidget(self.manual_upper_check)
+        upper_row.addStretch()
+        layout.addLayout(upper_row)
+        layout.addWidget(self.manual_upper_table)
+
+        lower_row = QHBoxLayout()
+        lower_row.addWidget(self.manual_lower_check)
+        lower_row.addStretch()
+        layout.addLayout(lower_row)
+        layout.addWidget(self.manual_lower_table)
+
+        self.manual_upper_check.stateChanged.connect(self._on_manual_check_changed)
+        self.manual_lower_check.stateChanged.connect(self._on_manual_check_changed)
+
+    def load_manual_config(self, config: dict) -> None:
+        config = config or {}
+        self._syncing_manual_table = True
+        try:
+            self.manual_upper_check.setChecked(bool(config.get("manual_upper_enabled", True)))
+            self.manual_lower_check.setChecked(bool(config.get("manual_lower_enabled", False)))
+            self._load_manual_segments(self.manual_upper_table, config.get("manual_upper_segments", []))
+            self._load_manual_segments(self.manual_lower_table, config.get("manual_lower_segments", []))
+        finally:
+            self._syncing_manual_table = False
+        self._sync_table_visibility()
+
+    def editable_manual_config(self) -> dict:
+        return {
+            "manual_upper_enabled": self.manual_upper_check.isChecked(),
+            "manual_lower_enabled": self.manual_lower_check.isChecked(),
+            "manual_upper_segments": self._manual_table_raw_segments(self.manual_upper_table),
+            "manual_lower_segments": self._manual_table_raw_segments(self.manual_lower_table),
+        }
+
+    def manual_config(self) -> dict:
+        return {
+            "manual_upper_enabled": self.manual_upper_check.isChecked(),
+            "manual_lower_enabled": self.manual_lower_check.isChecked(),
+            "manual_upper_segments": self._complete_manual_table_segments(self.manual_upper_table),
+            "manual_lower_segments": self._complete_manual_table_segments(self.manual_lower_table),
+        }
+
+    def manual_config_for_validation(self) -> dict:
+        upper_enabled = self.manual_upper_check.isChecked()
+        lower_enabled = self.manual_lower_check.isChecked()
+        return {
+            "manual_upper_enabled": upper_enabled,
+            "manual_lower_enabled": lower_enabled,
+            "manual_upper_segments": (
+                self._manual_table_segments_for_validation(self.manual_upper_table, "上限") if upper_enabled else []
+            ),
+            "manual_lower_segments": (
+                self._manual_table_segments_for_validation(self.manual_lower_table, "下限") if lower_enabled else []
+            ),
+        }
+
+    def manual_limit_preview_data(self):
+        upper_enabled = bool(self.manual_upper_check.isChecked())
+        lower_enabled = bool(self.manual_lower_check.isChecked())
+        upper_segments = self._complete_manual_table_segments(self.manual_upper_table) if upper_enabled else []
+        lower_segments = self._complete_manual_table_segments(self.manual_lower_table) if lower_enabled else []
+        x_values, upper_values, lower_values = [], [], []
+
+        def append_gap_if_needed():
+            if x_values:
+                x_values.append(np.nan)
+                upper_values.append(np.nan)
+                lower_values.append(np.nan)
+
+        for segment in upper_segments:
+            append_gap_if_needed()
+            x_values.extend([segment["start_x"], segment["end_x"]])
+            upper_values.extend([segment["start_y"], segment["end_y"]])
+            lower_values.extend([np.nan, np.nan])
+
+        for segment in lower_segments:
+            append_gap_if_needed()
+            x_values.extend([segment["start_x"], segment["end_x"]])
+            upper_values.extend([np.nan, np.nan])
+            lower_values.extend([segment["start_y"], segment["end_y"]])
+
+        if not x_values:
+            return ([0.0], [np.nan], [np.nan])
+        return (x_values, upper_values, lower_values)
+
+    def _create_manual_segment_table(self) -> TableWidget:
+        table = TableWidget(self)
+        table.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        table.setRowCount(len(self.MANUAL_SEGMENT_ROW_LABELS))
+        table.setColumnCount(1)
+        table.setVerticalHeaderLabels(self.MANUAL_SEGMENT_ROW_LABELS)
+        table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
+        table.verticalHeader().setSectionResizeMode(QHeaderView.ResizeToContents)
+        table.setMinimumWidth(360)
+        table.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self._ensure_manual_table_items(table)
+        self._update_manual_table_headers(table)
+        table.horizontalScrollBar().rangeChanged.connect(
+            lambda _minimum, _maximum, current_table=table: self._fit_manual_table_height(current_table)
+        )
+        self._fit_manual_table_height(table)
+        table.itemChanged.connect(lambda _item, current_table=table: self._on_manual_table_item_changed(current_table))
+        return table
+
+    def _fit_manual_table_height(self, table: TableWidget) -> None:
+        table.resizeRowsToContents()
+        height = (
+            table.horizontalHeader().height()
+            + sum(table.rowHeight(row) for row in range(table.rowCount()))
+            + table.frameWidth() * 2
+        )
+        scroll_bar = table.horizontalScrollBar()
+        if scroll_bar.maximum() > scroll_bar.minimum():
+            height += scroll_bar.sizeHint().height()
+        table.setFixedHeight(height)
+
+    def _load_manual_segments(self, table: TableWidget, raw_segments) -> None:
+        segments = raw_segments if isinstance(raw_segments, list) else []
+        column_count = max(len(segments) + 1, 1)
+        previous_syncing = self._syncing_manual_table
+        self._syncing_manual_table = True
+        try:
+            table.setColumnCount(column_count)
+            self._ensure_manual_table_items(table)
+            for row in range(table.rowCount()):
+                for column in range(table.columnCount()):
+                    table.item(row, column).setText("")
+            for column, segment in enumerate(segments):
+                if not isinstance(segment, dict):
+                    continue
+                for row, key in enumerate(self.MANUAL_SEGMENT_KEYS):
+                    value = segment.get(key, "")
+                    table.item(row, column).setText("" if value is None else str(value))
+            self._update_manual_table_headers(table)
+            self._fit_manual_table_height(table)
+        finally:
+            self._syncing_manual_table = previous_syncing
+
+    def _ensure_manual_table_items(self, table: TableWidget) -> None:
+        for row in range(table.rowCount()):
+            for column in range(table.columnCount()):
+                if table.item(row, column) is None:
+                    table.setItem(row, column, QTableWidgetItem(""))
+
+    def _update_manual_table_headers(self, table: TableWidget) -> None:
+        table.setHorizontalHeaderLabels([str(index + 1) for index in range(table.columnCount())])
+
+    def _on_manual_table_item_changed(self, table: TableWidget) -> None:
+        if self._syncing_manual_table:
+            return
+        self._syncing_manual_table = True
+        try:
+            self._ensure_trailing_blank_manual_column(table)
+        finally:
+            self._syncing_manual_table = False
+        self.config_changed.emit()
+
+    def _ensure_trailing_blank_manual_column(self, table: TableWidget) -> None:
+        if table.columnCount() == 0:
+            table.setColumnCount(1)
+            self._ensure_manual_table_items(table)
+            self._update_manual_table_headers(table)
+            self._fit_manual_table_height(table)
+            return
+        state, _segment = self._manual_table_column_state(table, table.columnCount() - 1)
+        if state == "complete":
+            table.insertColumn(table.columnCount())
+            self._ensure_manual_table_items(table)
+            self._update_manual_table_headers(table)
+            self._fit_manual_table_height(table)
+
+    def _on_manual_check_changed(self, *args) -> None:
+        if self._syncing_manual_table:
+            return
+        self._sync_table_visibility()
+        self.config_changed.emit()
+
+    def _sync_table_visibility(self) -> None:
+        self.manual_upper_table.setVisible(self.manual_upper_check.isChecked())
+        self.manual_lower_table.setVisible(self.manual_lower_check.isChecked())
+
+    def _manual_table_column_texts(self, table: TableWidget, column: int) -> list[str]:
+        values = []
+        for row in range(len(self.MANUAL_SEGMENT_KEYS)):
+            item = table.item(row, column)
+            values.append(item.text().strip() if item is not None else "")
+        return values
+
+    def _manual_table_column_state(self, table: TableWidget, column: int) -> tuple[str, dict[str, float] | None]:
+        values = self._manual_table_column_texts(table, column)
+        if all(value == "" for value in values):
+            return "blank", None
+        if any(value == "" for value in values):
+            return "partial", None
+        try:
+            numeric_values = [float(value) for value in values]
+        except ValueError:
+            return "invalid", None
+        if not np.all(np.isfinite(numeric_values)):
+            return "invalid", None
+        return "complete", dict(zip(self.MANUAL_SEGMENT_KEYS, numeric_values))
+
+    def _manual_table_has_nonblank_column_after(self, table: TableWidget, column: int) -> bool:
+        for later_column in range(column + 1, table.columnCount()):
+            state, _segment = self._manual_table_column_state(table, later_column)
+            if state != "blank":
+                return True
+        return False
+
+    def _manual_table_segments_for_validation(self, table: TableWidget, label: str) -> list[dict[str, float]]:
+        segments = []
+        for column in range(table.columnCount()):
+            state, segment = self._manual_table_column_state(table, column)
+            column_label = column + 1
+            if state == "blank":
+                if self._manual_table_has_nonblank_column_after(table, column):
+                    raise _ManualTableValidationError(f"{label}第{column_label}列为空，但后续列存在数据")
+                continue
+            if state == "partial":
+                raise _ManualTableValidationError(f"{label}第{column_label}列未填写完整")
+            if state == "invalid":
+                raise _ManualTableValidationError(f"{label}第{column_label}列必须填写有限数字")
+            segments.append(segment)
+        return segments
+
+    def _complete_manual_table_segments(self, table: TableWidget) -> list[dict[str, float]]:
+        segments = []
+        for column in range(table.columnCount()):
+            state, segment = self._manual_table_column_state(table, column)
+            if state == "complete":
+                segments.append(segment)
+        return segments
+
+    def _manual_table_raw_segments(self, table: TableWidget) -> list[dict[str, str]]:
+        segments = []
+        for column in range(table.columnCount()):
+            values = self._manual_table_column_texts(table, column)
+            if all(value == "" for value in values):
+                continue
+            segments.append(dict(zip(self.MANUAL_SEGMENT_KEYS, values)))
+        return segments
+
+
+class _ManualLimitEditorDialog(QDialog):
+    def __init__(self, parent, manual_config: dict, model_type: str):
+        super().__init__(parent)
+        self._accepted_manual_config = {}
+        self.setWindowTitle("编辑上下限")
+        self.setModal(True)
+
+        self.editor = _ManualLimitEditorWidget(self)
+        self.editor.load_manual_config(manual_config)
+
+        self.limit_graph = PlotWidget()
+        self.limit_graph.showGrid(True, True, 0.7)
+        self.limit_graph.setMinimumSize(180, 180)
+        _set_graph_label_until(self.limit_graph, model_type)
+
+        self.confirm_button = PushButton("确定", self)
+        self.confirm_button.clicked.connect(self._on_confirm_clicked)
+
+        button_layout = QHBoxLayout()
+        button_layout.addStretch()
+        button_layout.addWidget(self.confirm_button)
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(self.editor)
+        layout.addWidget(self.limit_graph)
+        layout.addLayout(button_layout)
+
+        self.editor.config_changed.connect(self._refresh_preview)
+        self._refresh_preview()
+
+    def _refresh_preview(self) -> None:
+        _draw_limit_curve(self.limit_graph, self.editor.manual_limit_preview_data())
+
+    def _on_confirm_clicked(self) -> None:
+        try:
+            validate_manual_limit_config(self.editor.manual_config_for_validation())
+        except (_ManualTableValidationError, ManualLimitValidationError) as exc:
+            MessageBox.warning(self, "提示", str(exc))
+            return
+        self._accepted_manual_config = self.editor.manual_config()
+        self.accept()
+
+    def manual_config(self) -> dict:
+        return dict(self._accepted_manual_config)
 
 
 class ThresholdConfigWidget(QWidget):
@@ -140,7 +479,6 @@ class ThresholdConfigWidget(QWidget):
             self.config_dir_box.setText("已加载")
 
     def _create_manual_limit_controls(self) -> None:
-        self._syncing_manual_table = False
         limit_mode = str(self.load_config.get("limit_mode", "csv") or "csv").lower()
         self.csv_mode_radio = RadioButton("CSV阈值曲线")
         self.manual_mode_radio = RadioButton("手动上下限")
@@ -151,120 +489,18 @@ class ThresholdConfigWidget(QWidget):
         self.csv_mode_radio.toggled.connect(self._on_limit_mode_changed)
         self.manual_mode_radio.toggled.connect(self._on_limit_mode_changed)
 
+        self._manual_state_editor = _ManualLimitEditorWidget(self)
+        self._manual_state_editor.hide()
+        self._manual_state_editor.load_manual_config(self.load_config)
+
         self.manual_widget = QWidget(self)
         self.manual_widget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)
-        manual_layout = QVBoxLayout(self.manual_widget)
+        manual_layout = QHBoxLayout(self.manual_widget)
         manual_layout.setContentsMargins(0, 0, 0, 0)
-
-        upper_row = QHBoxLayout()
-        self.manual_upper_check = CheckBox("上限")
-        self.manual_upper_check.setChecked(bool(self.load_config.get("manual_upper_enabled", True)))
-        upper_row.addWidget(self.manual_upper_check)
-        upper_row.addStretch()
-        self.manual_upper_table = self._create_manual_segment_table()
-        self._load_manual_segments(self.manual_upper_table, self.load_config.get("manual_upper_segments", []))
-
-        lower_row = QHBoxLayout()
-        self.manual_lower_check = CheckBox("下限")
-        self.manual_lower_check.setChecked(bool(self.load_config.get("manual_lower_enabled", False)))
-        lower_row.addWidget(self.manual_lower_check)
-        lower_row.addStretch()
-        self.manual_lower_table = self._create_manual_segment_table()
-        self._load_manual_segments(self.manual_lower_table, self.load_config.get("manual_lower_segments", []))
-
-        manual_layout.addLayout(upper_row)
-        manual_layout.addWidget(self.manual_upper_table)
-        manual_layout.addLayout(lower_row)
-        manual_layout.addWidget(self.manual_lower_table)
-
-        for widget in (
-            self.manual_upper_check,
-            self.manual_lower_check,
-        ):
-            if hasattr(widget, "stateChanged"):
-                widget.stateChanged.connect(self._on_manual_limit_changed)
-
-    def _create_manual_segment_table(self) -> TableWidget:
-        table = TableWidget(self.manual_widget)
-        table.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
-        table.setRowCount(len(self.MANUAL_SEGMENT_ROW_LABELS))
-        table.setColumnCount(1)
-        table.setVerticalHeaderLabels(self.MANUAL_SEGMENT_ROW_LABELS)
-        table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
-        table.verticalHeader().setSectionResizeMode(QHeaderView.ResizeToContents)
-        table.setMinimumWidth(360)
-        table.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
-        self._ensure_manual_table_items(table)
-        self._update_manual_table_headers(table)
-        table.horizontalScrollBar().rangeChanged.connect(
-            lambda _minimum, _maximum, current_table=table: self._fit_manual_table_height(current_table)
-        )
-        self._fit_manual_table_height(table)
-        table.itemChanged.connect(lambda _item, current_table=table: self._on_manual_table_item_changed(current_table))
-        return table
-
-    def _fit_manual_table_height(self, table: TableWidget) -> None:
-        table.resizeRowsToContents()
-        height = (
-            table.horizontalHeader().height()
-            + sum(table.rowHeight(row) for row in range(table.rowCount()))
-            + table.frameWidth() * 2
-        )
-        scroll_bar = table.horizontalScrollBar()
-        if scroll_bar.maximum() > scroll_bar.minimum():
-            height += scroll_bar.sizeHint().height()
-        table.setFixedHeight(height)
-
-    def _load_manual_segments(self, table: TableWidget, raw_segments) -> None:
-        segments = raw_segments if isinstance(raw_segments, list) else []
-        column_count = max(len(segments) + 1, 1)
-        self._syncing_manual_table = True
-        try:
-            table.setColumnCount(column_count)
-            self._ensure_manual_table_items(table)
-            for column, segment in enumerate(segments):
-                if not isinstance(segment, dict):
-                    continue
-                for row, key in enumerate(self.MANUAL_SEGMENT_KEYS):
-                    value = segment.get(key, "")
-                    table.item(row, column).setText("" if value is None else str(value))
-            self._update_manual_table_headers(table)
-            self._fit_manual_table_height(table)
-        finally:
-            self._syncing_manual_table = False
-
-    def _ensure_manual_table_items(self, table: TableWidget) -> None:
-        for row in range(table.rowCount()):
-            for column in range(table.columnCount()):
-                if table.item(row, column) is None:
-                    table.setItem(row, column, QTableWidgetItem(""))
-
-    def _update_manual_table_headers(self, table: TableWidget) -> None:
-        table.setHorizontalHeaderLabels([str(index + 1) for index in range(table.columnCount())])
-
-    def _on_manual_table_item_changed(self, table: TableWidget) -> None:
-        if self._syncing_manual_table:
-            return
-        self._syncing_manual_table = True
-        try:
-            self._ensure_trailing_blank_manual_column(table)
-        finally:
-            self._syncing_manual_table = False
-        self._on_manual_limit_changed()
-
-    def _ensure_trailing_blank_manual_column(self, table: TableWidget) -> None:
-        if table.columnCount() == 0:
-            table.setColumnCount(1)
-            self._ensure_manual_table_items(table)
-            self._update_manual_table_headers(table)
-            self._fit_manual_table_height(table)
-            return
-        state, _segment = self._manual_table_column_state(table, table.columnCount() - 1)
-        if state == "complete":
-            table.insertColumn(table.columnCount())
-            self._ensure_manual_table_items(table)
-            self._update_manual_table_headers(table)
-            self._fit_manual_table_height(table)
+        self.manual_edit_button = PushButton("编辑上下限", self.manual_widget)
+        self.manual_edit_button.clicked.connect(self._on_manual_edit_clicked)
+        manual_layout.addWidget(self.manual_edit_button)
+        manual_layout.addStretch()
 
     def _on_limit_checkbox_changed(self, state):
         """阈值复选框状态变更处理"""
@@ -275,62 +511,19 @@ class ThresholdConfigWidget(QWidget):
         self.config_changed.emit()
         self._sync_limit_mode_controls()
 
-    def _on_manual_limit_changed(self, *args):
+    def _accepted_manual_config(self) -> dict:
+        return self._manual_state_editor.editable_manual_config()
+
+    def _create_manual_limit_dialog(self) -> _ManualLimitEditorDialog:
+        return _ManualLimitEditorDialog(self, self._accepted_manual_config(), self.model_type)
+
+    def _on_manual_edit_clicked(self) -> None:
+        dialog = self._create_manual_limit_dialog()
+        if dialog.exec_() != QDialog.Accepted:
+            return
+        self._manual_state_editor.load_manual_config(dialog.manual_config())
         self.config_changed.emit()
-        if self.allow_manual_limits:
-            self._sync_limit_mode_controls()
-
-    def _manual_table_column_texts(self, table: TableWidget, column: int) -> list[str]:
-        values = []
-        for row in range(len(self.MANUAL_SEGMENT_KEYS)):
-            item = table.item(row, column)
-            values.append(item.text().strip() if item is not None else "")
-        return values
-
-    def _manual_table_column_state(self, table: TableWidget, column: int) -> tuple[str, dict[str, float] | None]:
-        values = self._manual_table_column_texts(table, column)
-        if all(value == "" for value in values):
-            return "blank", None
-        if any(value == "" for value in values):
-            return "partial", None
-        try:
-            numeric_values = [float(value) for value in values]
-        except ValueError:
-            return "invalid", None
-        if not np.all(np.isfinite(numeric_values)):
-            return "invalid", None
-        return "complete", dict(zip(self.MANUAL_SEGMENT_KEYS, numeric_values))
-
-    def _manual_table_has_nonblank_column_after(self, table: TableWidget, column: int) -> bool:
-        for later_column in range(column + 1, table.columnCount()):
-            state, _segment = self._manual_table_column_state(table, later_column)
-            if state != "blank":
-                return True
-        return False
-
-    def _manual_table_segments_for_validation(self, table: TableWidget, label: str) -> list[dict[str, float]]:
-        segments = []
-        for column in range(table.columnCount()):
-            state, segment = self._manual_table_column_state(table, column)
-            column_label = column + 1
-            if state == "blank":
-                if self._manual_table_has_nonblank_column_after(table, column):
-                    raise _ManualTableValidationError(f"{label}第{column_label}列为空，但后续列存在数据")
-                continue
-            if state == "partial":
-                raise _ManualTableValidationError(f"{label}第{column_label}列未填写完整")
-            if state == "invalid":
-                raise _ManualTableValidationError(f"{label}第{column_label}列必须填写有限数字")
-            segments.append(segment)
-        return segments
-
-    def _complete_manual_table_segments(self, table: TableWidget) -> list[dict[str, float]]:
-        segments = []
-        for column in range(table.columnCount()):
-            state, segment = self._manual_table_column_state(table, column)
-            if state == "complete":
-                segments.append(segment)
-        return segments
+        self._sync_limit_mode_controls()
 
     def current_limit_mode(self) -> str:
         if self.allow_manual_limits and hasattr(self, "manual_mode_radio") and self.manual_mode_radio.isChecked():
@@ -355,8 +548,6 @@ class ThresholdConfigWidget(QWidget):
         if self.manual_widget is not None:
             self.manual_widget.setEnabled(True)
             self.manual_widget.setVisible(manual)
-            self.manual_upper_table.setVisible(manual and self.manual_upper_check.isChecked())
-            self.manual_lower_table.setVisible(manual and self.manual_lower_check.isChecked())
         if manual:
             self.draw_limit_curve(self._manual_limit_preview_data())
         else:
@@ -375,33 +566,7 @@ class ThresholdConfigWidget(QWidget):
             parent = parent.parentWidget()
 
     def _manual_limit_preview_data(self):
-        upper_enabled = bool(self.manual_upper_check.isChecked())
-        lower_enabled = bool(self.manual_lower_check.isChecked())
-        upper_segments = self._complete_manual_table_segments(self.manual_upper_table) if upper_enabled else []
-        lower_segments = self._complete_manual_table_segments(self.manual_lower_table) if lower_enabled else []
-        x_values, upper_values, lower_values = [], [], []
-
-        def append_gap_if_needed():
-            if x_values:
-                x_values.append(np.nan)
-                upper_values.append(np.nan)
-                lower_values.append(np.nan)
-
-        for segment in upper_segments:
-            append_gap_if_needed()
-            x_values.extend([segment["start_x"], segment["end_x"]])
-            upper_values.extend([segment["start_y"], segment["end_y"]])
-            lower_values.extend([np.nan, np.nan])
-
-        for segment in lower_segments:
-            append_gap_if_needed()
-            x_values.extend([segment["start_x"], segment["end_x"]])
-            upper_values.extend([np.nan, np.nan])
-            lower_values.extend([segment["start_y"], segment["end_y"]])
-
-        if not x_values:
-            return ([0.0], [np.nan], [np.nan])
-        return (x_values, upper_values, lower_values)
+        return self._manual_state_editor.manual_limit_preview_data()
 
     def _on_config_dir_btn_clicked(self):
         """配置文件选择按钮点击处理"""
@@ -429,22 +594,7 @@ class ThresholdConfigWidget(QWidget):
             model_type: 模型类型
         """
         self.model_type = model_type
-        # 此处可根据 model_type 设置不同的图表标签
-        if "SPLF" in model_type:
-            self.limit_graph.setLabel("left", "SPLF (dB)")
-            self.limit_graph.setLabel("bottom", "Frequency (Hz)")
-        elif "SPL" in model_type:
-            self.limit_graph.setLabel("left", "SPL (dB)")
-            self.limit_graph.setLabel("bottom", "Time (s)")
-        elif "FR" in model_type:
-            self.limit_graph.setLabel("left", "Amplitude (dB)")
-            self.limit_graph.setLabel("bottom", "Frequency (Hz)")
-        elif "PRB" in model_type:
-            self.limit_graph.setLabel("left", "phon")
-            self.limit_graph.setLabel("bottom", "Frequency (Hz)")
-        elif "RB" in model_type or "HD" in model_type:
-            self.limit_graph.setLabel("left", "Distortion (%)")
-            self.limit_graph.setLabel("bottom", "Frequency (Hz)")
+        _set_graph_label_until(self.limit_graph, model_type)
 
     def draw_limit_curve(self, result_data: tuple):
         """
@@ -453,14 +603,7 @@ class ThresholdConfigWidget(QWidget):
         Args:
             result_data: 包含横坐标、上限和下限数据的元组
         """
-        self.limit_graph.clear()
-        if not result_data:
-            return
-        duration, upper_limit, lower_limit = result_data
-        if upper_limit is not None and not np.all(np.isnan(upper_limit)):
-            self.limit_graph.plot(duration, upper_limit, pen=mkPen(color="r", width=2), name="Upper Limit")
-        if lower_limit is not None and not np.all(np.isnan(lower_limit)):
-            self.limit_graph.plot(duration, lower_limit, pen=mkPen(color="b", width=2), name="Lower Limit")
+        _draw_limit_curve(self.limit_graph, result_data)
 
     def get_config(self) -> dict:
         """
@@ -481,25 +624,11 @@ class ThresholdConfigWidget(QWidget):
             return {}
         return {
             "limit_mode": self.current_limit_mode(),
-            "manual_upper_enabled": self.manual_upper_check.isChecked(),
-            "manual_lower_enabled": self.manual_lower_check.isChecked(),
-            "manual_upper_segments": self._complete_manual_table_segments(self.manual_upper_table),
-            "manual_lower_segments": self._complete_manual_table_segments(self.manual_lower_table),
+            **self._manual_state_editor.manual_config(),
         }
 
     def _manual_limit_config_for_validation(self) -> dict:
-        upper_enabled = self.manual_upper_check.isChecked()
-        lower_enabled = self.manual_lower_check.isChecked()
-        return {
-            "manual_upper_enabled": upper_enabled,
-            "manual_lower_enabled": lower_enabled,
-            "manual_upper_segments": (
-                self._manual_table_segments_for_validation(self.manual_upper_table, "上限") if upper_enabled else []
-            ),
-            "manual_lower_segments": (
-                self._manual_table_segments_for_validation(self.manual_lower_table, "下限") if lower_enabled else []
-            ),
-        }
+        return self._manual_state_editor.manual_config_for_validation()
 
     def validate(self) -> bool:
         """

--- a/ui/ui_config/analysis_default_config.json
+++ b/ui/ui_config/analysis_default_config.json
@@ -16,9 +16,9 @@
         "limit_mode": "csv",
         "limit_data": null,
         "manual_upper_enabled": true,
-        "manual_upper": 0.0,
         "manual_lower_enabled": false,
-        "manual_lower": 0.0,
+        "manual_upper_segments": [],
+        "manual_lower_segments": [],
         "weighting": "Z",
         "show_overall_spl": false,
         "analysis_channel": 0
@@ -29,6 +29,11 @@
         "golden_sample_checked": false,
         "limit_checked": false,
         "limit_data": null,
+        "limit_mode": "csv",
+        "manual_upper_enabled": true,
+        "manual_lower_enabled": false,
+        "manual_upper_segments": [],
+        "manual_lower_segments": [],
         "weighting": "Z",
         "analysis_channel": 0
     },
@@ -65,7 +70,12 @@
         "octave_smoothing": 0,
         "golden_sample_checked": false,
         "limit_checked": false,
-        "limit_data": null
+        "limit_data": null,
+        "limit_mode": "csv",
+        "manual_upper_enabled": true,
+        "manual_lower_enabled": false,
+        "manual_upper_segments": [],
+        "manual_lower_segments": []
     },
     "FBA": {
         "band_strategy": "1/3 \u500d\u9891\u7a0b",
@@ -92,7 +102,12 @@
         "all_checked": false,
         "golden_sample_checked": false,
         "limit_checked": false,
-        "limit_data": null
+        "limit_data": null,
+        "limit_mode": "csv",
+        "manual_upper_enabled": true,
+        "manual_lower_enabled": false,
+        "manual_upper_segments": [],
+        "manual_lower_segments": []
     },
     "RB": {
         "selected_labels": [
@@ -116,7 +131,12 @@
         "all_checked": false,
         "golden_sample_checked": false,
         "limit_checked": false,
-        "limit_data": null
+        "limit_data": null,
+        "limit_mode": "csv",
+        "manual_upper_enabled": true,
+        "manual_lower_enabled": false,
+        "manual_upper_segments": [],
+        "manual_lower_segments": []
     },
     "PRB": {
         "prb_method": "sc",
@@ -125,7 +145,12 @@
         },
         "golden_sample_checked": false,
         "limit_checked": false,
-        "limit_data": null
+        "limit_data": null,
+        "limit_mode": "csv",
+        "manual_upper_enabled": true,
+        "manual_lower_enabled": false,
+        "manual_upper_segments": [],
+        "manual_lower_segments": []
     },
     "LP": {
         "trigger_threshold": 22,

--- a/unit_test/base/test_frequency_stepped_database.py
+++ b/unit_test/base/test_frequency_stepped_database.py
@@ -879,6 +879,67 @@ def test_frequency_stepped_recording_save_creates_valid_metadata_row(monkeypatch
     assert loaded_rows[0]["stimulus_payload"]["frequencies"] == metadata["frequencies"]
 
 
+@pytest.mark.parametrize("name_update", ["__missing__", None, "   "])
+def test_frequency_stepped_recording_auto_insert_without_usable_name_generates_deletable_name(
+    monkeypatch, local_tmp_path, name_update
+):
+    db_path = local_tmp_path / "recording_step_sc_insert_without_name.db"
+    _create_database(db_path)
+    monkeypatch.setattr(model_consts, "DATABASE_PATH", str(db_path))
+    monkeypatch.setattr(model_consts, "AUDIO_DATABASE_PATH", str(db_path))
+
+    manager = RecordingManager()
+    manager.db_path = str(db_path)
+    metadata = _step_sc_metadata(stimulus_name="should_be_removed", start_freq=1, stop_freq=2, num_steps=99)
+    if name_update == "__missing__":
+        metadata.pop("stimulus_name")
+    else:
+        metadata["stimulus_name"] = name_update
+
+    code, msg = manager.save_signal_info_to_db(
+        {
+            "file_path": "audio_data/stored_data/step_sc_recording_without_name.wav",
+            "product_model": "S004",
+            "sample_rate": 48000,
+            "record_date": "2026-05-18",
+            "labels": "OK",
+            "barcode": "step-sc-no-name",
+        },
+        metadata,
+    )
+
+    assert code == error_code.OK, msg
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            """
+            SELECT stimulus_name, stimulus_metadata_json
+            FROM stimulus_signal_table
+            WHERE stimulus_method = 'frequency_stepped'
+            """
+        ).fetchone()
+
+    assert row is not None
+    generated_name = row[0]
+    assert isinstance(generated_name, str)
+    assert generated_name.strip()
+    parsed_metadata = json.loads(row[1])
+    assert parsed_metadata["stimulus_name"] == generated_name
+
+    query_code, loaded_rows = StimulusSignalManagement.query_all_stimulus_info()
+    assert query_code == error_code.OK
+    assert loaded_rows[0]["stimulus_name"] == generated_name
+    assert loaded_rows[0]["stimulus_payload"]["stimulus_name"] == generated_name
+    assert loaded_rows[0]["stimulus_payload"]["stimulus_id"]
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("DELETE FROM audio_data_table")
+    delete_code, delete_msg = StimulusSignalManagement.delete_stimulus_info_from_db(generated_name)
+    assert delete_code == error_code.OK, delete_msg
+    with sqlite3.connect(db_path) as conn:
+        remaining = conn.execute("SELECT COUNT(*) FROM stimulus_signal_table").fetchone()[0]
+    assert remaining == 0
+
+
 def test_frequency_stepped_recording_save_reuses_existing_rich_row(monkeypatch, local_tmp_path):
     db_path = local_tmp_path / "recording_step_sc_reuse.db"
     _create_database(db_path)

--- a/unit_test/ui/test_analysis_config_defaults.py
+++ b/unit_test/ui/test_analysis_config_defaults.py
@@ -24,6 +24,15 @@ EXPOSED_ANALYSIS_TYPES = {
     "Excel",
 }
 
+MANUAL_SEGMENT_ANALYSIS_TYPES = ("SPL", "SPLF", "FR", "HD", "RB", "PRB")
+MANUAL_SEGMENT_DEFAULT_KEYS = (
+    "limit_mode",
+    "manual_upper_enabled",
+    "manual_lower_enabled",
+    "manual_upper_segments",
+    "manual_lower_segments",
+)
+
 
 def load_defaults():
     with DEFAULT_CONFIG_PATH.open("r", encoding="utf-8") as file:
@@ -58,6 +67,26 @@ def test_curve_and_distortion_defaults_keep_legacy_threshold_and_golden_keys():
         assert defaults[analysis_type]["golden_sample_checked"] is False
 
 
+def test_manual_segment_enabled_defaults_have_stable_schema_without_scalar_keys():
+    defaults = load_defaults()
+
+    for analysis_type in MANUAL_SEGMENT_ANALYSIS_TYPES:
+        config = defaults[analysis_type]
+        for key in MANUAL_SEGMENT_DEFAULT_KEYS:
+            assert key in config, analysis_type
+        assert config["limit_mode"] == "csv"
+        assert config["manual_upper_enabled"] is True
+        assert config["manual_lower_enabled"] is False
+        assert config["manual_upper_segments"] == []
+        assert config["manual_lower_segments"] == []
+        assert "manual_upper" not in config
+        assert "manual_lower" not in config
+
+    assert "limit_mode" not in defaults["FBA"]
+    assert "manual_upper_segments" not in defaults["FBA"]
+    assert "manual_lower_segments" not in defaults["FBA"]
+
+
 def test_channel_defaults_are_present_for_channel_aware_dialogs():
     defaults = load_defaults()
 
@@ -84,9 +113,9 @@ def test_special_dialog_defaults_include_required_legacy_keys():
         "analysis_end_time_sec",
         "limit_mode",
         "manual_upper_enabled",
-        "manual_upper",
         "manual_lower_enabled",
-        "manual_lower",
+        "manual_upper_segments",
+        "manual_lower_segments",
         "show_overall_spl",
     ):
         assert key in spl_defaults

--- a/unit_test/ui/test_analysis_config_dialog_migration.py
+++ b/unit_test/ui/test_analysis_config_dialog_migration.py
@@ -1,12 +1,16 @@
 import os
 import sys
 import types
+from pathlib import Path
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
+import numpy as np
 import pytest
+from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QStandardItemModel
-from PyQt5.QtWidgets import QApplication, QTableView
+from PyQt5.QtWidgets import QApplication, QHeaderView, QSizePolicy, QTableView, QTableWidgetItem
 
 from consts import error_code
 
@@ -90,6 +94,570 @@ def assert_vertical_golden_size(window):
     assert window.minimumWidth() == 630
     assert window.minimumHeight() == 840
     assert round(window.minimumWidth() / window.minimumHeight(), 2) == 0.75
+
+
+def create_threshold_widget(qapp, load_config):
+    from ui.ui_analysis_config.threshold_config_widget import ThresholdConfigWidget
+
+    widget = ThresholdConfigWidget(
+        load_config=load_config,
+        model_type="SPL",
+        allow_manual_limits=True,
+    )
+    widget.show()
+    qapp.processEvents()
+    return widget
+
+
+def create_manual_dialog(widget):
+    dialog = widget._create_manual_limit_dialog()
+    dialog.show()
+    QApplication.instance().processEvents()
+    return dialog
+
+
+def confirm_dialog(dialog):
+    dialog._on_confirm_clicked()
+    QApplication.instance().processEvents()
+
+
+def plot_data_snapshot(plot_widget):
+    snapshot = []
+    for item in plot_widget.listDataItems():
+        x_data, y_data = item.getData()
+        snapshot.append((np.asarray(x_data).tolist(), np.asarray(y_data).tolist()))
+    return snapshot
+
+
+def _manual_table_content_height(table):
+    height = (
+        table.horizontalHeader().height()
+        + sum(table.rowHeight(row) for row in range(table.rowCount()))
+        + table.frameWidth() * 2
+    )
+    scroll_bar = table.horizontalScrollBar()
+    if scroll_bar.maximum() > scroll_bar.minimum():
+        height += scroll_bar.sizeHint().height()
+    return height
+
+
+def set_table_cell(table, row, column, value):
+    item = table.item(row, column)
+    if item is None:
+        item = QTableWidgetItem()
+        table.setItem(row, column, item)
+    item.setText(str(value))
+    QApplication.instance().processEvents()
+
+
+def set_segment_column(table, column, values):
+    for row, value in enumerate(values):
+        set_table_cell(table, row, column, value)
+
+
+def clear_segment_column(table, column):
+    for row in range(table.rowCount()):
+        set_table_cell(table, row, column, "")
+
+
+def assert_blank_column(table, column):
+    assert [table.item(row, column).text() if table.item(row, column) else "" for row in range(4)] == ["", "", "", ""]
+
+
+def test_threshold_widget_manual_mode_without_segment_keys_starts_blank_not_scalar_derived(qapp):
+    widget = create_threshold_widget(
+        qapp,
+        {
+            "limit_checked": True,
+            "limit_mode": "manual",
+            "manual_upper_enabled": True,
+            "manual_upper": 88.5,
+            "manual_lower_enabled": True,
+            "manual_lower": 20.0,
+        },
+    )
+
+    assert widget.manual_edit_button.isVisible() is True
+    assert not hasattr(widget, "manual_upper_table")
+    assert not hasattr(widget, "manual_lower_table")
+    dialog = create_manual_dialog(widget)
+
+    assert dialog.editor.manual_upper_table.rowCount() == 4
+    assert dialog.editor.manual_lower_table.rowCount() == 4
+    assert dialog.editor.manual_upper_table.columnCount() == 1
+    assert dialog.editor.manual_lower_table.columnCount() == 1
+    assert_blank_column(dialog.editor.manual_upper_table, 0)
+    assert_blank_column(dialog.editor.manual_lower_table, 0)
+    assert not hasattr(widget, "manual_upper_spin")
+    assert not hasattr(widget, "manual_lower_spin")
+
+
+def test_threshold_widget_filling_final_upper_column_auto_appends_blank_column(qapp):
+    widget = create_threshold_widget(
+        qapp,
+        {"limit_checked": True, "limit_mode": "manual", "manual_upper_enabled": True},
+    )
+    dialog = create_manual_dialog(widget)
+
+    set_segment_column(dialog.editor.manual_upper_table, 0, [0, 10, 1, 20])
+
+    assert dialog.editor.manual_upper_table.columnCount() == 2
+    assert_blank_column(dialog.editor.manual_upper_table, 1)
+
+
+def test_threshold_widget_partial_non_trailing_column_is_invalid_and_warns(qapp, monkeypatch):
+    from ui.ui_analysis_config import threshold_config_widget
+
+    warnings = []
+    monkeypatch.setattr(threshold_config_widget.MessageBox, "warning", lambda *args, **kwargs: warnings.append(args))
+    widget = create_threshold_widget(
+        qapp,
+        {"limit_checked": True, "limit_mode": "manual", "manual_upper_enabled": True},
+    )
+    dialog = create_manual_dialog(widget)
+    set_segment_column(dialog.editor.manual_upper_table, 0, [0, 10, 1, 20])
+    set_table_cell(dialog.editor.manual_upper_table, 0, 0, "")
+
+    confirm_dialog(dialog)
+    assert warnings
+    assert dialog.result() != dialog.Accepted
+
+
+def test_threshold_widget_blank_before_later_nonblank_column_is_invalid_and_warns(qapp, monkeypatch):
+    from ui.ui_analysis_config import threshold_config_widget
+
+    warnings = []
+    monkeypatch.setattr(threshold_config_widget.MessageBox, "warning", lambda *args, **kwargs: warnings.append(args))
+    widget = create_threshold_widget(
+        qapp,
+        {"limit_checked": True, "limit_mode": "manual", "manual_upper_enabled": True},
+    )
+    dialog = create_manual_dialog(widget)
+    set_segment_column(dialog.editor.manual_upper_table, 0, [0, 10, 1, 20])
+    set_segment_column(dialog.editor.manual_upper_table, 1, [2, 30, 3, 40])
+    clear_segment_column(dialog.editor.manual_upper_table, 0)
+
+    confirm_dialog(dialog)
+    assert warnings
+    assert dialog.result() != dialog.Accepted
+
+
+def test_threshold_widget_manual_config_serializes_segments_without_scalar_keys(qapp, monkeypatch):
+    widget = create_threshold_widget(
+        qapp,
+        {
+            "limit_checked": True,
+            "limit_mode": "manual",
+            "manual_upper_enabled": True,
+            "manual_lower_enabled": False,
+        },
+    )
+    dialog = create_manual_dialog(widget)
+    set_segment_column(dialog.editor.manual_upper_table, 0, [0, 10, 1, 20])
+    monkeypatch.setattr(dialog, "exec_", lambda: (dialog._on_confirm_clicked() or dialog.result()))
+    monkeypatch.setattr(widget, "_create_manual_limit_dialog", lambda: dialog)
+    widget.manual_edit_button.click()
+    qapp.processEvents()
+    config = widget.get_config()
+
+    assert config["limit_mode"] == "manual"
+    assert config["manual_upper_enabled"] is True
+    assert config["manual_lower_enabled"] is False
+    assert config["manual_upper_segments"] == [{"start_x": 0.0, "start_y": 10.0, "end_x": 1.0, "end_y": 20.0}]
+    assert config["manual_lower_segments"] == []
+    assert "manual_upper" not in config
+    assert "manual_lower" not in config
+
+
+def test_threshold_widget_threshold_unchecked_hides_limit_group(qapp):
+    widget = create_threshold_widget(qapp, {"limit_checked": False, "limit_mode": "manual"})
+
+    assert widget.limit_group_box.isVisible() is False
+
+
+def test_threshold_widget_mode_visibility_switches_between_csv_and_manual(qapp):
+    widget = create_threshold_widget(qapp, {"limit_checked": True, "limit_mode": "manual"})
+
+    assert widget.manual_widget.isVisible() is True
+    assert widget.manual_edit_button.isVisible() is True
+    assert widget.config_dir_box.isVisible() is False
+
+    widget.csv_mode_radio.setChecked(True)
+    qapp.processEvents()
+
+    assert widget.manual_widget.isVisible() is False
+    assert widget.manual_edit_button.isVisible() is False
+    assert widget.config_dir_box.isVisible() is True
+
+
+def test_threshold_widget_unchecked_upper_lower_hide_their_tables(qapp):
+    widget = create_threshold_widget(
+        qapp,
+        {
+            "limit_checked": True,
+            "limit_mode": "manual",
+            "manual_upper_enabled": True,
+            "manual_lower_enabled": True,
+        },
+    )
+    dialog = create_manual_dialog(widget)
+
+    assert dialog.editor.manual_upper_table.isVisible() is True
+    assert dialog.editor.manual_lower_table.isVisible() is True
+
+    dialog.editor.manual_upper_check.setChecked(False)
+    dialog.editor.manual_lower_check.setChecked(False)
+    qapp.processEvents()
+
+    assert dialog.editor.manual_upper_table.isVisible() is False
+    assert dialog.editor.manual_lower_table.isVisible() is False
+
+
+def test_manual_segment_tables_fit_rendered_content_without_bottom_blank(qapp):
+    widget = create_threshold_widget(
+        qapp,
+        {
+            "limit_checked": True,
+            "limit_mode": "manual",
+            "manual_upper_enabled": True,
+            "manual_lower_enabled": True,
+            "manual_upper_segments": [],
+            "manual_lower_segments": [],
+        },
+    )
+    dialog = create_manual_dialog(widget)
+
+    for table in (dialog.editor.manual_upper_table, dialog.editor.manual_lower_table):
+        assert table.sizePolicy().verticalPolicy() == QSizePolicy.Fixed
+        assert table.verticalScrollBarPolicy() == Qt.ScrollBarAlwaysOff
+        assert table.height() == _manual_table_content_height(table)
+
+
+def manual_segments(count):
+    return [
+        {"start_x": index * 100, "start_y": 10 + index, "end_x": index * 100 + 50, "end_y": 20 + index}
+        for index in range(count)
+    ]
+
+
+def assert_manual_table_uses_stretch(table, expected_columns):
+    header = table.horizontalHeader()
+    assert table.columnCount() == expected_columns
+    assert header.sectionResizeMode(0) == QHeaderView.Stretch
+    assert header.minimumSectionSize() < 80
+
+
+def assert_manual_table_uses_interactive_80px_columns(table, expected_columns):
+    header = table.horizontalHeader()
+    assert table.columnCount() == expected_columns
+    assert header.sectionResizeMode(0) == QHeaderView.Interactive
+    assert header.minimumSectionSize() == 80
+    assert header.defaultSectionSize() == 80
+    for column in range(table.columnCount()):
+        assert table.columnWidth(column) >= 80
+
+
+def test_manual_segment_tables_use_stretch_until_seven_actual_columns(qapp):
+    widget = create_threshold_widget(
+        qapp,
+        {
+            "limit_checked": True,
+            "limit_mode": "manual",
+            "manual_upper_enabled": True,
+            "manual_lower_enabled": True,
+            "manual_upper_segments": [],
+            "manual_lower_segments": [],
+        },
+    )
+    dialog = create_manual_dialog(widget)
+
+    for table in (dialog.editor.manual_upper_table, dialog.editor.manual_lower_table):
+        assert_manual_table_uses_stretch(table, expected_columns=1)
+
+    dialog.editor.load_manual_config(
+        {
+            "manual_upper_enabled": True,
+            "manual_lower_enabled": True,
+            "manual_upper_segments": manual_segments(7),
+            "manual_lower_segments": manual_segments(7),
+        }
+    )
+    qapp.processEvents()
+
+    for table in (dialog.editor.manual_upper_table, dialog.editor.manual_lower_table):
+        assert_manual_table_uses_interactive_80px_columns(table, expected_columns=8)
+
+    dialog.editor.load_manual_config(
+        {
+            "manual_upper_enabled": True,
+            "manual_lower_enabled": True,
+            "manual_upper_segments": manual_segments(6),
+            "manual_lower_segments": manual_segments(6),
+        }
+    )
+    qapp.processEvents()
+
+    for table in (dialog.editor.manual_upper_table, dialog.editor.manual_lower_table):
+        assert_manual_table_uses_stretch(table, expected_columns=7)
+
+
+def test_manual_segment_tables_use_interactive_80px_columns_after_seven_actual_columns(qapp):
+    widget = create_threshold_widget(
+        qapp,
+        {
+            "limit_checked": True,
+            "limit_mode": "manual",
+            "manual_upper_enabled": True,
+            "manual_lower_enabled": True,
+            "manual_upper_segments": manual_segments(7),
+            "manual_lower_segments": manual_segments(7),
+        },
+    )
+    dialog = create_manual_dialog(widget)
+
+    for table in (dialog.editor.manual_upper_table, dialog.editor.manual_lower_table):
+        assert_manual_table_uses_interactive_80px_columns(table, expected_columns=8)
+
+
+def test_manual_segment_table_height_includes_required_horizontal_scrollbar(qapp):
+    complete_segments = manual_segments(9)
+    widget = create_threshold_widget(
+        qapp,
+        {
+            "limit_checked": True,
+            "limit_mode": "manual",
+            "manual_upper_enabled": True,
+            "manual_lower_enabled": False,
+            "manual_upper_segments": complete_segments,
+            "manual_lower_segments": [],
+        },
+    )
+    dialog = create_manual_dialog(widget)
+    dialog.setFixedWidth(dialog.minimumSizeHint().width())
+    qapp.processEvents()
+
+    table = dialog.editor.manual_upper_table
+    scroll_bar = table.horizontalScrollBar()
+    assert table.columnCount() == 10
+    assert scroll_bar.maximum() > scroll_bar.minimum()
+    assert table.height() == _manual_table_content_height(table)
+
+
+def test_threshold_widget_manual_mode_recomputes_scroll_height_after_being_enabled(qapp):
+    from ui.ui_analysis_config.spl_config_dialog import SplConfigWindow
+
+    config_manager = FakeConfigManager(
+        {
+            "SPLF": {
+                "splf_calc_mode": "fundamental",
+                "octave_smoothing": 0,
+                "golden_sample_checked": False,
+                "limit_checked": False,
+                "limit_mode": "csv",
+                "limit_data": None,
+                "manual_upper_enabled": True,
+                "manual_upper_segments": [],
+                "manual_lower_enabled": True,
+                "manual_lower_segments": [],
+                "weighting": "Z",
+                "analysis_channel": 0,
+            }
+        }
+    )
+    window = SplConfigWindow(config_manager, "SPLF", available_channels=[0])
+    window.show()
+    qapp.processEvents()
+
+    widget = window.threshold_widget
+    widget.limit_checkbox.setChecked(True)
+    widget.manual_mode_radio.setChecked(True)
+    qapp.processEvents()
+
+    assert window.section_container.minimumHeight() >= window.section_container.sizeHint().height()
+    assert widget.limit_group_box.height() >= widget.limit_group_box.sizeHint().height()
+    assert widget.manual_edit_button.isVisible() is True
+
+    window.close()
+
+
+def test_threshold_widget_manual_preview_inserts_gap_between_disconnected_segments(qapp):
+    widget = create_threshold_widget(
+        qapp,
+        {
+            "limit_checked": True,
+            "limit_mode": "manual",
+            "manual_upper_enabled": True,
+            "manual_lower_enabled": False,
+        },
+    )
+    dialog = create_manual_dialog(widget)
+    set_segment_column(dialog.editor.manual_upper_table, 0, [0, 10, 1, 20])
+    set_segment_column(dialog.editor.manual_upper_table, 1, [2, 30, 3, 40])
+
+    x_values, upper_values, lower_values = dialog.editor.manual_limit_preview_data()
+
+    assert x_values[:2] == [0.0, 1.0]
+    assert np.isnan(x_values[2])
+    assert x_values[3:] == [2.0, 3.0]
+    assert upper_values[:2] == [10.0, 20.0]
+    assert np.isnan(upper_values[2])
+    assert upper_values[3:] == [30.0, 40.0]
+    assert np.all(np.isnan(lower_values))
+
+
+def test_threshold_widget_switching_to_csv_without_data_clears_manual_preview(qapp, monkeypatch):
+    widget = create_threshold_widget(
+        qapp,
+        {
+            "limit_checked": True,
+            "limit_mode": "manual",
+            "limit_data": None,
+            "manual_upper_enabled": True,
+            "manual_lower_enabled": False,
+        },
+    )
+    dialog = create_manual_dialog(widget)
+    set_segment_column(dialog.editor.manual_upper_table, 0, [0, 10, 1, 20])
+    monkeypatch.setattr(dialog, "exec_", lambda: (dialog._on_confirm_clicked() or dialog.result()))
+    monkeypatch.setattr(widget, "_create_manual_limit_dialog", lambda: dialog)
+    widget.manual_edit_button.click()
+    qapp.processEvents()
+
+    assert len(widget.limit_graph.listDataItems()) == 1
+
+    widget.csv_mode_radio.setChecked(True)
+    qapp.processEvents()
+
+    assert widget.current_limit_mode() == "csv"
+    assert widget.limit_data is None
+    assert widget.limit_graph.listDataItems() == []
+
+
+def test_manual_limit_dialog_reject_keeps_parent_config_unchanged(qapp, monkeypatch):
+    widget = create_threshold_widget(
+        qapp,
+        {
+            "limit_checked": True,
+            "limit_mode": "manual",
+            "manual_upper_enabled": True,
+            "manual_lower_enabled": False,
+            "manual_upper_segments": [{"start_x": 0.0, "start_y": 10.0, "end_x": 1.0, "end_y": 20.0}],
+            "manual_lower_segments": [],
+        },
+    )
+    before = widget.get_config()
+    before_plot = plot_data_snapshot(widget.limit_graph)
+
+    dialog = create_manual_dialog(widget)
+    set_segment_column(dialog.editor.manual_upper_table, 0, [0, 99, 1, 100])
+    monkeypatch.setattr(dialog, "exec_", lambda: dialog.Rejected)
+    monkeypatch.setattr(widget, "_create_manual_limit_dialog", lambda: dialog)
+    widget.manual_edit_button.click()
+    qapp.processEvents()
+
+    assert widget.get_config() == before
+    assert plot_data_snapshot(widget.limit_graph) == before_plot
+
+
+def test_manual_limit_dialog_button_confirm_updates_parent_config_and_preview(qapp, monkeypatch):
+    widget = create_threshold_widget(
+        qapp,
+        {"limit_checked": True, "limit_mode": "manual", "manual_upper_enabled": True},
+    )
+
+    dialog = create_manual_dialog(widget)
+    set_segment_column(dialog.editor.manual_upper_table, 0, [0, 10, 1, 20])
+
+    def accept_from_button_path():
+        dialog._on_confirm_clicked()
+        return dialog.result()
+
+    monkeypatch.setattr(dialog, "exec_", accept_from_button_path)
+    monkeypatch.setattr(widget, "_create_manual_limit_dialog", lambda: dialog)
+    widget.manual_edit_button.click()
+    qapp.processEvents()
+
+    config = widget.get_config()
+    assert config["manual_upper_segments"] == [{"start_x": 0.0, "start_y": 10.0, "end_x": 1.0, "end_y": 20.0}]
+    assert len(widget.limit_graph.listDataItems()) == 1
+
+
+def test_manual_limit_dialog_confirm_replaces_accepted_segments_without_stale_preview(qapp, monkeypatch):
+    stale_segment = {"start_x": 2.0, "start_y": 30.0, "end_x": 3.0, "end_y": 40.0}
+    replacement_segments = [{"start_x": 0.0, "start_y": 10.0, "end_x": 1.0, "end_y": 20.0}]
+    widget = create_threshold_widget(
+        qapp,
+        {
+            "limit_checked": True,
+            "limit_mode": "manual",
+            "manual_upper_enabled": True,
+            "manual_lower_enabled": False,
+            "manual_upper_segments": [replacement_segments[0], stale_segment],
+            "manual_lower_segments": [],
+        },
+    )
+
+    dialog = create_manual_dialog(widget)
+    clear_segment_column(dialog.editor.manual_upper_table, 1)
+
+    def accept_from_button_path():
+        dialog._on_confirm_clicked()
+        return dialog.result()
+
+    monkeypatch.setattr(dialog, "exec_", accept_from_button_path)
+    monkeypatch.setattr(widget, "_create_manual_limit_dialog", lambda: dialog)
+    widget.manual_edit_button.click()
+    qapp.processEvents()
+
+    config = widget.get_config()
+    assert config["manual_upper_segments"] == replacement_segments
+    assert stale_segment not in config["manual_upper_segments"]
+    assert_blank_column(widget._manual_state_editor.manual_upper_table, 1)
+    assert plot_data_snapshot(widget.limit_graph) == [([0.0, 1.0], [10.0, 20.0])]
+
+
+def test_manual_limit_dialog_invalid_warning_is_chinese_and_dialog_stays_open(qapp, monkeypatch):
+    from ui.ui_analysis_config import threshold_config_widget
+
+    warnings = []
+    monkeypatch.setattr(threshold_config_widget.MessageBox, "warning", lambda *args, **kwargs: warnings.append(args))
+    widget = create_threshold_widget(
+        qapp,
+        {
+            "limit_checked": True,
+            "limit_mode": "manual",
+            "manual_upper_enabled": True,
+            "manual_lower_enabled": True,
+        },
+    )
+
+    dialog = create_manual_dialog(widget)
+    set_segment_column(dialog.editor.manual_upper_table, 0, [0, 0, 1, 0])
+    set_segment_column(dialog.editor.manual_lower_table, 0, [0, 1, 1, 0])
+    confirm_dialog(dialog)
+
+    assert warnings
+    assert "下限不能大于上限" in warnings[-1][2]
+    assert dialog.result() != dialog.Accepted
+    assert dialog.isVisible() is True
+
+
+def test_threshold_widget_without_manual_limits_keeps_csv_only_behavior(qapp):
+    from ui.ui_analysis_config.threshold_config_widget import ThresholdConfigWidget
+
+    widget = ThresholdConfigWidget(
+        load_config={"limit_checked": True, "limit_data": None},
+        model_type="SPL",
+        allow_manual_limits=False,
+    )
+    widget.show()
+    qapp.processEvents()
+
+    assert widget.config_dir_box.isVisible() is True
+    assert not hasattr(widget, "csv_mode_radio")
+    assert not hasattr(widget, "manual_mode_radio")
+    assert not hasattr(widget, "manual_edit_button")
+    assert widget.get_config() == {"limit_checked": True, "limit_data": None}
 
 
 def test_ai_dialog_uses_shared_channel_selector_without_changing_config(qapp, monkeypatch):
@@ -221,9 +789,9 @@ def test_spl_dialog_preserves_saved_keys_after_shared_control_migration(qapp):
         "limit_data": None,
         "limit_mode": "csv",
         "manual_upper_enabled": True,
-        "manual_upper": 0.0,
+        "manual_upper_segments": [],
         "manual_lower_enabled": False,
-        "manual_lower": 0.0,
+        "manual_lower_segments": [],
         "show_overall_spl": True,
         "weighting": "C",
         "analysis_channel": 2,
@@ -261,6 +829,11 @@ def test_splf_dialog_preserves_saved_keys_after_shared_control_migration(qapp):
         "golden_sample_checked": True,
         "limit_checked": False,
         "limit_data": None,
+        "limit_mode": "csv",
+        "manual_upper_enabled": True,
+        "manual_upper_segments": [],
+        "manual_lower_enabled": False,
+        "manual_lower_segments": [],
         "weighting": "Z",
         "analysis_channel": 1,
     }
@@ -278,9 +851,9 @@ def test_spl_dialog_preserves_manual_threshold_config(qapp):
                 "limit_mode": "manual",
                 "limit_data": None,
                 "manual_upper_enabled": True,
-                "manual_upper": 88.5,
+                "manual_upper_segments": [{"start_x": 0.0, "start_y": 88.5, "end_x": 1.0, "end_y": 88.5}],
                 "manual_lower_enabled": True,
-                "manual_lower": 20.0,
+                "manual_lower_segments": [{"start_x": 0.0, "start_y": 20.0, "end_x": 1.0, "end_y": 20.0}],
                 "weighting": "A",
                 "analysis_channel": 0,
             }
@@ -293,11 +866,149 @@ def test_spl_dialog_preserves_manual_threshold_config(qapp):
     assert config["limit_checked"] is True
     assert config["limit_mode"] == "manual"
     assert config["manual_upper_enabled"] is True
-    assert config["manual_upper"] == 88.5
+    assert config["manual_upper_segments"] == [{"start_x": 0.0, "start_y": 88.5, "end_x": 1.0, "end_y": 88.5}]
     assert config["manual_lower_enabled"] is True
-    assert config["manual_lower"] == 20.0
+    assert config["manual_lower_segments"] == [{"start_x": 0.0, "start_y": 20.0, "end_x": 1.0, "end_y": 20.0}]
     assert config["show_overall_spl"] is False
     assert window.threshold_widget.validate() is True
+
+
+def test_requested_dialogs_return_manual_segment_keys_from_threshold_widget(qapp):
+    from ui.ui_analysis_config.fr_config_dialog import FrConfigWindow
+    from ui.ui_analysis_config.hd_config_dialog import HdConfigWindow
+    from ui.ui_analysis_config.perceptual_rb_config_dialog import PerceptualRbConfigWindow
+    from ui.ui_analysis_config.rb_config_dialog import RbConfigWindow
+    from ui.ui_analysis_config.spl_config_dialog import SplConfigWindow
+
+    upper_segments = [{"start_x": 0.0, "start_y": 80.0, "end_x": 1.0, "end_y": 82.0}]
+    lower_segments = [{"start_x": 0.0, "start_y": 20.0, "end_x": 1.0, "end_y": 21.0}]
+
+    cases = [
+        (
+            "SPLF",
+            SplConfigWindow(
+                FakeConfigManager(
+                    {
+                        "SPLF": {
+                            "splf_calc_mode": "fundamental",
+                            "octave_smoothing": 0,
+                            "golden_sample_checked": False,
+                            "limit_checked": True,
+                            "limit_mode": "manual",
+                            "limit_data": None,
+                            "manual_upper_enabled": True,
+                            "manual_upper_segments": upper_segments,
+                            "manual_lower_enabled": True,
+                            "manual_lower_segments": lower_segments,
+                            "weighting": "Z",
+                            "analysis_channel": 0,
+                        }
+                    }
+                ),
+                "SPLF",
+                available_channels=[0],
+            ),
+        ),
+        (
+            "FR",
+            FrConfigWindow(
+                FakeConfigManager(
+                    {
+                        "FR": {
+                            "octave_smoothing": 0,
+                            "golden_sample_checked": False,
+                            "limit_checked": True,
+                            "limit_mode": "manual",
+                            "limit_data": None,
+                            "manual_upper_enabled": True,
+                            "manual_upper_segments": upper_segments,
+                            "manual_lower_enabled": True,
+                            "manual_lower_segments": lower_segments,
+                        }
+                    }
+                ),
+                "FR",
+            ),
+        ),
+        (
+            "HD",
+            HdConfigWindow(
+                FakeConfigManager(
+                    {
+                        "HD": {
+                            "selected_labels": [2],
+                            "all_checked": False,
+                            "golden_sample_checked": False,
+                            "limit_checked": True,
+                            "limit_mode": "manual",
+                            "limit_data": None,
+                            "manual_upper_enabled": True,
+                            "manual_upper_segments": upper_segments,
+                            "manual_lower_enabled": True,
+                            "manual_lower_segments": lower_segments,
+                        }
+                    }
+                ),
+                "HD",
+            ),
+        ),
+        (
+            "RB",
+            RbConfigWindow(
+                FakeConfigManager(
+                    {
+                        "RB": {
+                            "selected_labels": [10],
+                            "all_checked": False,
+                            "golden_sample_checked": False,
+                            "limit_checked": True,
+                            "limit_mode": "manual",
+                            "limit_data": None,
+                            "manual_upper_enabled": True,
+                            "manual_upper_segments": upper_segments,
+                            "manual_lower_enabled": True,
+                            "manual_lower_segments": lower_segments,
+                        }
+                    }
+                ),
+                "RB",
+            ),
+        ),
+        (
+            "PRB",
+            PerceptualRbConfigWindow(
+                FakeConfigManager(
+                    {
+                        "PRB": {
+                            "masking_config": {"sc_metric": "totalnl_x_ehs"},
+                            "golden_sample_checked": False,
+                            "limit_checked": True,
+                            "limit_mode": "manual",
+                            "limit_data": None,
+                            "manual_upper_enabled": True,
+                            "manual_upper_segments": upper_segments,
+                            "manual_lower_enabled": True,
+                            "manual_lower_segments": lower_segments,
+                        }
+                    }
+                ),
+                "PRB",
+            ),
+        ),
+    ]
+
+    for analysis_type, window in cases:
+        assert hasattr(window.threshold_widget, "manual_edit_button"), analysis_type
+        assert not hasattr(window.threshold_widget, "manual_upper_table"), analysis_type
+        assert not hasattr(window.threshold_widget, "manual_lower_table"), analysis_type
+        config = window.get_default_config()
+        assert config["limit_mode"] == "manual", analysis_type
+        assert config["manual_upper_enabled"] is True, analysis_type
+        assert config["manual_upper_segments"] == upper_segments, analysis_type
+        assert config["manual_lower_enabled"] is True, analysis_type
+        assert config["manual_lower_segments"] == lower_segments, analysis_type
+        assert "manual_upper" not in config
+        assert "manual_lower" not in config
 
 
 def test_fr_dialog_uses_shared_octave_smoothing_legacy_fallback(qapp):
@@ -323,6 +1034,11 @@ def test_fr_dialog_uses_shared_octave_smoothing_legacy_fallback(qapp):
         "golden_sample_checked": True,
         "limit_checked": False,
         "limit_data": None,
+        "limit_mode": "csv",
+        "manual_upper_enabled": True,
+        "manual_upper_segments": [],
+        "manual_lower_enabled": False,
+        "manual_lower_segments": [],
     }
 
 
@@ -369,9 +1085,9 @@ def test_spl_dialog_restore_default_reloads_semantic_sections(qapp):
         "limit_data": None,
         "limit_mode": "csv",
         "manual_upper_enabled": True,
-        "manual_upper": 0.0,
+        "manual_upper_segments": [],
         "manual_lower_enabled": False,
-        "manual_lower": 0.0,
+        "manual_lower_segments": [],
         "show_overall_spl": True,
         "weighting": "C",
         "analysis_channel": 1,
@@ -480,6 +1196,11 @@ def test_hd_dialog_uses_shared_harmonic_and_golden_widgets(qapp):
         "golden_sample_checked": True,
         "limit_checked": False,
         "limit_data": None,
+        "limit_mode": "csv",
+        "manual_upper_enabled": True,
+        "manual_upper_segments": [],
+        "manual_lower_enabled": False,
+        "manual_lower_segments": [],
     }
 
 
@@ -508,6 +1229,11 @@ def test_rb_dialog_filters_harmonics_to_rub_buzz_range(qapp):
         "golden_sample_checked": False,
         "limit_checked": False,
         "limit_data": None,
+        "limit_mode": "csv",
+        "manual_upper_enabled": True,
+        "manual_upper_segments": [],
+        "manual_lower_enabled": False,
+        "manual_lower_segments": [],
     }
 
 
@@ -535,6 +1261,11 @@ def test_prb_dialog_preserves_metric_fallback_and_golden_sample(qapp):
     assert config["golden_sample_checked"] is True
     assert config["limit_checked"] is False
     assert config["limit_data"] is None
+    assert config["limit_mode"] == "csv"
+    assert config["manual_upper_enabled"] is True
+    assert config["manual_upper_segments"] == []
+    assert config["manual_lower_enabled"] is False
+    assert config["manual_lower_segments"] == []
 
 
 def test_rsc_dialog_keeps_smoothing_key_after_shared_selector_migration(qapp, monkeypatch):

--- a/unit_test/ui/test_custom_widgets.py
+++ b/unit_test/ui/test_custom_widgets.py
@@ -1,0 +1,42 @@
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import pytest
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QApplication, QWidget
+
+from ui.custom_ui_widget.widgets import TableWidget
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return QApplication.instance() or QApplication([])
+
+
+def assert_table_fonts_match(table):
+    body_font = QWidget.font(table)
+    for header in (
+        table.horizontalHeader(),
+        table.verticalHeader(),
+    ):
+        header_font = header.font()
+        assert header.testAttribute(Qt.WA_SetFont)
+        assert header_font.family() == body_font.family()
+        assert header_font.pixelSize() == body_font.pixelSize()
+
+
+def test_table_widget_applies_font_to_headers_on_construction(qapp):
+    table = TableWidget()
+    assert_table_fonts_match(table)
+
+
+def test_table_widget_set_font_size_updates_headers(qapp):
+    table = TableWidget()
+    table.set_font_size(37)
+
+    assert QWidget.font(table).pixelSize() == table.font_size
+    assert_table_fonts_match(table)

--- a/unit_test/ui/test_main_window_startup_device_recovery.py
+++ b/unit_test/ui/test_main_window_startup_device_recovery.py
@@ -748,6 +748,96 @@ def test_startup_unavailable_state_schedules_recovery_prompt(main_window_module,
     assert scheduled[-1][1] == window.show_startup_device_warning
 
 
+def test_init_ui_does_not_schedule_startup_recovery_when_login_fails(main_window_module, monkeypatch):
+    window = _window(main_window_module)
+    window.sequence_window.close = lambda: None
+    window.sequence_window.refresh_channel_windows = lambda: None
+    scheduled = []
+
+    monkeypatch.setattr(main_window_module.MainWindow, "init_sequence_widget", lambda self: None)
+    monkeypatch.setattr(main_window_module.MainWindow, "show_statusbar_layout", lambda self: None)
+    monkeypatch.setattr(main_window_module.MainWindow, "showMaximized", lambda self: None)
+    monkeypatch.setattr(main_window_module.MainWindow, "on_access_lvl_changed", lambda self: None)
+    monkeypatch.setattr(main_window_module.MainWindow, "on_login_window_init", lambda self: False)
+    monkeypatch.setattr(
+        main_window_module.MainWindow,
+        "_schedule_startup_device_recovery_if_needed",
+        lambda self: scheduled.append(True),
+    )
+
+    main_window_module.MainWindow.init_ui(window)
+
+    assert scheduled == []
+
+
+def test_init_ui_schedules_startup_recovery_after_successful_login(main_window_module, monkeypatch):
+    window = _window(main_window_module)
+    window.sequence_window.close = lambda: None
+    window.sequence_window.refresh_channel_windows = lambda: None
+    scheduled = []
+
+    monkeypatch.setattr(main_window_module.MainWindow, "init_sequence_widget", lambda self: None)
+    monkeypatch.setattr(main_window_module.MainWindow, "show_statusbar_layout", lambda self: None)
+    monkeypatch.setattr(main_window_module.MainWindow, "showMaximized", lambda self: None)
+    monkeypatch.setattr(main_window_module.MainWindow, "on_access_lvl_changed", lambda self: None)
+    monkeypatch.setattr(main_window_module.MainWindow, "on_login_window_init", lambda self: True)
+    monkeypatch.setattr(
+        main_window_module.MainWindow,
+        "_schedule_startup_device_recovery_if_needed",
+        lambda self: scheduled.append(True),
+    )
+
+    main_window_module.MainWindow.init_ui(window)
+
+    assert scheduled == [True]
+
+
+def test_on_login_window_init_returns_false_for_unsuccessful_login(main_window_module, monkeypatch):
+    class FakeLoginWindow:
+        def on_exec(self):
+            return None, None
+
+    window = _window(main_window_module)
+    window.access_lvl = None
+    window.user_name = None
+    access_refreshes = []
+    monkeypatch.setattr(main_window_module, "LoginWindow", FakeLoginWindow)
+    monkeypatch.setattr(window, "on_access_lvl_changed", lambda: access_refreshes.append(True))
+
+    result = window.on_login_window_init()
+
+    assert result is False
+    assert window.access_lvl is None
+    assert window.user_name is None
+    assert access_refreshes == [True]
+
+
+def test_on_login_window_init_returns_true_for_successful_login(main_window_module, monkeypatch):
+    class FakeLoginWindow:
+        def on_exec(self):
+            return "Engineer", "alice"
+
+    window = _window(main_window_module)
+    window.sequence_window.show_calls = 0
+    window.sequence_window.show = lambda: setattr(
+        window.sequence_window,
+        "show_calls",
+        window.sequence_window.show_calls + 1,
+    )
+    access_refreshes = []
+    monkeypatch.setattr(main_window_module, "LoginWindow", FakeLoginWindow)
+    monkeypatch.setattr(window, "on_access_lvl_changed", lambda: access_refreshes.append(True))
+
+    result = window.on_login_window_init()
+
+    assert result is True
+    assert window.access_lvl == "Engineer"
+    assert window.user_name == "alice"
+    assert window.sequence_window.show_calls == 1
+    assert window.statusbar_updates == 1
+    assert access_refreshes == [True]
+
+
 def test_apply_startup_audio_devices_syncs_unavailable_state_before_prompt(main_window_module):
     window = _window(main_window_module)
     window.startup_device_error_reason = "设备不可用"

--- a/unit_test/ui/test_manual_limit_runtime.py
+++ b/unit_test/ui/test_manual_limit_runtime.py
@@ -1,0 +1,625 @@
+import os
+import sys
+import types
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from PyQt5.QtWidgets import QApplication
+
+from ui import signal_analysis_window as saw
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return QApplication.instance() or QApplication([])
+
+
+@pytest.fixture
+def captured_limit_utils(monkeypatch):
+    captured = {"setup": [], "check": [], "out": []}
+    original_check_interp_limits = saw.LimitPlotUtils.check_interp_limits
+
+    def setup_limit_plot(
+        plot_widget,
+        data_x,
+        data_y,
+        csv_x,
+        csv_upper,
+        csv_lower,
+        *args,
+        **kwargs,
+    ):
+        captured["setup"].append(
+            {
+                "data_x": np.asarray(data_x, dtype=float),
+                "data_y": np.asarray(data_y, dtype=float),
+                "csv_x": np.asarray(csv_x, dtype=float),
+                "csv_upper": np.asarray(csv_upper, dtype=float),
+                "csv_lower": np.asarray(csv_lower, dtype=float),
+            }
+        )
+
+    def check_interp_limits(data_x, data_y, csv_x, csv_upper, csv_lower):
+        result = original_check_interp_limits(data_x, data_y, csv_x, csv_upper, csv_lower)
+        captured["check"].append(
+            {
+                "data_x": np.asarray(data_x, dtype=float),
+                "data_y": np.asarray(data_y, dtype=float),
+                "csv_x": np.asarray(csv_x, dtype=float),
+                "csv_upper": np.asarray(csv_upper, dtype=float),
+                "csv_lower": np.asarray(csv_lower, dtype=float),
+                "result": result,
+            }
+        )
+        return result
+
+    def plot_out_segments(plot_widget, x_data, y_data, out_mask, *args, **kwargs):
+        captured["out"].append(
+            {
+                "x_data": np.asarray(x_data, dtype=float),
+                "y_data": np.asarray(y_data, dtype=float),
+                "out_mask": np.asarray(out_mask, dtype=bool),
+            }
+        )
+
+    monkeypatch.setattr(saw.LimitPlotUtils, "setup_limit_plot", staticmethod(setup_limit_plot))
+    monkeypatch.setattr(saw.LimitPlotUtils, "check_interp_limits", staticmethod(check_interp_limits))
+    monkeypatch.setattr(saw.LimitPlotUtils, "plot_out_segments", staticmethod(plot_out_segments))
+    return captured
+
+
+def _manual_upper_config(segments, *, scalar_upper=999.0):
+    return {
+        "limit_checked": True,
+        "limit_mode": "manual",
+        "limit_data": None,
+        "manual_upper_enabled": True,
+        "manual_lower_enabled": False,
+        "manual_upper": scalar_upper,
+        "manual_lower": -999.0,
+        "manual_upper_segments": segments,
+        "manual_lower_segments": [],
+    }
+
+
+def _assert_upper_with_gap(actual, expected_middle):
+    assert np.isnan(actual[0])
+    assert actual[1] == pytest.approx(expected_middle)
+    assert np.isnan(actual[2])
+
+
+def _recording_widget(widget, analysis_config):
+    widget.analysis_config = analysis_config
+    widget.data_struct.sample_rate = 10
+    widget.data_struct.store_wave_data = np.ones(3, dtype=np.float32)
+    widget.data_struct.store_wave_data_multi = None
+    return widget
+
+
+def test_spl_time_domain_manual_segments_drive_limit_arrays_and_out_of_range(
+    qapp, monkeypatch, captured_limit_utils
+):
+    config = _manual_upper_config(
+        [{"start_x": 0.0, "start_y": 8.0, "end_x": 0.2, "end_y": 8.0}]
+    )
+    config.update({"analysis_channel": 0, "weighting": "Z", "smooth_checked": False})
+    widget = _recording_widget(saw.Spl("SPL"), config)
+    monkeypatch.setattr(widget, "_resolve_v2pa_factor_for_analysis", lambda: True)
+
+    def spl_calculation(self, recorded_signal, reference_pressure=20e-6, **kwargs):
+        return np.array([5.0, 12.0, 4.0])
+
+    monkeypatch.setattr(saw.AudioThdFrequencyResponseAnalysis, "spl_calculation", spl_calculation)
+
+    result = widget.calculate_spl()
+
+    assert result is not False
+    setup = captured_limit_utils["setup"][-1]
+    np.testing.assert_allclose(setup["csv_x"], [0.0, 0.1, 0.2])
+    assert np.isnan(setup["csv_upper"][0])
+    np.testing.assert_allclose(setup["csv_upper"][1:], [8.0, 8.0])
+    assert np.all(np.isnan(setup["csv_lower"]))
+    out = captured_limit_utils["out"][-1]
+    assert out["out_mask"].tolist() == [False, True, False]
+    assert widget.data_struct.analysis_result_dict["SPL"] == (False, 4.0)
+
+
+def test_spl_frequency_manual_segments_with_gaps_drive_interp_check_and_out_of_range(
+    qapp, monkeypatch, captured_limit_utils
+):
+    config = _manual_upper_config(
+        [{"start_x": 100.0, "start_y": 10.0, "end_x": 250.0, "end_y": 10.0}]
+    )
+    config.update(
+        {
+            "analysis_channel": 0,
+            "splf_calc_mode": "fundamental",
+            "stimulus_method": "steps",
+            "stimulus_type": "linear",
+            "start_freq": 100,
+            "stop_freq": 300,
+            "num_steps": 3,
+            "total_time": 0.3,
+            "repeat_times": 1,
+        }
+    )
+    widget = _recording_widget(saw.SplFrequency("SPLF"), config)
+    widget.data_struct.sample_rate = 48000
+    widget.data_struct.stimulus_info = dict(config)
+    monkeypatch.setattr(widget, "_resolve_v2pa_factor_for_analysis", lambda: True)
+
+    class FakeSplFrequencyAnalyzer:
+        def __init__(self, sample_rate):
+            pass
+
+        def compute(self, recorded_signal, *, stimulus_metadata, v2pa_factor, splf_calc_mode):
+            return types.SimpleNamespace(
+                frequencies_hz=np.array([100.0, 200.0, 300.0]),
+                spl_db=np.array([1.0, 20.0, 1.0]),
+            )
+
+    monkeypatch.setattr(saw, "SplFrequencyAnalyzer", FakeSplFrequencyAnalyzer)
+
+    result = widget.calculate_spl()
+
+    assert result is not False
+    check = captured_limit_utils["check"][-1]
+    np.testing.assert_allclose(check["csv_x"], [100.0, 200.0, 300.0])
+    _assert_upper_with_gap(check["csv_upper"], 10.0)
+    out_mask, _plot_x, _plot_y, deviation, is_ok = check["result"]
+    assert out_mask.tolist() == [False, True, False]
+    assert deviation == 10.0
+    assert is_ok is False
+
+
+def test_spl_frequency_manual_segments_stay_aligned_for_unsorted_analyzer_output(
+    qapp, monkeypatch, captured_limit_utils
+):
+    config = _manual_upper_config(
+        [{"start_x": 100.0, "start_y": 10.0, "end_x": 250.0, "end_y": 10.0}]
+    )
+    config.update(
+        {
+            "analysis_channel": 0,
+            "splf_calc_mode": "fundamental",
+            "stimulus_method": "steps",
+            "stimulus_type": "linear",
+            "start_freq": 100,
+            "stop_freq": 300,
+            "num_steps": 3,
+            "total_time": 0.3,
+            "repeat_times": 1,
+        }
+    )
+    widget = _recording_widget(saw.SplFrequency("SPLF"), config)
+    widget.data_struct.sample_rate = 48000
+    widget.data_struct.stimulus_info = dict(config)
+    monkeypatch.setattr(widget, "_resolve_v2pa_factor_for_analysis", lambda: True)
+
+    class FakeSplFrequencyAnalyzer:
+        def __init__(self, sample_rate):
+            pass
+
+        def compute(self, recorded_signal, *, stimulus_metadata, v2pa_factor, splf_calc_mode):
+            return types.SimpleNamespace(
+                frequencies_hz=np.array([300.0, 200.0, 100.0]),
+                spl_db=np.array([1.0, 20.0, 1.0]),
+            )
+
+    monkeypatch.setattr(saw, "SplFrequencyAnalyzer", FakeSplFrequencyAnalyzer)
+
+    result = widget.calculate_spl()
+
+    assert result is not False
+    check = captured_limit_utils["check"][-1]
+    np.testing.assert_allclose(check["data_x"], [100.0, 200.0, 300.0])
+    np.testing.assert_allclose(check["data_y"], [1.0, 20.0, 1.0])
+    np.testing.assert_allclose(check["csv_x"], [100.0, 200.0, 300.0])
+    _assert_upper_with_gap(check["csv_upper"], 10.0)
+    out_mask, _plot_x, _plot_y, deviation, is_ok = check["result"]
+    assert out_mask.tolist() == [False, True, False]
+    assert deviation == 10.0
+    assert is_ok is False
+    assert widget.data_struct.analysis_result_dict["SPLF"] == (False, 10.0)
+
+
+def test_frequency_response_manual_segments_with_gaps_drive_interp_check_and_out_of_range(
+    qapp, monkeypatch, captured_limit_utils
+):
+    config = _manual_upper_config(
+        [{"start_x": 100.0, "start_y": 10.0, "end_x": 250.0, "end_y": 10.0}]
+    )
+    config.update(
+        {
+            "analysis_channel": 0,
+            "stimulus_method": "steps",
+            "stimulus_type": "linear",
+            "start_freq": 100,
+            "stop_freq": 300,
+            "num_steps": 3,
+            "total_time": 0.3,
+            "repeat_times": 1,
+        }
+    )
+    widget = _recording_widget(saw.Frequency("FR"), config)
+    widget.data_struct.sample_rate = 48000
+    widget.data_struct.stimulus_data = np.ones(3, dtype=np.float32)
+    widget.data_struct.stimulus_info = dict(config)
+
+    class FakeFrequencyResponseAnalyzer:
+        def __init__(self, sample_rate):
+            pass
+
+        def compute(self, stimulus_signal, recorded_signal, *, stimulus_metadata, method):
+            return types.SimpleNamespace(
+                frequencies_hz=np.array([100.0, 200.0, 300.0]),
+                magnitude_db=np.array([1.0, 12.0, 1.0]),
+            )
+
+    monkeypatch.setattr(saw, "FrequencyResponseAnalyzer", FakeFrequencyResponseAnalyzer)
+
+    result = widget.calculate_fr()
+
+    assert result is not False
+    check = captured_limit_utils["check"][-1]
+    np.testing.assert_allclose(check["csv_x"], [100.0, 200.0, 300.0])
+    _assert_upper_with_gap(check["csv_upper"], 10.0)
+    out_mask, _plot_x, _plot_y, deviation, is_ok = check["result"]
+    assert out_mask.tolist() == [False, True, False]
+    assert deviation == 2.0
+    assert is_ok is False
+
+
+def test_frequency_response_manual_segments_stay_aligned_for_unsorted_analyzer_output(
+    qapp, monkeypatch, captured_limit_utils
+):
+    config = _manual_upper_config(
+        [{"start_x": 100.0, "start_y": 10.0, "end_x": 250.0, "end_y": 10.0}]
+    )
+    config.update(
+        {
+            "analysis_channel": 0,
+            "stimulus_method": "steps",
+            "stimulus_type": "linear",
+            "start_freq": 100,
+            "stop_freq": 300,
+            "num_steps": 3,
+            "total_time": 0.3,
+            "repeat_times": 1,
+        }
+    )
+    widget = _recording_widget(saw.Frequency("FR"), config)
+    widget.data_struct.sample_rate = 48000
+    widget.data_struct.stimulus_data = np.ones(3, dtype=np.float32)
+    widget.data_struct.stimulus_info = dict(config)
+
+    class FakeFrequencyResponseAnalyzer:
+        def __init__(self, sample_rate):
+            pass
+
+        def compute(self, stimulus_signal, recorded_signal, *, stimulus_metadata, method):
+            return types.SimpleNamespace(
+                frequencies_hz=np.array([300.0, 200.0, 100.0]),
+                magnitude_db=np.array([1.0, 12.0, 1.0]),
+            )
+
+    monkeypatch.setattr(saw, "FrequencyResponseAnalyzer", FakeFrequencyResponseAnalyzer)
+
+    result = widget.calculate_fr()
+
+    assert result is not False
+    check = captured_limit_utils["check"][-1]
+    np.testing.assert_allclose(check["data_x"], [100.0, 200.0, 300.0])
+    np.testing.assert_allclose(check["data_y"], [1.0, 12.0, 1.0])
+    np.testing.assert_allclose(check["csv_x"], [100.0, 200.0, 300.0])
+    _assert_upper_with_gap(check["csv_upper"], 10.0)
+    out_mask, _plot_x, _plot_y, deviation, is_ok = check["result"]
+    assert out_mask.tolist() == [False, True, False]
+    assert deviation == 2.0
+    assert is_ok is False
+    assert widget.data_struct.analysis_result_dict["FR"] == (False, 2.0)
+
+
+def test_distortion_plot_graph_uses_manual_segments_for_out_of_range_highlight(
+    qapp, captured_limit_utils
+):
+    widget = saw.Distortion("HD")
+    config = _manual_upper_config(
+        [{"start_x": 100.0, "start_y": 10.0, "end_x": 250.0, "end_y": 10.0}]
+    )
+
+    widget.plot_graph(
+        np.array([100.0, 200.0, 300.0]),
+        np.array([1.0, 12.0, 1.0]),
+        config,
+    )
+
+    setup = captured_limit_utils["setup"][-1]
+    np.testing.assert_allclose(setup["csv_x"], [100.0, 200.0, 300.0])
+    _assert_upper_with_gap(setup["csv_upper"], 10.0)
+    out = captured_limit_utils["out"][-1]
+    assert out["out_mask"].tolist() == [False, True, False]
+    assert widget.data_struct.analysis_result_dict["HD"] == (False, 2.0)
+
+
+def test_distortion_plot_graph_csv_passing_margin_preserves_legacy_limit_behavior(
+    qapp, captured_limit_utils
+):
+    widget = saw.Distortion("HD")
+    config = {
+        "limit_checked": True,
+        "limit_mode": "csv",
+        "limit_data": (
+            np.array([100.0, 200.0]),
+            np.array([10.0, 100.0]),
+            np.array([0.0, 0.0]),
+        ),
+    }
+
+    widget.plot_graph(
+        np.array([100.0, 200.0]),
+        np.array([8.0, 9.0]),
+        config,
+    )
+
+    out = captured_limit_utils["out"][-1]
+    assert out["out_mask"].tolist() == [False, False]
+    assert widget.data_struct.analysis_result_dict["HD"] == (True, 1.0)
+
+
+def test_distortion_plot_graph_csv_upper_only_margin_preserves_legacy_nan_side(
+    qapp, captured_limit_utils
+):
+    widget = saw.Distortion("HD")
+    config = {
+        "limit_checked": True,
+        "limit_mode": "csv",
+        "limit_data": (
+            np.array([100.0, 200.0]),
+            np.array([10.0, 10.0]),
+            np.array([np.nan, np.nan]),
+        ),
+    }
+
+    widget.plot_graph(
+        np.array([100.0, 200.0]),
+        np.array([8.0, 9.0]),
+        config,
+    )
+
+    out = captured_limit_utils["out"][-1]
+    assert out["out_mask"].tolist() == [False, False]
+    assert widget.data_struct.analysis_result_dict["HD"] == (True, 1.0)
+
+
+def test_distortion_plot_graph_csv_lower_only_margin_preserves_legacy_nan_side(
+    qapp, captured_limit_utils
+):
+    widget = saw.Distortion("HD")
+    config = {
+        "limit_checked": True,
+        "limit_mode": "csv",
+        "limit_data": (
+            np.array([100.0, 200.0]),
+            np.array([np.nan, np.nan]),
+            np.array([0.0, 0.0]),
+        ),
+    }
+
+    widget.plot_graph(
+        np.array([100.0, 200.0]),
+        np.array([1.0, 2.0]),
+        config,
+    )
+
+    out = captured_limit_utils["out"][-1]
+    assert out["out_mask"].tolist() == [False, False]
+    is_ok, deviation = widget.data_struct.analysis_result_dict["HD"]
+    assert is_ok is True
+    assert np.isnan(deviation)
+
+
+def test_distortion_plot_graph_manual_gap_keeps_passing_deviation_finite(
+    qapp, captured_limit_utils
+):
+    widget = saw.Distortion("HD")
+    config = _manual_upper_config(
+        [{"start_x": 400.0, "start_y": 10.0, "end_x": 500.0, "end_y": 10.0}]
+    )
+
+    widget.plot_graph(
+        np.array([100.0, 200.0, 300.0]),
+        np.array([1.0, 2.0, 3.0]),
+        config,
+    )
+
+    setup = captured_limit_utils["setup"][-1]
+    assert np.all(np.isnan(setup["csv_upper"]))
+    out = captured_limit_utils["out"][-1]
+    assert out["out_mask"].tolist() == [False, False, False]
+    is_ok, deviation = widget.data_struct.analysis_result_dict["HD"]
+    assert is_ok is True
+    assert deviation == 0.0
+    assert np.isfinite(deviation)
+
+
+@pytest.mark.parametrize("nonfinite_y", [np.nan, np.inf])
+def test_distortion_plot_graph_manual_margins_ignore_nonfinite_measured_values(
+    qapp, captured_limit_utils, nonfinite_y
+):
+    widget = saw.Distortion("HD")
+    config = _manual_upper_config(
+        [{"start_x": 100.0, "start_y": 10.0, "end_x": 250.0, "end_y": 10.0}]
+    )
+
+    widget.plot_graph(
+        np.array([100.0, 200.0]),
+        np.array([1.0, nonfinite_y]),
+        config,
+    )
+
+    out = captured_limit_utils["out"][-1]
+    assert out["out_mask"].tolist() == [False, False]
+    is_ok, deviation = widget.data_struct.analysis_result_dict["HD"]
+    assert is_ok is True
+    assert deviation == 0.0
+    assert np.isfinite(deviation)
+
+
+@pytest.mark.parametrize("uncovered_y", [10.0, 10.2])
+def test_distortion_plot_graph_passing_margin_ignores_uncovered_manual_points(
+    qapp, captured_limit_utils, uncovered_y
+):
+    widget = saw.Distortion("HD")
+    config = _manual_upper_config(
+        [{"start_x": 100.0, "start_y": 10.0, "end_x": 250.0, "end_y": 10.0}]
+    )
+
+    widget.plot_graph(
+        np.array([100.0, 200.0]),
+        np.array([uncovered_y, 8.0]),
+        config,
+    )
+
+    setup = captured_limit_utils["setup"][-1]
+    assert np.isnan(setup["csv_upper"][0])
+    assert setup["csv_upper"][1] == pytest.approx(10.0)
+    out = captured_limit_utils["out"][-1]
+    assert out["out_mask"].tolist() == [False, False]
+    assert widget.data_struct.analysis_result_dict["HD"] == (True, 2.0)
+
+
+def test_perceptual_rub_and_buzz_plot_graph_uses_manual_segments_for_out_of_range_highlight(
+    qapp, captured_limit_utils
+):
+    widget = saw.PerceptualRubAndBuzz("PRB")
+    config = _manual_upper_config(
+        [{"start_x": 100.0, "start_y": 10.0, "end_x": 250.0, "end_y": 10.0}]
+    )
+
+    widget.plot_graph(
+        np.array([100.0, 200.0, 300.0]),
+        np.array([1.0, 12.0, 1.0]),
+        config,
+    )
+
+    setup = captured_limit_utils["setup"][-1]
+    np.testing.assert_allclose(setup["csv_x"], [100.0, 200.0, 300.0])
+    _assert_upper_with_gap(setup["csv_upper"], 10.0)
+    out = captured_limit_utils["out"][-1]
+    assert out["out_mask"].tolist() == [False, True, False]
+    assert widget.data_struct.analysis_result_dict["PRB"] == (False, 2.0)
+
+
+def test_perceptual_rub_and_buzz_plot_graph_manual_gap_keeps_passing_deviation_finite(
+    qapp, captured_limit_utils
+):
+    widget = saw.PerceptualRubAndBuzz("PRB")
+    config = _manual_upper_config(
+        [{"start_x": 400.0, "start_y": 10.0, "end_x": 500.0, "end_y": 10.0}]
+    )
+
+    widget.plot_graph(
+        np.array([100.0, 200.0, 300.0]),
+        np.array([1.0, 2.0, 3.0]),
+        config,
+    )
+
+    setup = captured_limit_utils["setup"][-1]
+    assert np.all(np.isnan(setup["csv_upper"]))
+    out = captured_limit_utils["out"][-1]
+    assert out["out_mask"].tolist() == [False, False, False]
+    is_ok, deviation = widget.data_struct.analysis_result_dict["PRB"]
+    assert is_ok is True
+    assert deviation == 0.0
+    assert np.isfinite(deviation)
+
+
+@pytest.mark.parametrize("nonfinite_y", [np.nan, np.inf])
+def test_perceptual_rub_and_buzz_manual_margins_ignore_nonfinite_measured_values(
+    qapp, captured_limit_utils, nonfinite_y
+):
+    widget = saw.PerceptualRubAndBuzz("PRB")
+    config = _manual_upper_config(
+        [{"start_x": 100.0, "start_y": 10.0, "end_x": 250.0, "end_y": 10.0}]
+    )
+
+    widget.plot_graph(
+        np.array([100.0, 200.0]),
+        np.array([1.0, nonfinite_y]),
+        config,
+    )
+
+    out = captured_limit_utils["out"][-1]
+    assert out["out_mask"].tolist() == [False, False]
+    is_ok, deviation = widget.data_struct.analysis_result_dict["PRB"]
+    assert is_ok is True
+    assert deviation == 0.0
+    assert np.isfinite(deviation)
+
+
+@pytest.mark.parametrize("uncovered_y", [10.0, 10.2])
+def test_perceptual_rub_and_buzz_passing_margin_ignores_uncovered_manual_points(
+    qapp, captured_limit_utils, uncovered_y
+):
+    widget = saw.PerceptualRubAndBuzz("PRB")
+    config = _manual_upper_config(
+        [{"start_x": 100.0, "start_y": 10.0, "end_x": 250.0, "end_y": 10.0}]
+    )
+
+    widget.plot_graph(
+        np.array([100.0, 200.0]),
+        np.array([uncovered_y, 8.0]),
+        config,
+    )
+
+    setup = captured_limit_utils["setup"][-1]
+    assert np.isnan(setup["csv_upper"][0])
+    assert setup["csv_upper"][1] == pytest.approx(10.0)
+    out = captured_limit_utils["out"][-1]
+    assert out["out_mask"].tolist() == [False, False]
+    assert widget.data_struct.analysis_result_dict["PRB"] == (True, 2.0)
+
+
+def test_scalar_only_manual_config_warns_and_returns_invalid_boundary(
+    qapp, monkeypatch, captured_limit_utils
+):
+    warnings = []
+    config = {
+        "limit_checked": True,
+        "limit_mode": "manual",
+        "manual_upper_enabled": True,
+        "manual_lower_enabled": False,
+        "manual_upper": 8.0,
+        "manual_lower": -999.0,
+        "analysis_channel": 0,
+        "weighting": "Z",
+        "smooth_checked": False,
+    }
+    widget = _recording_widget(saw.Spl("SPL"), config)
+    monkeypatch.setattr(widget, "_resolve_v2pa_factor_for_analysis", lambda: True)
+    monkeypatch.setattr(
+        saw.AudioThdFrequencyResponseAnalysis,
+        "spl_calculation",
+        lambda self, *args, **kwargs: np.array([12.0, 12.0, 12.0]),
+    )
+    monkeypatch.setattr(
+        saw.MessageBox,
+        "warning",
+        lambda parent, title, message: warnings.append((title, message)),
+    )
+
+    result = widget.calculate_spl()
+
+    assert result is False
+    assert captured_limit_utils["setup"] == []
+    assert warnings
+    assert warnings[-1][0] == "提示"
+    assert "上限" in warnings[-1][1]

--- a/unit_test/ui/test_manual_limit_segments.py
+++ b/unit_test/ui/test_manual_limit_segments.py
@@ -1,0 +1,142 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from ui.ui_analysis_config.manual_limit_segments import (
+    ManualLimitValidationError,
+    limits_from_manual_segments,
+    normalize_segments,
+    validate_manual_limit_config,
+    validate_manual_segments,
+)
+
+
+def test_segment_values_are_left_open_right_closed():
+    config = {
+        "manual_upper_enabled": True,
+        "manual_lower_enabled": False,
+        "manual_upper_segments": [
+            {"start_x": 0.0, "start_y": 10.0, "end_x": 1.0, "end_y": 20.0},
+            {"start_x": 1.0, "start_y": 30.0, "end_x": 2.0, "end_y": 40.0},
+        ],
+        "manual_lower_segments": [],
+    }
+
+    x, upper, lower = limits_from_manual_segments(config, np.array([0.0, 0.5, 1.0, 1.5, 2.0]))
+
+    assert np.array_equal(x, np.array([0.0, 0.5, 1.0, 1.5, 2.0]))
+    assert np.isnan(upper[0])
+    assert upper[1] == pytest.approx(15.0)
+    assert upper[2] == pytest.approx(20.0)
+    assert upper[3] == pytest.approx(35.0)
+    assert upper[4] == pytest.approx(40.0)
+    assert np.all(np.isnan(lower))
+
+
+def test_sequence_allows_equal_start_after_previous_end():
+    validate_manual_segments(
+        [
+            {"start_x": 0, "start_y": 1, "end_x": 1, "end_y": 1},
+            {"start_x": 1, "start_y": 2, "end_x": 2, "end_y": 2},
+        ],
+        label="上限",
+    )
+
+
+def test_zero_width_and_reordered_segments_fail():
+    with pytest.raises(ManualLimitValidationError):
+        validate_manual_segments([{"start_x": 1, "start_y": 1, "end_x": 1, "end_y": 1}], label="上限")
+
+    with pytest.raises(ManualLimitValidationError):
+        validate_manual_segments(
+            [
+                {"start_x": 1, "start_y": 1, "end_x": 2, "end_y": 1},
+                {"start_x": 1.5, "start_y": 1, "end_x": 3, "end_y": 1},
+            ],
+            label="上限",
+        )
+
+
+def test_lower_above_upper_detects_left_open_interval_violation():
+    config = {
+        "manual_upper_enabled": True,
+        "manual_lower_enabled": True,
+        "manual_upper_segments": [{"start_x": 0, "start_y": 0, "end_x": 1, "end_y": 0}],
+        "manual_lower_segments": [{"start_x": 0, "start_y": 1, "end_x": 1, "end_y": 0}],
+    }
+
+    with pytest.raises(ManualLimitValidationError):
+        limits_from_manual_segments(config, np.array([0.5, 1.0]))
+
+
+def test_negative_first_start_empty_enabled_table_disabled_limits_and_nonfinite_values_fail():
+    with pytest.raises(ManualLimitValidationError):
+        validate_manual_segments([{"start_x": -0.1, "start_y": 1, "end_x": 1, "end_y": 1}], label="上限")
+
+    with pytest.raises(ManualLimitValidationError):
+        limits_from_manual_segments({"manual_upper_enabled": True, "manual_upper_segments": []}, np.array([0.5]))
+
+    with pytest.raises(ManualLimitValidationError):
+        limits_from_manual_segments(
+            {
+                "manual_upper_enabled": False,
+                "manual_lower_enabled": False,
+                "manual_upper_segments": [],
+                "manual_lower_segments": [],
+            },
+            np.array([0.5]),
+        )
+
+    with pytest.raises(ManualLimitValidationError):
+        validate_manual_segments([{"start_x": 0, "start_y": float("nan"), "end_x": 1, "end_y": 1}], label="上限")
+
+
+def test_normalize_segments_coerces_numeric_values_and_rejects_nonfinite():
+    normalized = normalize_segments(
+        [{"start_x": "0", "start_y": "1.5", "end_x": "2", "end_y": 3}]
+    )
+
+    assert normalized == [{"start_x": 0.0, "start_y": 1.5, "end_x": 2.0, "end_y": 3.0}]
+
+    with pytest.raises(ManualLimitValidationError):
+        normalize_segments([{"start_x": 0, "start_y": 1, "end_x": float("inf"), "end_y": 1}])
+
+
+@pytest.mark.parametrize("value", [True, False, np.bool_(True), np.bool_(False)])
+@pytest.mark.parametrize("key", ["start_x", "start_y", "end_x", "end_y"])
+def test_normalize_segments_rejects_bool_values_before_numeric_coercion(key, value):
+    segment = {"start_x": 0, "start_y": 1, "end_x": 2, "end_y": 3}
+    segment[key] = value
+
+    with pytest.raises(ManualLimitValidationError):
+        normalize_segments([segment])
+
+
+def test_validate_config_defaults_upper_enabled_and_ignores_scalar_manual_keys():
+    config = {
+        "manual_upper": 10,
+        "manual_lower": 0,
+        "manual_upper_segments": [],
+        "manual_lower_segments": [],
+    }
+
+    with pytest.raises(ManualLimitValidationError):
+        validate_manual_limit_config(config)
+
+
+def test_lower_equal_upper_on_shared_boundary_is_valid():
+    config = {
+        "manual_upper_enabled": True,
+        "manual_lower_enabled": True,
+        "manual_upper_segments": [
+            {"start_x": 0, "start_y": 10, "end_x": 1, "end_y": 10},
+            {"start_x": 1, "start_y": 20, "end_x": 2, "end_y": 20},
+        ],
+        "manual_lower_segments": [{"start_x": 0, "start_y": 0, "end_x": 2, "end_y": 10}],
+    }
+
+    validate_manual_limit_config(config)

--- a/unit_test/ui/test_manual_limit_segments.py
+++ b/unit_test/ui/test_manual_limit_segments.py
@@ -15,6 +15,29 @@ from ui.ui_analysis_config.manual_limit_segments import (
 )
 
 
+def test_manual_limit_validation_messages_are_chinese():
+    with pytest.raises(ManualLimitValidationError, match="手动上下限段配置必须是列表"):
+        normalize_segments("bad")
+
+    with pytest.raises(ManualLimitValidationError, match="第1段起始X必须是数字"):
+        normalize_segments([{"start_x": True, "start_y": 1, "end_x": 2, "end_y": 3}])
+
+    with pytest.raises(ManualLimitValidationError, match="上限至少需要包含一段配置"):
+        validate_manual_segments([], label="上限")
+
+    with pytest.raises(ManualLimitValidationError, match="上限第1段截止X必须大于起始X"):
+        validate_manual_segments([{"start_x": 1, "start_y": 1, "end_x": 1, "end_y": 1}], label="上限")
+
+    config = {
+        "manual_upper_enabled": True,
+        "manual_lower_enabled": True,
+        "manual_upper_segments": [{"start_x": 0, "start_y": 0, "end_x": 1, "end_y": 0}],
+        "manual_lower_segments": [{"start_x": 0, "start_y": 1, "end_x": 1, "end_y": 0}],
+    }
+    with pytest.raises(ManualLimitValidationError, match="下限不能大于上限"):
+        validate_manual_limit_config(config)
+
+
 def test_segment_values_are_left_open_right_closed():
     config = {
         "manual_upper_enabled": True,

--- a/unit_test/ui/test_sequence_import_runtime_refresh.py
+++ b/unit_test/ui/test_sequence_import_runtime_refresh.py
@@ -51,6 +51,7 @@ def _runtime_window(detail=None):
         alignment_sample_count=320,
         wav_calibration_metadata={"source": "recording.wav"},
         wav_calibration_metadata_authoritative=True,
+        wav_calibration_warning_shown=True,
         analysis_result_dict={"old": (True, "OK")},
     )
     window = SimpleNamespace(
@@ -283,6 +284,27 @@ def test_mode_change_uses_existing_full_reset_path_and_clears_import_runtime():
     assert window.data_struct.wav_calibration_warning_shown is False
     assert window._has_imported_recording_runtime_state() is False
     assert window._has_import_stimulus_runtime_reference() is False
+
+
+@pytest.mark.parametrize("mode", ["IMPORT_AUDIO", "IMPORT_STIMULUS_AUDIO"])
+def test_import_mode_stimulus_config_init_preserves_imported_recording_sample_rate(mode):
+    window = _runtime_window()
+    window.sequence_config = _sequence({}, mode=mode)
+    original_mono = window.data_struct.store_wave_data
+    original_multi = window.data_struct.store_wave_data_multi
+    original_calibration = window.data_struct.wav_calibration_metadata
+
+    sequence_widget.SequenceWindow.init_data_struct_stimulus_config(window)
+
+    assert window.data_struct.sample_rate == 32000
+    assert window.data_struct.audio_lenth == 320
+    assert window.data_struct.store_wave_data is original_mono
+    assert window.data_struct.store_wave_data_multi is original_multi
+    assert window.data_struct.wav_calibration_metadata is original_calibration
+    assert window.data_struct.wav_calibration_metadata_authoritative is True
+    assert window.data_struct.wav_calibration_warning_shown is True
+    assert window.data_struct.stimulus_data is None
+    assert window.data_struct.stimulus_info is None
 
 
 READINESS_WARNING = "分析参考激励尚未就绪或采样率与导入音频不一致，请检查激励配置后重试。"

--- a/unit_test/ui/test_sequence_import_runtime_refresh.py
+++ b/unit_test/ui/test_sequence_import_runtime_refresh.py
@@ -1,0 +1,404 @@
+from copy import deepcopy
+from types import MethodType, SimpleNamespace
+
+import numpy as np
+import pytest
+
+from base.data_struct.data_deal_struct import DataDealStruct
+from ui.sequence import sequence_widget
+
+
+class _Button:
+    def __init__(self, enabled=True):
+        self.enabled = enabled
+
+    def setEnabled(self, enabled):
+        self.enabled = bool(enabled)
+
+
+def _detail(start_freq=100):
+    return {
+        "sample_rate": 44100,
+        "stimulus_info": {
+            "stimulus_method": "chirp",
+            "stimulus_type": "linear",
+            "sample_rate": 44100,
+            "start_freq": start_freq,
+            "stop_freq": 1000,
+            "total_time": 0.01,
+            "repeat_times": 1,
+            "amplitude": 0.5,
+        },
+    }
+
+
+def _sequence(detail, mode="IMPORT_STIMULUS_AUDIO"):
+    return [{"seq1": {"acq": {"mode": mode, "detail": detail}}}]
+
+
+def _runtime_window(detail=None):
+    detail = deepcopy(detail or _detail())
+    mono = np.ones(320, dtype=np.float32)
+    multi = mono.reshape(-1, 1)
+    reference = np.ones(320, dtype=np.float32)
+    data_struct = SimpleNamespace(
+        sample_rate=32000,
+        store_wave_data=mono,
+        store_wave_data_multi=multi,
+        audio_lenth=320,
+        stimulus_data=reference,
+        stimulus_info={"sample_rate": 32000, "total_time": 0.01},
+        alignment_sample_count=320,
+        wav_calibration_metadata={"source": "recording.wav"},
+        wav_calibration_metadata_authoritative=True,
+        analysis_result_dict={"old": (True, "OK")},
+    )
+    window = SimpleNamespace(
+        mode="IMPORT_STIMULUS_AUDIO",
+        sequence_config=_sequence(detail),
+        analysis_config={"display_sequence": []},
+        data_struct=data_struct,
+        recorded_path="recording.wav",
+        recorded_signal_info={"file_path": "recording.wav"},
+        data_btn=_Button(True),
+        count_board=None,
+        default_logger=SimpleNamespace(warning=lambda *_: None),
+        update_using_file_combobox=lambda: None,
+        init_fft_and_stft_flag=lambda: None,
+        refresh_channel_windows=lambda: None,
+        _clear_plot_area=lambda: None,
+        _refresh_test_mode_availability=lambda: None,
+        using_config_path="configs/sequence.json",
+    )
+    for name in (
+        "_is_positive_runtime_integer",
+        "_has_runtime_samples",
+        "_has_imported_recording_runtime_state",
+        "_has_import_stimulus_runtime_reference",
+        "_refresh_import_stimulus_analysis_reference",
+    ):
+        setattr(window, name, MethodType(getattr(sequence_widget.SequenceWindow, name), window))
+    return window
+
+
+def test_analysis_only_config_update_preserves_import_runtime(monkeypatch):
+    window = _runtime_window()
+    original_recorded_path = window.recorded_path
+    original_recorded_signal_info = window.recorded_signal_info
+    original = {
+        name: getattr(window.data_struct, name)
+        for name in (
+            "store_wave_data",
+            "store_wave_data_multi",
+            "stimulus_data",
+            "stimulus_info",
+            "wav_calibration_metadata",
+        )
+    }
+    init_calls = []
+    window.init_data_struct_stimulus_config = lambda: init_calls.append(True)
+
+    def reload_config():
+        window.analysis_config = {"display_sequence": ["SPL"]}
+
+    window.get_sequence_config_from_json = reload_config
+    sequence_widget.SequenceWindow.on_sequence_config_updated(window)
+
+    assert init_calls == []
+    assert window.data_struct.sample_rate == 32000
+    assert window.data_struct.audio_lenth == 320
+    for name, value in original.items():
+        assert getattr(window.data_struct, name) is value
+    assert window.recorded_path == original_recorded_path
+    assert window.recorded_signal_info is original_recorded_signal_info
+    assert window.data_btn.enabled is True
+
+
+def test_stale_mode_state_preserves_same_import_stimulus_config_refresh():
+    window = _runtime_window()
+    window.mode = None
+    original_recorded_path = window.recorded_path
+    original_recorded_signal_info = window.recorded_signal_info
+    original = {
+        name: getattr(window.data_struct, name)
+        for name in (
+            "store_wave_data",
+            "store_wave_data_multi",
+            "stimulus_data",
+            "stimulus_info",
+            "wav_calibration_metadata",
+        )
+    }
+    events = []
+
+    def reload_config():
+        window.sequence_config = _sequence(deepcopy(_detail()))
+        window.analysis_config = {"display_sequence": ["SPL"]}
+        window.mode = "IMPORT_STIMULUS_AUDIO"
+
+    def clear_data():
+        events.append("clear_data")
+        window.data_struct.stimulus_data = None
+        window.data_struct.stimulus_info = None
+
+    window.get_sequence_config_from_json = reload_config
+    window._clear_plot_area = lambda: events.append("clear_plot")
+    window.data_struct.clear_data = clear_data
+    window.refresh_channel_windows = lambda: events.append("refresh_channels")
+    window.init_data_struct_stimulus_config = lambda: events.append("init_runtime")
+
+    sequence_widget.SequenceWindow.on_sequence_config_updated(window)
+
+    assert events == []
+    assert window.data_struct.sample_rate == 32000
+    assert window.data_struct.audio_lenth == 320
+    for name, value in original.items():
+        assert getattr(window.data_struct, name) is value
+    assert window.recorded_path == original_recorded_path
+    assert window.recorded_signal_info is original_recorded_signal_info
+    assert window.data_btn.enabled is True
+
+
+def test_stimulus_config_update_rebuilds_reference_at_imported_rate(monkeypatch):
+    window = _runtime_window()
+    original_mono = window.data_struct.store_wave_data
+    original_multi = window.data_struct.store_wave_data_multi
+    original_calibration = window.data_struct.wav_calibration_metadata
+    original_recorded_path = window.recorded_path
+    original_recorded_signal_info = window.recorded_signal_info
+    calls = []
+
+    def reload_config():
+        window.sequence_config = _sequence(_detail(start_freq=200))
+        window.mode = "IMPORT_STIMULUS_AUDIO"
+
+    def build_reference(staged, detail, using_config_path=None, *, runtime_sample_rate, logger=None):
+        calls.append((detail, using_config_path, runtime_sample_rate))
+        staged.stimulus_data = np.full(320, 2.0, dtype=np.float32)
+        staged.stimulus_info = {"sample_rate": runtime_sample_rate, "total_time": 0.01}
+        staged.alignment_sample_count = 320
+        return True
+
+    window.get_sequence_config_from_json = reload_config
+    window.init_data_struct_stimulus_config = lambda: pytest.fail("import runtime must not be reinitialized")
+    monkeypatch.setattr(sequence_widget, "set_data_struct_analysis_reference_signal", build_reference)
+
+    sequence_widget.SequenceWindow.on_sequence_config_updated(window)
+
+    assert calls[0][2] == 32000
+    assert window.sequence_config[0]["seq1"]["acq"]["detail"]["stimulus_info"]["sample_rate"] == 44100
+    assert window.data_struct.store_wave_data is original_mono
+    assert window.data_struct.store_wave_data_multi is original_multi
+    assert window.data_struct.wav_calibration_metadata is original_calibration
+    assert window.recorded_path == original_recorded_path
+    assert window.recorded_signal_info is original_recorded_signal_info
+    assert window.data_struct.stimulus_info == {"sample_rate": 32000, "total_time": 0.01}
+    assert window.data_struct.alignment_sample_count == 320
+    assert window.data_btn.enabled is True
+
+
+@pytest.mark.parametrize("failure", ["false", "raise"])
+def test_failed_stimulus_refresh_clears_only_reference(monkeypatch, failure):
+    window = _runtime_window()
+    original_mono = window.data_struct.store_wave_data
+    original_multi = window.data_struct.store_wave_data_multi
+    original_calibration = window.data_struct.wav_calibration_metadata
+    warnings = []
+
+    def reload_config():
+        window.sequence_config = _sequence(_detail(start_freq=200))
+
+    def fail_reference(*args, **kwargs):
+        if failure == "raise":
+            raise RuntimeError("reference failed")
+        return False
+
+    window.get_sequence_config_from_json = reload_config
+    window.init_data_struct_stimulus_config = lambda: pytest.fail("full import state must not be cleared")
+    monkeypatch.setattr(sequence_widget, "set_data_struct_analysis_reference_signal", fail_reference)
+    monkeypatch.setattr(sequence_widget.MessageBox, "warning", lambda *args: warnings.append(args))
+
+    sequence_widget.SequenceWindow.on_sequence_config_updated(window)
+
+    assert len(warnings) == 1
+    assert warnings[0][1] == "提示"
+    expected_message = (
+        "加载分析参考激励失败: reference failed"
+        if failure == "raise"
+        else "加载分析参考激励失败，请检查激励配置。"
+    )
+    assert warnings[0][2] == expected_message
+    assert window.data_struct.store_wave_data is original_mono
+    assert window.data_struct.store_wave_data_multi is original_multi
+    assert window.data_struct.wav_calibration_metadata is original_calibration
+    assert window.data_struct.sample_rate == 32000
+    assert window.data_struct.audio_lenth == 320
+    assert window.data_struct.stimulus_data is None
+    assert window.data_struct.stimulus_info is None
+    assert not hasattr(window.data_struct, "alignment_sample_count")
+    assert window.recorded_path == "recording.wav"
+    assert window.data_btn.enabled is False
+
+
+def test_mode_change_uses_existing_full_reset_path_and_clears_import_runtime():
+    window = _runtime_window()
+    events = []
+
+    def reload_config():
+        window.sequence_config = _sequence({}, mode="IMPORT_AUDIO")
+        window.mode = "IMPORT_AUDIO"
+
+    def clear_data():
+        events.append("clear_data")
+        DataDealStruct.clear_data(window.data_struct)
+
+    def init_runtime():
+        events.append("init_runtime")
+        sequence_widget.SequenceWindow.init_data_struct_stimulus_config(window)
+
+    window.get_sequence_config_from_json = reload_config
+    window._clear_plot_area = lambda: events.append("clear_plot")
+    window.data_struct.clear_data = clear_data
+    window.refresh_channel_windows = lambda: events.append("refresh_channels")
+    window.init_data_struct_stimulus_config = init_runtime
+    window._refresh_import_stimulus_analysis_reference = lambda *_: pytest.fail(
+        "mode changes must not refresh the old import reference"
+    )
+
+    sequence_widget.SequenceWindow.on_sequence_config_updated(window)
+
+    assert events == ["clear_plot", "clear_data", "refresh_channels", "init_runtime"]
+    assert window.data_btn.enabled is False
+    assert window.data_struct.sample_rate is None
+    assert window.data_struct.audio_lenth is None
+    assert window.data_struct.store_wave_data is None
+    assert window.data_struct.store_wave_data_multi is None
+    assert window.data_struct.stimulus_data is None
+    assert window.data_struct.stimulus_info is None
+    assert not hasattr(window.data_struct, "alignment_sample_count")
+    assert window.recorded_path is None
+    assert window.recorded_signal_info is None
+    assert window.data_struct.wav_calibration_metadata is None
+    assert window.data_struct.wav_calibration_metadata_authoritative is False
+    assert window.data_struct.wav_calibration_warning_shown is False
+    assert window._has_imported_recording_runtime_state() is False
+    assert window._has_import_stimulus_runtime_reference() is False
+
+
+READINESS_WARNING = "分析参考激励尚未就绪或采样率与导入音频不一致，请检查激励配置后重试。"
+
+
+def _run_window():
+    window = _runtime_window()
+    window.analysis_window = [SimpleNamespace(name="previous-analysis-window")]
+    window._analysis_result_summary_window = SimpleNamespace(name="previous-summary")
+    window.analysis_config = {
+        "display_sequence": ["item"],
+        "item": {"type": "FAKE"},
+    }
+    window.instantiated_analysis = []
+
+    def instance_analysis_class(key, item_type, config):
+        assert window.data_struct.analysis_result_dict == {}
+        window.instantiated_analysis.append((key, item_type, config))
+
+    window.instance_analysis_class = instance_analysis_class
+    window._handle_post_analysis_exports = lambda: None
+    window.count_board = SimpleNamespace(mode="analysis")
+    window.screen = lambda: SimpleNamespace(
+        size=lambda: SimpleNamespace(width=lambda: 1200, height=lambda: 800)
+    )
+    window._maybe_show_analysis_result_summary = lambda *args: None
+    window._send_tcp_analysis_result_callback = lambda: None
+    if hasattr(sequence_widget.SequenceWindow, "_validate_import_stimulus_analysis_readiness"):
+        window._validate_import_stimulus_analysis_readiness = MethodType(
+            sequence_widget.SequenceWindow._validate_import_stimulus_analysis_readiness,
+            window,
+        )
+    return window
+
+
+def _assert_previous_output_state_preserved(window, previous_windows, previous_summary):
+    assert window.data_struct.analysis_result_dict == {"old": (True, "OK")}
+    assert window.analysis_window is previous_windows
+    assert window._analysis_result_summary_window is previous_summary
+    assert window.instantiated_analysis == []
+
+
+def test_run_with_missing_reference_warns_without_clearing_previous_results(monkeypatch):
+    window = _run_window()
+    previous_windows = window.analysis_window
+    previous_summary = window._analysis_result_summary_window
+    window.data_struct.stimulus_info = None
+    warnings = []
+    monkeypatch.setattr(sequence_widget.MessageBox, "warning", lambda *args: warnings.append(args))
+
+    sequence_widget.SequenceWindow.run(window)
+
+    assert warnings == [(window, "提示", READINESS_WARNING)]
+    _assert_previous_output_state_preserved(window, previous_windows, previous_summary)
+
+
+def test_run_with_reference_rate_mismatch_warns_without_analysis(monkeypatch):
+    window = _run_window()
+    previous_windows = window.analysis_window
+    previous_summary = window._analysis_result_summary_window
+    window.data_struct.stimulus_info = {"sample_rate": 44100, "total_time": 0.01}
+    warnings = []
+    monkeypatch.setattr(sequence_widget.MessageBox, "warning", lambda *args: warnings.append(args))
+
+    sequence_widget.SequenceWindow.run(window)
+
+    assert warnings == [(window, "提示", READINESS_WARNING)]
+    _assert_previous_output_state_preserved(window, previous_windows, previous_summary)
+
+
+@pytest.mark.parametrize("total_time", [None, 0, float("nan")])
+def test_run_with_invalid_total_time_warns_without_clearing_previous_results(monkeypatch, total_time):
+    window = _run_window()
+    previous_windows = window.analysis_window
+    previous_summary = window._analysis_result_summary_window
+    window.data_struct.stimulus_info = {"sample_rate": 32000, "total_time": total_time}
+    warnings = []
+    monkeypatch.setattr(sequence_widget.MessageBox, "warning", lambda *args: warnings.append(args))
+
+    sequence_widget.SequenceWindow.run(window)
+
+    assert warnings == [(window, "提示", READINESS_WARNING)]
+    _assert_previous_output_state_preserved(window, previous_windows, previous_summary)
+
+
+def test_run_retains_length_mismatch_gate_before_clearing_results(monkeypatch):
+    window = _run_window()
+    previous_windows = window.analysis_window
+    previous_summary = window._analysis_result_summary_window
+    window.data_struct.audio_lenth = 319
+    warnings = []
+    monkeypatch.setattr(sequence_widget.MessageBox, "warning", lambda *args: warnings.append(args))
+
+    sequence_widget.SequenceWindow.run(window)
+
+    assert warnings == [
+        (
+            window,
+            "音频长度校验失败",
+            "导入音频长度(319)\n与激励信号长度(320)不一致！无法分析！",
+        )
+    ]
+    _assert_previous_output_state_preserved(window, previous_windows, previous_summary)
+
+
+def test_run_clears_previous_results_after_all_import_gates_pass(monkeypatch):
+    window = _run_window()
+    warnings = []
+    monkeypatch.setattr(sequence_widget.MessageBox, "warning", lambda *args: warnings.append(args))
+
+    sequence_widget.SequenceWindow.run(window)
+
+    assert warnings == []
+    assert window.data_struct.analysis_result_dict == {}
+    assert window.analysis_window == []
+    assert window._analysis_result_summary_window is None
+    assert window.instantiated_analysis == [
+        ("item", "FAKE", window.analysis_config["item"])
+    ]

--- a/unit_test/ui/test_sequence_wav_calibration_metadata.py
+++ b/unit_test/ui/test_sequence_wav_calibration_metadata.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import numpy as np
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
@@ -11,6 +12,13 @@ if str(REPO_ROOT) not in sys.path:
 from base.data_struct.data_deal_struct import DataDealStruct
 from consts import error_code
 from ui.sequence import sequence_widget
+
+
+@pytest.fixture(autouse=True)
+def reset_data_deal_struct_singleton():
+    DataDealStruct._instance = None
+    yield
+    DataDealStruct._instance = None
 
 
 class FakeLogger:

--- a/unit_test/ui/test_signal_analysis_v2pa_resolution.py
+++ b/unit_test/ui/test_signal_analysis_v2pa_resolution.py
@@ -389,6 +389,24 @@ def test_spl_direct_analysis_displays_configured_overall_spl_with_weighting_unit
     assert titles == ["总体声压级：100.00 dBC"]
 
 
+def test_spl_missing_sample_rate_warns_and_returns_false(qapp, monkeypatch):
+    warnings = []
+    widget = saw.Spl("SPL")
+    widget.analysis_config = {"analysis_channel": 0, "weighting": "A"}
+    widget.data_struct.store_wave_data = np.ones(32, dtype=np.float32)
+    widget.data_struct.store_wave_data_multi = np.ones((32, 1), dtype=np.float32)
+    widget.data_struct.sample_rate = None
+    monkeypatch.setattr(saw.MessageBox, "warning", lambda parent, title, message: warnings.append((title, message)))
+    monkeypatch.setattr(
+        saw,
+        "resolve_analysis_v2pa_factor_for_channel",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("missing data must stop before calibration")),
+    )
+
+    assert widget.calculate_spl() is False
+    assert warnings == [("提示", "声压级分析失败：没有可用录音数据。")]
+
+
 def test_spl_frequency_direct_analysis_passes_resolved_v2pa(qapp, monkeypatch):
     resolver_calls = _install_resolver(monkeypatch, factor=3.5)
     captured = {}


### PR DESCRIPTION
## Summary
- Add segmented manual upper/lower threshold tables and runtime support for SPL, SPLF, FR, HD, RB, and PRB.
- Fix manual table sizing, table header font consistency, and configuration visibility behavior.
- Refresh and validate imported stimulus runtime state without losing imported recording data.

## Test Plan
- [x] `QT_QPA_PLATFORM=offscreen pytest unit_test/ui/test_manual_limit_segments.py unit_test/ui/test_analysis_config_defaults.py unit_test/ui/test_analysis_config_dialog_migration.py unit_test/ui/test_manual_limit_runtime.py unit_test/ui/test_custom_widgets.py unit_test/ui/test_sequence_import_runtime_refresh.py -q`
- [x] 100 passed, 18 warnings

Closes #767