### PR TITLE
fix: refine analysis configuration UI

### DIFF
--- a/consts/running_consts.py
+++ b/consts/running_consts.py
@@ -1,6 +1,8 @@
 import os
 import sys
 
+APP_DISPLAY_NAME = "希听声学检测"
+
 # DEFAULT_DIR = os.path.split(os.path.realpath(__file__))[0].replace("\\", "/") + "/../"
 DEFAULT_DIR = os.path.dirname(os.path.realpath(sys.argv[0])).replace("\\", "/") + "/"
 

--- a/main_window.py
+++ b/main_window.py
@@ -10,6 +10,7 @@ from base.log_manager import LogManager
 from base.db_manager import DataSave, ensure_system_database_ready
 from base.sound_device_manager import SoundDeviceManager
 from consts.model_consts import SYSTEM_DATABASE_PATH
+from consts.running_consts import APP_DISPLAY_NAME
 from ui.custom_ui_widget.widgets import PushButton, MenuBar, Label, Action, MessageBox
 from ui.ai_window import AiWindow
 from ui.archive_audio_data_dialog import ArchiveAudioDataDialog
@@ -28,6 +29,7 @@ class MainWindow(QMainWindow):
 
     def __init__(self):
         super().__init__()
+        self.setWindowTitle(APP_DISPLAY_NAME)
         # set up statusbar object data
         self.user_name = None
         self.access_lvl = None
@@ -111,7 +113,7 @@ class MainWindow(QMainWindow):
         icon_label.setFixedSize(25, 25)
         icon_label.setScaledContents(True)
         current_version = self.get_current_version()
-        title_label = Label(f"希听异音检测 -{current_version} beta")
+        title_label = Label(f"{APP_DISPLAY_NAME} -{current_version} beta")
         h_spacer = QSpacerItem(10, 10, QSizePolicy.Expanding, QSizePolicy.Minimum)
         title_layout.addWidget(icon_label)
         title_layout.addWidget(title_label)

--- a/main_window_Launcher.py
+++ b/main_window_Launcher.py
@@ -3,6 +3,7 @@ import sys
 from PyQt5.QtCore import QThread, QFile, QTextStream
 from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import QApplication
+from consts.running_consts import APP_DISPLAY_NAME
 from ui.splash_screen_window import Splash, LoaderThread
 
 from ui.custom_ui_widget.widgets import MessageBox
@@ -12,6 +13,8 @@ from ui.ui_src import ui_resources
 class MainWindowLauncher(object):
     def __init__(self):
         self.app = QApplication(sys.argv)
+        self.app.setApplicationName(APP_DISPLAY_NAME)
+        self.app.setApplicationDisplayName(APP_DISPLAY_NAME)
         self.app.setWindowIcon(QIcon(":/ui/icon/ting.ico"))
         qss = self.load_qss()
         self.app.setStyleSheet(qss)

--- a/ui/splash_screen_window.py
+++ b/ui/splash_screen_window.py
@@ -3,8 +3,8 @@ import importlib
 
 from PyQt5.QtCore import Qt, QObject, pyqtSignal, QRect
 from PyQt5.QtWidgets import QWidget, QProgressBar, QLabel
-from consts.running_consts import MODULES_LOAD
-from PyQt5.QtGui import QPixmap
+from consts.running_consts import APP_DISPLAY_NAME, MODULES_LOAD
+from PyQt5.QtGui import QFont, QPixmap
 from ui.ui_src import ui_resources
 
 
@@ -35,12 +35,23 @@ class Splash(QWidget):
         self.label.setScaledContents(True)
         self.label.setObjectName("label")
 
+        self.product_name_label = QLabel(self)
+        self.product_name_label.setGeometry(QRect(20, 285, 591, 50))
+        self.product_name_label.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+        product_name_font = QFont("SimSun")
+        product_name_font.setPixelSize(22)
+        self.product_name_label.setFont(product_name_font)
+        self.product_name_label.setStyleSheet("background-color: #ffffff; color: #111111;")
+        self.product_name_label.setText(f"欢迎使用{APP_DISPLAY_NAME}系统")
+        self.product_name_label.setObjectName("productNameLabel")
+
         self.lab = QLabel(self)
         self.lab.setGeometry(QRect(30, 340, 200, 16))
         self.lab.setObjectName("lab")
         self.lab.setText("正在初始化...0%")
 
         self.label.raise_()
+        self.product_name_label.raise_()
         self.prg.raise_()
         self.lab.raise_()
 

--- a/ui/ui_analysis_config/common_widgets.py
+++ b/ui/ui_analysis_config/common_widgets.py
@@ -10,6 +10,7 @@ from PyQt5.QtWidgets import (
     QButtonGroup,
     QDialog,
     QHBoxLayout,
+    QLayout,
     QScrollArea,
     QSizePolicy,
     QVBoxLayout,
@@ -54,8 +55,6 @@ from ui.ui_analysis_config.config_normalization import (
     normalize_weighting,
     weighting_to_display_label,
 )
-
-
 OCTAVE_SMOOTHING_LABELS = {
     0: "不平滑",
     1: "1/1 Oct",
@@ -178,6 +177,7 @@ class SemanticAnalysisConfigDialogBase(AnalysisConfigDialogBase):
         self.section_layout = QVBoxLayout(self.section_container)
         self.section_layout.setContentsMargins(0, 0, 0, 0)
         self.section_layout.setSpacing(22)
+        self.section_layout.setSizeConstraint(QLayout.SetMinimumSize)
         self.section_layout.addStretch(1)
         self.section_scroll_area.setWidget(self.section_container)
         self.section_scroll_area.verticalScrollBar().valueChanged.connect(self._sync_active_section_from_scroll)
@@ -434,9 +434,18 @@ class SemanticAnalysisConfigDialogBase(AnalysisConfigDialogBase):
         return content_layout
 
     def _refresh_section_container_minimum_height(self) -> None:
+        for content in self._semantic_section_contents.values():
+            content.layout().invalidate()
+            content.layout().activate()
+            content.updateGeometry()
+        for section in self._semantic_sections.values():
+            section.layout().invalidate()
+            section.layout().activate()
+            section.updateGeometry()
+        self.section_container.setMinimumHeight(0)
+        self.section_layout.invalidate()
         self.section_layout.activate()
-        self.section_container.setMinimumWidth(0)
-        self.section_container.setMinimumHeight(max(0, self.section_container.sizeHint().height()))
+        self.section_container.updateGeometry()
 
     def semantic_group_keys(self) -> list[str]:
         return list(self._semantic_sections.keys())

--- a/ui/ui_analysis_config/curve_color_config_widget.py
+++ b/ui/ui_analysis_config/curve_color_config_widget.py
@@ -200,7 +200,7 @@ class CurveColorConfigWidget(QWidget):
         layout.setSpacing(10)
         for key, label in CURVE_COLOR_FIELDS:
             layout.addLayout(self._create_color_row(key, label))
-        layout.addWidget(self._create_label("示意预览"))
+        layout.addWidget(self._create_label("示意预览", True))
         self.preview_widget = CurveColorPreviewWidget(self._colors, content_widget)
         layout.addWidget(self.preview_widget)
         return content_widget
@@ -221,9 +221,14 @@ class CurveColorConfigWidget(QWidget):
     def is_expanded(self):
         return not self.content_widget.isHidden()
 
-    def _create_label(self, text):
+    def _create_label(self, text, preview=False):
         label = Label(text, self)
-        label.setStyleSheet("color: #475467; font-size: 14px; font-weight: 400;")
+        if preview:
+            label.setObjectName("curveColorPreviewLabel")
+            label.setStyleSheet("color: #344054; font-size: 15px; font-weight: 500;")
+        else:
+            label.setObjectName("curveColorFieldLabel")
+            label.setStyleSheet("color: #344054; font-size: 15px; font-weight: 400;")
         return label
 
     def _create_color_row(self, key, label):
@@ -232,6 +237,7 @@ class CurveColorConfigWidget(QWidget):
         row.addStretch()
         button = QPushButton(self)
         button.setFixedSize(72, 30)
+        button.setCursor(Qt.PointingHandCursor)
         button.setToolTip("点击选择预设颜色")
         button.clicked.connect(partial(self._choose_color, key))
         self._color_buttons[key] = button
@@ -259,7 +265,21 @@ class CurveColorConfigWidget(QWidget):
         color = self._colors[key]
         button = self._color_buttons[key]
         button.setAccessibleName(f"{dict(CURVE_COLOR_FIELDS)[key]} {color}")
-        button.setStyleSheet(f"background-color: {color}; border: 1px solid #667085; border-radius: 5px;")
+        button.setStyleSheet(
+            f"""
+            QPushButton {{
+                background-color: {color};
+                border: 1px solid #667085;
+                border-radius: 5px;
+            }}
+            QPushButton:hover {{
+                border: 2px solid #2563EB;
+            }}
+            QPushButton:pressed {{
+                border: 2px solid #1D4ED8;
+            }}
+            """
+        )
 
     def colors(self):
         return dict(self._colors)

--- a/ui/ui_analysis_config/fft_config_dialog.py
+++ b/ui/ui_analysis_config/fft_config_dialog.py
@@ -3,7 +3,14 @@ from typing import List, Optional
 
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QIcon
-from PyQt5.QtWidgets import QFileDialog, QHBoxLayout, QVBoxLayout, QWidget
+from PyQt5.QtWidgets import (
+    QFileDialog,
+    QFormLayout,
+    QHBoxLayout,
+    QToolButton,
+    QVBoxLayout,
+    QWidget,
+)
 
 from consts.acoustic_analysis.specific_consts.fft_consts import (
     FFT_SIZE_PRESETS,
@@ -78,35 +85,32 @@ class FftConfigWindow(SemanticAnalysisConfigDialogBase):
         compute_layout.setSpacing(12)
 
         fft_group = GroupBox("FFT 参数")
-        fft_layout = QVBoxLayout(fft_group)
+        fft_layout = QFormLayout(fft_group)
+        fft_layout.setContentsMargins(8, 12, 8, 8)
+        fft_layout.setHorizontalSpacing(12)
+        fft_layout.setVerticalSpacing(8)
+        fft_layout.setLabelAlignment(Qt.AlignRight | Qt.AlignVCenter)
+        fft_layout.setFieldGrowthPolicy(QFormLayout.AllNonFixedFieldsGrow)
+        fft_layout.setRowWrapPolicy(QFormLayout.DontWrapRows)
 
-        fft_size_layout = QHBoxLayout()
-        fft_size_layout.addWidget(Label("FFT 点数:"))
         self.fft_size_box = ComboBox()
         self.fft_size_box.setEditable(True)
         self.fft_size_box.lineEdit().setFont(self.fft_size_box.font())
         self.fft_size_box.addItems([str(value) for value in self.FFT_PRESETS])
         self.fft_size_box.setCurrentText(str(int(self.load_config.get("n_fft", 4096))))
-        fft_size_layout.addWidget(self.fft_size_box, 1)
-        fft_layout.addLayout(fft_size_layout)
+        fft_layout.addRow(Label("FFT 点数:"), self.fft_size_box)
 
-        window_layout = QHBoxLayout()
-        window_layout.addWidget(Label("窗函数:"))
         self.window_combo = ComboBox()
         self.window_combo.addItems(self.WINDOWS)
         self.window_combo.setCurrentText(str(self.load_config.get("window", "hann")))
-        window_layout.addWidget(self.window_combo, 1)
-        fft_layout.addLayout(window_layout)
+        fft_layout.addRow(Label("窗函数:"), self.window_combo)
 
-        overlap_layout = QHBoxLayout()
-        overlap_layout.addWidget(Label("重叠率:"))
         self.overlap_spin = DoubleSpinBox()
         self.overlap_spin.setRange(0, MAX_OVERLAP_RATIO * 100.0)
         self.overlap_spin.setDecimals(0)
         self.overlap_spin.setSuffix(" %")
         self.overlap_spin.setValue(float(self.load_config.get("overlap_ratio", 0.5)) * 100.0)
-        overlap_layout.addWidget(self.overlap_spin, 1)
-        fft_layout.addLayout(overlap_layout)
+        fft_layout.addRow(Label("重叠率:"), self.overlap_spin)
         compute_layout.addWidget(fft_group)
 
         self.weighting_selector = WeightingSelectorWidget(
@@ -118,10 +122,25 @@ class FftConfigWindow(SemanticAnalysisConfigDialogBase):
         compute_layout.addWidget(self.weighting_selector)
         self.add_semantic_section("compute", widget=compute_widget)
 
-        display_widget = QWidget(self)
-        display_layout = QVBoxLayout(display_widget)
+        self.spectrum_display_widget = QWidget(self)
+        display_layout = QVBoxLayout(self.spectrum_display_widget)
         display_layout.setContentsMargins(0, 0, 0, 0)
         display_layout.setSpacing(12)
+
+        self.spectrum_expand_button = QToolButton(self)
+        self.spectrum_expand_button.setText("频谱显示设置")
+        self.spectrum_expand_button.setCheckable(True)
+        self.spectrum_expand_button.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+        self.spectrum_expand_button.setCursor(Qt.PointingHandCursor)
+        self.spectrum_expand_button.setStyleSheet(
+            "color: #344054; font-size: 16px; font-weight: 600; border: none;"
+        )
+        display_layout.addWidget(self.spectrum_expand_button)
+
+        self.spectrum_content_widget = QWidget(self)
+        spectrum_content_layout = QVBoxLayout(self.spectrum_content_widget)
+        spectrum_content_layout.setContentsMargins(16, 2, 0, 0)
+        spectrum_content_layout.setSpacing(10)
 
         axis_layout = QHBoxLayout()
         axis_layout.addWidget(Label("横轴:"))
@@ -129,12 +148,12 @@ class FftConfigWindow(SemanticAnalysisConfigDialogBase):
         self.x_axis_combo.addItems(self.X_AXIS_SCALES)
         self.x_axis_combo.setCurrentText(str(self.load_config.get("x_axis_scale", "log")))
         axis_layout.addWidget(self.x_axis_combo, 1)
-        display_layout.addLayout(axis_layout)
+        spectrum_content_layout.addLayout(axis_layout)
 
         self.focus_checkbox = CheckBox("启用频率聚焦范围")
         self.focus_checkbox.setChecked(bool(self.load_config.get("focus_range_enabled", True)))
         self.focus_checkbox.stateChanged.connect(self._on_focus_changed)
-        display_layout.addWidget(self.focus_checkbox)
+        spectrum_content_layout.addWidget(self.focus_checkbox)
 
         self.focus_widget = QWidget(self)
         focus_layout = QHBoxLayout(self.focus_widget)
@@ -151,9 +170,12 @@ class FftConfigWindow(SemanticAnalysisConfigDialogBase):
         self.focus_max_spin.setSuffix(" Hz")
         self.focus_max_spin.setValue(int(self.load_config.get("focus_max_hz", 20000)))
         focus_layout.addWidget(self.focus_max_spin)
-        display_layout.addWidget(self.focus_widget)
+        spectrum_content_layout.addWidget(self.focus_widget)
+        display_layout.addWidget(self.spectrum_content_widget)
         self._on_focus_changed(self.focus_checkbox.checkState())
-        self.add_semantic_section("display", widget=display_widget)
+        self.add_semantic_section("display", widget=self.spectrum_display_widget)
+        self.spectrum_expand_button.toggled.connect(self._set_spectrum_display_expanded)
+        self._set_spectrum_display_expanded(False)
 
         baseline_widget = QWidget(self)
         baseline_layout = QVBoxLayout(baseline_widget)
@@ -209,6 +231,16 @@ class FftConfigWindow(SemanticAnalysisConfigDialogBase):
         self.x_axis_combo.currentIndexChanged.connect(self._sync_plot_view_x_constraint)
         self.weighting_selector.combo_box.currentIndexChanged.connect(self._sync_plot_view_y_unit)
         self.baseline_mode_combo.currentIndexChanged.connect(self._sync_plot_view_y_unit)
+
+    def _set_spectrum_display_expanded(self, expanded):
+        expanded = bool(expanded)
+        self.spectrum_expand_button.setArrowType(
+            Qt.DownArrow if expanded else Qt.RightArrow
+        )
+        self.spectrum_content_widget.setVisible(expanded)
+        self.spectrum_content_widget.updateGeometry()
+        self.spectrum_display_widget.updateGeometry()
+        self._on_display_config_expanded(expanded)
 
     def _sync_plot_view_x_constraint(self, _index=None):
         self.plot_view_config_widget.set_positive_x(self.x_axis_combo.currentText() == "log")

--- a/unit_test/ui/test_application_display_name.py
+++ b/unit_test/ui/test_application_display_name.py
@@ -1,0 +1,27 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from PyQt5.QtWidgets import QApplication
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from consts.running_consts import APP_DISPLAY_NAME
+from ui.splash_screen_window import Splash
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QApplication.instance() or QApplication([])
+    yield app
+
+
+def test_splash_screen_uses_application_display_name(qapp):
+    splash = Splash()
+
+    assert APP_DISPLAY_NAME == "希听声学检测"
+    assert splash.product_name_label.text() == "欢迎使用希听声学检测系统"
+    assert splash.product_name_label.font().family() == "SimSun"
+    assert splash.product_name_label.font().pixelSize() == 22

--- a/unit_test/ui/test_curve_color_config.py
+++ b/unit_test/ui/test_curve_color_config.py
@@ -123,9 +123,26 @@ def test_curve_color_widget_updates_preview_and_nested_config(qapp):
         "下限颜色",
         "示意预览",
     }
-    assert all("color: #475467" in label.styleSheet() for label in content_labels)
-    assert all("font-size: 14px" in label.styleSheet() for label in content_labels)
-    assert all("font-weight: 400" in label.styleSheet() for label in content_labels)
+    field_labels = [
+        label
+        for label in content_labels
+        if label.objectName() == "curveColorFieldLabel"
+    ]
+    preview_label = widget.content_widget.findChild(QLabel, "curveColorPreviewLabel")
+    assert len(field_labels) == 3
+    assert all("color: #344054" in label.styleSheet() for label in field_labels)
+    assert all("font-size: 15px" in label.styleSheet() for label in field_labels)
+    assert all("font-weight: 400" in label.styleSheet() for label in field_labels)
+    assert preview_label is not None
+    assert "color: #344054" in preview_label.styleSheet()
+    assert "font-size: 15px" in preview_label.styleSheet()
+    assert "font-weight: 500" in preview_label.styleSheet()
+    color_buttons = list(widget._color_buttons.values())
+    assert all(button.cursor().shape() == Qt.PointingHandCursor for button in color_buttons)
+    assert all("QPushButton:hover" in button.styleSheet() for button in color_buttons)
+    assert all("border: 2px solid #2563EB" in button.styleSheet() for button in color_buttons)
+    assert all("QPushButton:pressed" in button.styleSheet() for button in color_buttons)
+    assert all("border: 2px solid #1D4ED8" in button.styleSheet() for button in color_buttons)
     assert emitted[-1][MAIN_CURVE_COLOR] == "#2563EB"
     assert config["display"][MAIN_CURVE_COLOR] == "#2563EB"
     assert config["display"]["grid_visible"] is True

--- a/unit_test/ui/test_fft_config_dialog.py
+++ b/unit_test/ui/test_fft_config_dialog.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+from PyQt5.QtCore import Qt
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
@@ -66,6 +67,51 @@ def test_fft_size_editor_uses_combo_box_font(qapp):
     assert editor is not None
     assert editor.font().pixelSize() == window.fft_size_box.font().pixelSize()
     assert editor.font().pixelSize() == window.window_combo.font().pixelSize()
+
+
+def test_fft_parameter_fields_share_the_same_form_column(qapp):
+    window = FftConfigWindow(
+        FakeConfigManager({"FFT1": {"type": "FFT"}}),
+        "FFT1",
+        available_channels=[0],
+    )
+    window.show()
+    qapp.processEvents()
+
+    fields = (window.fft_size_box, window.window_combo, window.overlap_spin)
+    assert len({field.geometry().left() for field in fields}) == 1
+    assert len({field.geometry().right() for field in fields}) == 1
+    assert all(
+        lower.geometry().top() > upper.geometry().bottom()
+        for upper, lower in zip(fields, fields[1:])
+    )
+    assert (
+        window.section_container.minimumHeight()
+        >= window.section_container.sizeHint().height()
+    )
+    window.close()
+
+
+def test_fft_spectrum_display_settings_have_collapsible_title(qapp):
+    window = FftConfigWindow(FakeConfigManager({"FFT1": {"type": "FFT"}}), "FFT1")
+    window.show()
+    qapp.processEvents()
+
+    assert window.spectrum_expand_button.text() == "频谱显示设置"
+    assert window.spectrum_expand_button.arrowType() == Qt.RightArrow
+    assert window.spectrum_content_widget.isHidden() is True
+
+    collapsed_container_height = window.section_container.minimumHeight()
+    window.spectrum_expand_button.setChecked(True)
+    qapp.processEvents()
+    assert window.spectrum_expand_button.arrowType() == Qt.DownArrow
+    assert window.spectrum_content_widget.isHidden() is False
+    assert window.section_container.minimumHeight() > collapsed_container_height
+
+    window.spectrum_expand_button.setChecked(False)
+    qapp.processEvents()
+    assert window.section_container.minimumHeight() == collapsed_container_height
+    window.close()
 
 
 def test_fft_config_uses_shared_fft_constraints(qapp):

--- a/unit_test/ui/test_main_window_startup_device_recovery.py
+++ b/unit_test/ui/test_main_window_startup_device_recovery.py
@@ -215,6 +215,7 @@ def test_hardware_management_menu_action_matches_hardware_role_and_opens_window(
     )
 
     window = main_window_module.MainWindow()
+    assert window.windowTitle() == "希听声学检测"
     window.access_lvl = "Engineer"
     menu_bar = window.init_menu()
 


### PR DESCRIPTION
## Summary

- align the FFT parameter fields and add a collapsible spectrum-display section
- refresh semantic-section sizing on first open and after expand/collapse changes
- refine curve-color labels and color-button interaction feedback

## Why

The FFT configuration dialog could overlap controls on first open, while display controls lacked consistent collapsible grouping and curve-color controls needed clearer visual feedback.

## Verification

- 222 related UI tests passed on the original commit tree
- the clean cherry-picked commit tree is byte-identical to that tested tree
- `git diff --check origin/develop...HEAD` passed
- the PR branch contains one commit and five scoped files
