### PR TITLE
BUG20260727-fix-ui-layout-resizing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ unit_test/ui/test_custom_double_spin_box.py
 dist
 create_hardware_tables.exe
 tmp
+.tmp

--- a/ui/sequence/sequence_widget.py
+++ b/ui/sequence/sequence_widget.py
@@ -19,6 +19,7 @@ from PyQt5.QtWidgets import (
     QLineEdit,
     QDialog,
     QLabel,
+    QSplitter,
 )
 from base.data_struct.data_deal_struct import DataDealStruct
 from base.excel_result_exporter import (
@@ -342,8 +343,9 @@ class SequenceWindow(QWidget):
 
         sequence_layout = QVBoxLayout()
         sequence_layout.addWidget(self.toolsbar)
-        sequence_layout.addLayout(waveform_layout)
-        sequence_layout.setAlignment(Qt.AlignCenter)
+        sequence_layout.addLayout(waveform_layout, stretch=1)
+        sequence_layout.setAlignment(Qt.AlignTop)
+        sequence_layout.setSpacing(0)
         sequence_layout.setContentsMargins(1, 0, 1, 0)
 
         self.add_file_to_using_file_combobox()
@@ -863,11 +865,164 @@ class SequenceWindow(QWidget):
 
         self.channel_workspace = ChannelPlotWorkspace(self)
 
-        layout.addWidget(self.count_board, stretch=1)
-        layout.addSpacing(20)
-        layout.addWidget(self.channel_workspace, stretch=8)
+        self.waveform_splitter = QSplitter(Qt.Horizontal)
+        self.waveform_splitter.setObjectName("SequenceWaveformSplitter")
+        self.waveform_splitter.setChildrenCollapsible(False)
+        splitter_side_padding = ui_style_const.scale_size_px(3)
+        self.waveform_splitter.setHandleWidth(1)
+        self.waveform_splitter.setStyleSheet(
+            f"""
+            QSplitter#SequenceWaveformSplitter::handle {{
+                background-color: #b8b8b8;
+                border: 0;
+                margin-left: {splitter_side_padding}px;
+                margin-right: {splitter_side_padding}px;
+            }}
+            """
+        )
+        self.waveform_splitter.addWidget(self.count_board)
+        self.waveform_splitter.addWidget(self.channel_workspace)
+        self.waveform_splitter.setStretchFactor(0, 1)
+        self.waveform_splitter.setStretchFactor(1, 8)
+
+        self._init_count_board_splitter_state()
+
+        layout.addWidget(self.waveform_splitter)
         layout.setContentsMargins(40, 20, 40, 20)
         return layout
+
+    def _init_count_board_splitter_state(self) -> None:
+        collapsed_hint = self.count_board.collapsed_width_hint()
+        self._count_board_collapsed_width = max(collapsed_hint, ui_style_const.scale_size_px(36))
+        self._count_board_collapse_threshold = self._count_board_collapsed_width + ui_style_const.scale_size_px(16)
+        self._count_board_expand_threshold = self._count_board_collapse_threshold + ui_style_const.scale_size_px(24)
+        self._last_count_board_expanded_width = self.count_board.expanded_width_hint()
+        self._count_board_max_width = self._last_count_board_expanded_width + ui_style_const.scale_size_px(120)
+        self._applying_count_board_splitter_state = False
+        self._count_board_splitter_reconcile_pending = False
+
+        self.count_board.set_compact_resize_enabled(True)
+        self.count_board.setMaximumWidth(self._count_board_max_width)
+        self.waveform_splitter.installEventFilter(self)
+        self.count_board.installEventFilter(self)
+        self.count_board.collapsed_changed.connect(self._on_count_board_collapsed_changed)
+        self.waveform_splitter.splitterMoved.connect(self._on_waveform_splitter_moved)
+        QTimer.singleShot(0, self._apply_initial_waveform_splitter_sizes)
+
+    def _apply_initial_waveform_splitter_sizes(self) -> None:
+        if not hasattr(self, "waveform_splitter"):
+            return
+        available_width = self._count_board_splitter_available_width()
+        if available_width <= 0:
+            QTimer.singleShot(0, self._apply_initial_waveform_splitter_sizes)
+            return
+
+        if not self._can_expand_count_board(available_width):
+            was_collapsed = self.count_board.is_collapsed()
+            self.count_board.set_collapsed(True)
+            if was_collapsed:
+                self._apply_count_board_splitter_sizes(True)
+            return
+
+        expanded_width = self._bounded_count_board_width(self.count_board.expanded_width_hint())
+        left_width = min(expanded_width, max(0, available_width - 1))
+        self.waveform_splitter.setSizes([left_width, max(1, available_width - left_width)])
+
+    def _schedule_count_board_splitter_reconcile(self) -> None:
+        if self._applying_count_board_splitter_state:
+            return
+        if getattr(self, "_count_board_splitter_reconcile_pending", False):
+            return
+        self._count_board_splitter_reconcile_pending = True
+        QTimer.singleShot(0, self._reconcile_count_board_splitter_state)
+
+    def _reconcile_count_board_splitter_state(self) -> None:
+        self._count_board_splitter_reconcile_pending = False
+        if self._applying_count_board_splitter_state:
+            return
+        if not hasattr(self, "waveform_splitter"):
+            return
+
+        sizes = self.waveform_splitter.sizes()
+        left_width = sizes[0] if sizes else 0
+        available_width = self._count_board_splitter_available_width()
+        minimum_expanded_width = self.count_board.expanded_width_hint()
+
+        if not self.count_board.is_collapsed() and (
+            left_width < minimum_expanded_width or not self._can_expand_count_board(available_width)
+        ):
+            self.count_board.set_collapsed(True)
+
+    def _on_count_board_collapsed_changed(self, collapsed: bool) -> None:
+        if self._applying_count_board_splitter_state:
+            return
+        self._apply_count_board_splitter_sizes(bool(collapsed))
+
+    def _on_waveform_splitter_moved(self, pos: int, index: int) -> None:
+        if self._applying_count_board_splitter_state:
+            return
+
+        sizes = self.waveform_splitter.sizes()
+        left_width = sizes[0] if sizes else int(pos)
+        minimum_expanded_width = self.count_board.expanded_width_hint()
+
+        if left_width < minimum_expanded_width:
+            was_collapsed = self.count_board.is_collapsed()
+            self.count_board.set_collapsed(True)
+            if was_collapsed:
+                self._apply_count_board_splitter_sizes(True)
+            return
+
+        self._last_count_board_expanded_width = self._bounded_count_board_width(left_width)
+        self.count_board.set_collapsed(False)
+        if left_width > self._count_board_max_width:
+            self._apply_count_board_splitter_sizes(False)
+
+    def _apply_count_board_splitter_sizes(self, collapsed: bool) -> None:
+        total_width = self._count_board_splitter_available_width()
+        if total_width <= 0:
+            total_width = self.count_board.expanded_width_hint() * 4
+
+        if collapsed:
+            left_width = self._count_board_collapsed_width
+        else:
+            if not self._can_expand_count_board(total_width):
+                self._applying_count_board_splitter_state = True
+                try:
+                    self.count_board.set_collapsed(True)
+                    left_width = min(self._count_board_collapsed_width, max(0, total_width - 1))
+                    self.waveform_splitter.setSizes([left_width, max(1, total_width - left_width)])
+                finally:
+                    self._applying_count_board_splitter_state = False
+                return
+
+            left_width = max(self._last_count_board_expanded_width, self.count_board.expanded_width_hint())
+            left_width = self._bounded_count_board_width(left_width)
+            left_width = min(left_width, max(self._count_board_expand_threshold + 1, total_width - 1))
+
+        right_width = max(1, total_width - left_width)
+        self._applying_count_board_splitter_state = True
+        try:
+            self.waveform_splitter.setSizes([left_width, right_width])
+        finally:
+            self._applying_count_board_splitter_state = False
+
+    def _bounded_count_board_width(self, width: int) -> int:
+        return min(max(int(width), self._count_board_collapsed_width), self._count_board_max_width)
+
+    def _count_board_splitter_available_width(self) -> int:
+        sizes = self.waveform_splitter.sizes()
+        total_width = sum(sizes) if sizes else 0
+        if total_width > 0:
+            return total_width
+        return max(0, self.waveform_splitter.width() - self.waveform_splitter.handleWidth())
+
+    def _can_expand_count_board(self, available_width=None) -> bool:
+        if available_width is None:
+            available_width = self._count_board_splitter_available_width()
+        if available_width <= 0:
+            return True
+        return available_width >= self.count_board.expanded_width_hint() + 1
 
     def init_fft_and_stft_flag(self):
         model_item_list = self.analysis_config.get("display_sequence", "")
@@ -3080,18 +3235,27 @@ class SequenceWindow(QWidget):
         """
         Persist analysis window geometry on move/resize (no close handling).
         """
+        is_count_board_splitter_resize = (
+            obj is getattr(self, "waveform_splitter", None) or obj is getattr(self, "count_board", None)
+        ) and event.type() == QEvent.Resize
+        if is_count_board_splitter_resize:
+            self._schedule_count_board_splitter_reconcile()
+
+        analysis_window_key_by_obj = getattr(self, "_analysis_window_key_by_obj", None)
         try:
-            if obj in self._analysis_window_key_by_obj:
+            if analysis_window_key_by_obj is not None and obj in analysis_window_key_by_obj:
                 et = event.type()
                 if et in (QEvent.Move, QEvent.Resize):
-                    key = self._analysis_window_key_by_obj.get(obj)
+                    key = analysis_window_key_by_obj.get(obj)
                     if key:
                         rect = obj.geometry()
                         geo = {"x": rect.x(), "y": rect.y(), "w": rect.width(), "h": rect.height()}
                         self._set_analysis_window_geometry(key, geo)
         except Exception as e:
             # Never break Qt event loop
-            self.default_logger.error(f"eventFilter geometry persist error: {e}")
+            log_error = getattr(getattr(self, "default_logger", None), "error", None)
+            if callable(log_error):
+                log_error(f"eventFilter geometry persist error: {e}")
 
         # 键盘事件捕获（扫码枪键盘楔入模式）
         try:

--- a/ui/sequence/sequencement_count_board.py
+++ b/ui/sequence/sequencement_count_board.py
@@ -1,9 +1,9 @@
 import json
 from datetime import datetime
 
-from PyQt5.QtCore import Qt, QSize
+from PyQt5.QtCore import Qt, QSize, pyqtSignal
 from PyQt5.QtGui import QIcon
-from PyQt5.QtWidgets import QVBoxLayout, QHBoxLayout, QFrame, QWidget, QStackedWidget
+from PyQt5.QtWidgets import QVBoxLayout, QHBoxLayout, QFrame, QWidget, QStackedWidget, QSizePolicy
 
 from base.save_data import ensure_test_result_file
 from consts import ui_style_const
@@ -13,21 +13,32 @@ from ui.ui_src import ui_resources
 
 
 class SequenceCountBoard(QWidget):
+    collapsed_changed = pyqtSignal(bool)
 
     def __init__(self, analysis_config, parent=None):
         super(SequenceCountBoard, self).__init__(parent)
 
         self.btn_height = ui_style_const.scale_size_px(80)
         self.btn_width = ui_style_const.scale_size_px(180)
-        self.lineedit_width = ui_style_const.scale_size_px(130)
-        self.lineedit_height = ui_style_const.scale_size_px(35)
+        self._minimum_content_width = self.btn_width + ui_style_const.scale_size_px(20)
         self.label_width = ui_style_const.scale_size_px(100)
+        self.lineedit_width = max(ui_style_const.scale_size_px(80), self._minimum_content_width - self.label_width)
+        self.lineedit_height = ui_style_const.scale_size_px(35)
+        self.mode_label_width = ui_style_const.scale_size_px(60)
+        self.mode_button_width = max(
+            ui_style_const.scale_size_px(70),
+            int((self._minimum_content_width - self.mode_label_width) / 2),
+        )
         self.icon_size = ui_style_const.scale_size_px(24)
 
         self.analysis_config = analysis_config
         self.mode = str()
         self._test_available = True
         self._test_unavailable_reason = ""
+        self._collapsed = False
+        self._compact_resize_enabled = False
+        self._collapse_bar_width = ui_style_const.scale_size_px(36)
+        self._splitter_gap_width = ui_style_const.scale_size_px(5)
 
         self.test_btn = PushButton("测试")
         self.mark_btn = PushButton("标记")
@@ -47,6 +58,25 @@ class SequenceCountBoard(QWidget):
         self.ng_btn.setObjectName("NgBtn")
         self.reset_btn = PushButton("重置统计")
         self.reset_btn.setObjectName("ResrtBtn")
+        self.collapse_toggle_btn = PushButton("<<")
+        self.collapse_toggle_btn.setObjectName("CollapseToggleBtn")
+        self.collapse_toggle_btn.setFixedWidth(self._collapse_bar_width)
+        self.collapse_toggle_btn.setToolTip("折叠计数板")
+        self.collapse_toggle_btn.setStyleSheet(
+            """
+            #CollapseToggleBtn {
+                background-color: transparent;
+                border: none;
+            }
+            #CollapseToggleBtn:hover {
+                background-color: transparent;
+            }
+            #CollapseToggleBtn:pressed {
+                background-color: transparent;
+            }
+            """
+        )
+        self.collapse_toggle_btn.clicked.connect(self.toggle_collapsed)
 
         self.set_lineedit()
         self.set_btn()
@@ -76,27 +106,100 @@ class SequenceCountBoard(QWidget):
         layout.addLayout(mode_btn_layout)
         layout.addWidget(separator_line)
         layout.addWidget(self.stacked_widget)
+        layout.setContentsMargins(0, 0, 0, 0)
 
-        widget = QWidget()
-        widget.setLayout(layout)
-        widget.setObjectName("SequenceCountBoard")
+        self.content_widget = QWidget()
+        self.content_widget.setLayout(layout)
+        self.content_widget.setObjectName("SequenceCountBoardContent")
+        self.content_widget.setMinimumWidth(0)
+        self.content_widget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
 
-        layout_main = QVBoxLayout()
-        layout_main.addWidget(widget)
-        layout_main.addStretch()
-        layout_main.setContentsMargins(0, 0, 0, 0)
+        collapse_bar_layout = QVBoxLayout()
+        collapse_bar_layout.addWidget(self.collapse_toggle_btn)
+        collapse_bar_layout.addStretch()
+        collapse_bar_layout.setContentsMargins(0, 0, 0, 0)
+        collapse_bar_layout.setSpacing(0)
+
+        collapse_bar_widget = QWidget()
+        collapse_bar_widget.setObjectName("SequenceCountBoardCollapseBar")
+        collapse_bar_widget.setFixedWidth(self._collapse_bar_width)
+        collapse_bar_widget.setLayout(collapse_bar_layout)
+
+        layout_main = QHBoxLayout()
+        layout_main.addWidget(self.content_widget, stretch=1)
+        layout_main.addWidget(collapse_bar_widget)
+        layout_main.setSpacing(0)
+        layout_main.setContentsMargins(0, 0, self._splitter_gap_width, 0)
 
         self.setLayout(layout_main)
+        self._refresh_minimum_width()
 
         self.set_test_text()
         self.set_mark_text()
 
+    def is_collapsed(self):
+        return self._collapsed
+
+    def set_collapsed(self, collapsed: bool) -> None:
+        collapsed = bool(collapsed)
+        if self._collapsed == collapsed:
+            return
+
+        self._collapsed = collapsed
+        self.content_widget.setVisible(not collapsed)
+        self.collapse_toggle_btn.setText(">>" if collapsed else "<<")
+        self.collapse_toggle_btn.setToolTip("展开计数板" if collapsed else "折叠计数板")
+        self._refresh_minimum_width()
+        self.updateGeometry()
+        self.collapsed_changed.emit(collapsed)
+
+    def toggle_collapsed(self) -> None:
+        self.set_collapsed(not self.is_collapsed())
+
+    def set_compact_resize_enabled(self, enabled: bool) -> None:
+        self._compact_resize_enabled = bool(enabled)
+        self._refresh_minimum_width()
+        self.updateGeometry()
+
+    def expanded_width_hint(self) -> int:
+        layout = self.layout()
+        margins = layout.contentsMargins()
+        spacing = max(0, layout.spacing())
+        expanded_layout_width = (
+            max(self._minimum_content_width, self.content_widget.minimumSizeHint().width())
+            + self._collapse_bar_width
+            + spacing
+            + margins.left()
+            + margins.right()
+        )
+        return expanded_layout_width
+
+    def collapsed_width_hint(self) -> int:
+        return self._collapse_bar_width + self._splitter_gap_width
+
+    def minimumSizeHint(self):
+        hint = super().minimumSizeHint()
+        if self._collapsed or self._compact_resize_enabled:
+            hint.setWidth(self.collapsed_width_hint())
+        else:
+            hint.setWidth(self.expanded_width_hint())
+        return hint
+
+    def _refresh_minimum_width(self) -> None:
+        if self._collapsed or self._compact_resize_enabled:
+            self.setMinimumWidth(self.collapsed_width_hint())
+        else:
+            self.setMinimumWidth(self.expanded_width_hint())
+
     def create_horizontal_layout(self, label_str, item):
         label = Label(label_str)
+        label.setFixedWidth(self.label_width)
 
         layout = QHBoxLayout()
         layout.addWidget(label)
-        layout.addWidget(item)
+        layout.addWidget(item, stretch=1)
+        layout.setSpacing(0)
+        layout.setContentsMargins(0, 0, 0, 0)
 
         return layout
 
@@ -119,14 +222,20 @@ class SequenceCountBoard(QWidget):
         self.mark_ok_edit.setDisabled(True)
         self.mark_ng_edit.setDisabled(True)
 
-        self.total_line_edit.setFixedSize(self.lineedit_width, self.lineedit_height)
-        self.ok_line_edit.setFixedSize(self.lineedit_width, self.lineedit_height)
-        self.ng_line_edit.setFixedSize(self.lineedit_width, self.lineedit_height)
-        self.yield_line_edit.setFixedSize(self.lineedit_width, self.lineedit_height)
-        self.datatime_line_edit.setFixedSize(self.lineedit_width, self.lineedit_height)
-        self.mark_total_edit.setFixedSize(self.lineedit_width, self.lineedit_height)
-        self.mark_ok_edit.setFixedSize(self.lineedit_width, self.lineedit_height)
-        self.mark_ng_edit.setFixedSize(self.lineedit_width, self.lineedit_height)
+        line_edits = (
+            self.total_line_edit,
+            self.ok_line_edit,
+            self.ng_line_edit,
+            self.yield_line_edit,
+            self.datatime_line_edit,
+            self.mark_total_edit,
+            self.mark_ok_edit,
+            self.mark_ng_edit,
+        )
+        for line_edit in line_edits:
+            line_edit.setFixedHeight(self.lineedit_height)
+            line_edit.setMinimumWidth(self.lineedit_width)
+            line_edit.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
 
     def set_btn(self):
         self.ok_btn.setIcon(QIcon(":/ui/icon/green_circle.png"))
@@ -138,17 +247,19 @@ class SequenceCountBoard(QWidget):
 
     def create_mode_btn_layout(self):
         mode_label = Label("模式：")
-        self.test_btn.setFixedSize(self.label_width, self.lineedit_height)
-        self.mark_btn.setFixedSize(self.label_width, self.lineedit_height)
+        mode_label.setFixedWidth(self.mode_label_width)
+        self.test_btn.setFixedSize(self.mode_button_width, self.lineedit_height)
+        self.mark_btn.setFixedSize(self.mode_button_width, self.lineedit_height)
         self.test_btn.clicked.connect(self.on_test_btn_clicked)
         self.mark_btn.clicked.connect(self.on_mark_btn_clicked)
 
         model_button_layout = QHBoxLayout()
         model_button_layout.addWidget(mode_label)
-        model_button_layout.addSpacing(70)
+        model_button_layout.addStretch()
         model_button_layout.addWidget(self.test_btn)
         model_button_layout.addWidget(self.mark_btn)
         model_button_layout.setSpacing(0)
+        model_button_layout.setContentsMargins(0, 0, 0, 0)
 
         return model_button_layout
 
@@ -164,12 +275,15 @@ class SequenceCountBoard(QWidget):
         reset_btn_layout.addStretch()
 
         test_layout = QVBoxLayout()
-        test_layout.addLayout(total_layout, stretch=1)
-        test_layout.addLayout(ok_layout, stretch=1)
-        test_layout.addLayout(ng_layout, stretch=1)
-        test_layout.addLayout(yield_layout, stretch=1)
-        test_layout.addLayout(datatime_layout, stretch=1)
-        test_layout.addLayout(reset_btn_layout, stretch=1)
+        test_layout.setSpacing(ui_style_const.scale_size_px(7))
+        test_layout.setContentsMargins(0, 0, 0, 0)
+        test_layout.addLayout(total_layout)
+        test_layout.addLayout(ok_layout)
+        test_layout.addLayout(ng_layout)
+        test_layout.addLayout(yield_layout)
+        test_layout.addLayout(datatime_layout)
+        test_layout.addLayout(reset_btn_layout)
+        test_layout.addStretch()
 
         test_widget = QWidget()
         test_widget.setLayout(test_layout)
@@ -190,12 +304,15 @@ class SequenceCountBoard(QWidget):
         ng_btn_layout.addStretch()
 
         mark_layout = QVBoxLayout()
-        mark_layout.addLayout(total_layout, stretch=1)
-        mark_layout.addLayout(ok_layout, stretch=1)
-        mark_layout.addLayout(ng_layout, stretch=1)
+        mark_layout.setSpacing(ui_style_const.scale_size_px(7))
+        mark_layout.setContentsMargins(0, 0, 0, 0)
+        mark_layout.addLayout(total_layout)
+        mark_layout.addLayout(ok_layout)
+        mark_layout.addLayout(ng_layout)
         mark_layout.addSpacing(10)
-        mark_layout.addLayout(ok_btn_layout, stretch=1)
-        mark_layout.addLayout(ng_btn_layout, stretch=1)
+        mark_layout.addLayout(ok_btn_layout)
+        mark_layout.addLayout(ng_btn_layout)
+        mark_layout.addStretch()
 
         mark_widget = QWidget()
         mark_widget.setLayout(mark_layout)

--- a/ui/ui_analysis_config/common_widgets.py
+++ b/ui/ui_analysis_config/common_widgets.py
@@ -173,7 +173,7 @@ class SemanticAnalysisConfigDialogBase(AnalysisConfigDialogBase):
         self.section_scroll_area.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
         self.section_container = QWidget(self.section_scroll_area)
         self.section_container.setObjectName("semanticSectionContainer")
-        self.section_container.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Minimum)
+        self.section_container.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)
         self.section_layout = QVBoxLayout(self.section_container)
         self.section_layout.setContentsMargins(0, 0, 0, 0)
         self.section_layout.setSpacing(22)
@@ -373,7 +373,7 @@ class SemanticAnalysisConfigDialogBase(AnalysisConfigDialogBase):
         section_widget.setObjectName("semanticSectionCard")
         section_widget.setProperty("semanticGroupKey", group_key)
         section_widget.setAttribute(Qt.WA_StyledBackground, True)
-        section_widget.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Minimum)
+        self._apply_semantic_size_policy(section_widget)
         section_layout = QVBoxLayout(section_widget)
         section_layout.setContentsMargins(0, 0, 0, 0)
         section_layout.setSpacing(0)
@@ -411,12 +411,12 @@ class SemanticAnalysisConfigDialogBase(AnalysisConfigDialogBase):
         content_widget = QWidget(section_widget)
         content_widget.setObjectName("semanticSectionContent")
         content_widget.setAttribute(Qt.WA_StyledBackground, True)
-        content_widget.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Minimum)
+        self._apply_semantic_size_policy(content_widget)
         content_layout = QVBoxLayout(content_widget)
         content_layout.setContentsMargins(14, 12, 14, 14)
         content_layout.setSpacing(10)
         if widget is not None:
-            widget.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Minimum)
+            self._apply_semantic_size_policy(widget)
             content_layout.addWidget(widget)
         if layout is not None:
             content_layout.addLayout(layout)
@@ -446,6 +446,93 @@ class SemanticAnalysisConfigDialogBase(AnalysisConfigDialogBase):
         self.section_layout.invalidate()
         self.section_layout.activate()
         self.section_container.updateGeometry()
+        visible_sections = [
+            section for section in self._semantic_sections.values() if not section.isHidden()
+        ]
+        for section in visible_sections:
+            self._refresh_widget_minimum_height(section)
+        self.section_layout.activate()
+        spacing = self.section_layout.spacing()
+        height = sum(section.sizeHint().height() for section in visible_sections)
+        height += spacing * max(0, len(visible_sections) - 1)
+        self.section_container.setMinimumWidth(0)
+        self.section_container.setMinimumHeight(max(0, height))
+        self.section_container.updateGeometry()
+        self.section_container.adjustSize()
+
+    def _apply_semantic_size_policy(self, widget: QWidget) -> None:
+        policy = widget.sizePolicy()
+        vertical_policy = policy.verticalPolicy()
+        if (
+            vertical_policy != QSizePolicy.Fixed
+            and not self._has_fixed_height(widget)
+        ):
+            vertical_policy = QSizePolicy.Minimum
+        widget.setSizePolicy(QSizePolicy.Expanding, vertical_policy)
+
+    def _refresh_widget_minimum_height(self, widget: QWidget) -> None:
+        if widget.isHidden():
+            return
+
+        layout = widget.layout()
+        if layout is not None:
+            for index in range(layout.count()):
+                item = layout.itemAt(index)
+                child_widget = item.widget()
+                if child_widget is not None:
+                    self._refresh_widget_minimum_height(child_widget)
+                    continue
+                child_layout = item.layout()
+                if child_layout is not None:
+                    self._activate_visible_layouts(child_layout)
+            layout.activate()
+
+        widget.updateGeometry()
+        if widget.sizePolicy().verticalPolicy() == QSizePolicy.Fixed or self._has_fixed_height(widget):
+            return
+
+        base_minimum = widget.property("_semanticBaseMinimumHeight")
+        if base_minimum is None:
+            base_minimum = widget.minimumHeight()
+            widget.setProperty("_semanticBaseMinimumHeight", int(base_minimum))
+
+        hint_heights = [int(base_minimum)]
+        minimum_hint_height = widget.minimumSizeHint().height()
+        if minimum_hint_height > 0:
+            hint_heights.append(minimum_hint_height)
+        if layout is not None:
+            layout_hint_height = layout.sizeHint().height()
+            if layout_hint_height > 0:
+                hint_heights.append(layout_hint_height)
+
+        desired_height = max(hint_heights)
+        maximum_height = widget.maximumHeight()
+        if maximum_height < 16777215:
+            desired_height = min(desired_height, maximum_height)
+        widget.setMinimumHeight(max(0, desired_height))
+        widget.updateGeometry()
+
+    def _activate_visible_layouts(self, layout) -> None:
+        for index in range(layout.count()):
+            item = layout.itemAt(index)
+            child_widget = item.widget()
+            if child_widget is not None:
+                if child_widget.isHidden():
+                    continue
+                child_layout = child_widget.layout()
+                if child_layout is not None:
+                    self._activate_visible_layouts(child_layout)
+                child_widget.updateGeometry()
+                continue
+            child_layout = item.layout()
+            if child_layout is not None:
+                self._activate_visible_layouts(child_layout)
+        layout.activate()
+
+    @staticmethod
+    def _has_fixed_height(widget: QWidget) -> bool:
+        maximum_height = widget.maximumHeight()
+        return maximum_height < 16777215 and widget.minimumHeight() == maximum_height
 
     def semantic_group_keys(self) -> list[str]:
         return list(self._semantic_sections.keys())
@@ -455,7 +542,7 @@ class SemanticAnalysisConfigDialogBase(AnalysisConfigDialogBase):
         if group_key not in self._semantic_sections:
             return self.add_semantic_section(group_key, title=title, widget=widget)
         content_layout = self._semantic_section_contents[group_key].layout()
-        widget.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Minimum)
+        self._apply_semantic_size_policy(widget)
         content_layout.addWidget(widget)
         self._refresh_section_container_minimum_height()
         return content_layout

--- a/ui/ui_analysis_config/fba_config_dialog.py
+++ b/ui/ui_analysis_config/fba_config_dialog.py
@@ -179,6 +179,9 @@ class FbaConfigWindow(SemanticAnalysisConfigDialogBase):
 
         self.bandwidth_widget.setVisible(is_equal)
         self.custom_widget.setVisible(is_custom)
+        self.bandwidth_widget.updateGeometry()
+        self.custom_widget.updateGeometry()
+        self._refresh_section_container_minimum_height()
 
     def create_btn(self):
         return self.create_standard_button_layout(self.on_default_btn_clicked, self.on_click_ok_btn)

--- a/ui/ui_analysis_config/loudness_config_dialog.py
+++ b/ui/ui_analysis_config/loudness_config_dialog.py
@@ -90,6 +90,22 @@ class LoudnessConfigPanel(QWidget):
         layout.addStretch()
         self.setLayout(layout)
 
+    def _set_visible_and_refresh(self, widget: QWidget, visible: bool) -> None:
+        widget.setVisible(bool(visible))
+        widget.updateGeometry()
+        self._refresh_parent_semantic_layout()
+
+    def _refresh_parent_semantic_layout(self) -> None:
+        self.updateGeometry()
+        parent = self.parentWidget()
+        while parent is not None:
+            parent.updateGeometry()
+            refresh = getattr(parent, "_refresh_section_container_minimum_height", None)
+            if callable(refresh):
+                refresh()
+                return
+            parent = parent.parentWidget()
+
     def _create_algorithm_group(self):
         group = QWidget()
         layout = QVBoxLayout()
@@ -147,7 +163,7 @@ class LoudnessConfigPanel(QWidget):
         file_layout.addWidget(self.background_noise_path_edit, 1)
         noise_layout.addWidget(self.background_noise_file_widget)
         self.background_noise_enabled_box.toggled.connect(
-            self.background_noise_file_widget.setVisible
+            lambda checked: self._set_visible_and_refresh(self.background_noise_file_widget, checked)
         )
         self.background_noise_file_widget.setVisible(
             self.background_noise_enabled_box.isChecked()
@@ -294,7 +310,12 @@ class LoudnessConfigPanel(QWidget):
             exceedance_layout.addWidget(self.specific_exceedance_ref_widget)
 
             self.specific_exceedance_threshold_widget.setLayout(exceedance_layout)
-            self.show_specific_exceedance_box.toggled.connect(self.specific_exceedance_threshold_widget.setVisible)
+            self.show_specific_exceedance_box.toggled.connect(
+                lambda checked: self._set_visible_and_refresh(
+                    self.specific_exceedance_threshold_widget,
+                    checked,
+                )
+            )
             self.specific_exceedance_threshold_widget.setVisible(self.show_specific_exceedance_box.isChecked())
             self.specific_exceedance_mode_combo.currentTextChanged.connect(
                 self._refresh_exceedance_mode
@@ -324,7 +345,9 @@ class LoudnessConfigPanel(QWidget):
         curve_y_unit = str(advanced_cfg.get("curve_y_unit", "sone") or "sone").lower()
         self.curve_y_unit_combo.setCurrentText("phon" if curve_y_unit == "phon" else "sone")
         self.curve_y_unit_combo.setToolTip("响度时间曲线的纵轴单位。sone 为响度 N，phon 为响度级 LN。")
-        self.show_curve_box.toggled.connect(self.curve_y_unit_widget.setVisible)
+        self.show_curve_box.toggled.connect(
+            lambda checked: self._set_visible_and_refresh(self.curve_y_unit_widget, checked)
+        )
         self.curve_y_unit_combo.setMinimumWidth(120)
         self.curve_y_unit_combo.setMaximumWidth(180)
         curve_y_unit_layout.addWidget(self.curve_y_unit_combo)
@@ -357,7 +380,9 @@ class LoudnessConfigPanel(QWidget):
         profile_mode_layout.addWidget(self.specific_profile_mode_combo)
         profile_mode_layout.addStretch(1)
         self.specific_profile_mode_widget.setLayout(profile_mode_layout)
-        self.show_specific_profile_box.toggled.connect(self.specific_profile_mode_widget.setVisible)
+        self.show_specific_profile_box.toggled.connect(
+            lambda checked: self._set_visible_and_refresh(self.specific_profile_mode_widget, checked)
+        )
         self.specific_profile_mode_widget.setVisible(self.show_specific_profile_box.isChecked())
         self.specific_colormap_widget = QWidget(self)
         specific_colormap_layout = QHBoxLayout()
@@ -367,7 +392,9 @@ class LoudnessConfigPanel(QWidget):
         self.specific_colormap_combo.addItems(["viridis", "plasma", "magma", "inferno"])
         self.specific_colormap_combo.setCurrentText(advanced_cfg.get("specific_loudness_colormap", "viridis"))
         self.specific_colormap_combo.setToolTip("特征响度分布图使用的颜色映射。")
-        self.show_specific_box.toggled.connect(self.specific_colormap_widget.setVisible)
+        self.show_specific_box.toggled.connect(
+            lambda checked: self._set_visible_and_refresh(self.specific_colormap_widget, checked)
+        )
         self.specific_colormap_combo.setMinimumWidth(140)
         self.specific_colormap_combo.setMaximumWidth(200)
         specific_colormap_layout.addWidget(self.specific_colormap_combo)
@@ -508,6 +535,9 @@ class LoudnessConfigPanel(QWidget):
         is_ref = mode == "ref_line"
         self.specific_exceedance_t_widget.setVisible(not is_ref)
         self.specific_exceedance_ref_widget.setVisible(is_ref)
+        self.specific_exceedance_t_widget.updateGeometry()
+        self.specific_exceedance_ref_widget.updateGeometry()
+        self._refresh_parent_semantic_layout()
 
     def _exceedance_ref_line_value(self, advanced_cfg):
         if self.comparison_only:

--- a/ui/ui_analysis_config/reference_spectrum_config_dialog.py
+++ b/ui/ui_analysis_config/reference_spectrum_config_dialog.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from typing import List, Optional
 
 import numpy as np
-from PyQt5.QtCore import Qt
+from PyQt5.QtCore import Qt, QTimer
 from PyQt5.QtWidgets import (
     QFileDialog,
     QHBoxLayout,
@@ -415,6 +415,14 @@ class ReferenceSpectrumConfigWindow(SemanticAnalysisConfigDialogBase):
             row_widget.setLayout(row_layout)
             self.channel_name_layout.addWidget(row_widget)
             self._channel_name_inputs[channel_index] = line_edit
+        self.channel_name_layout.activate()
+        if hasattr(self, "channel_name_container"):
+            self.channel_name_container.updateGeometry()
+        if hasattr(self, "channel_name_group"):
+            self.channel_name_group.updateGeometry()
+        if hasattr(self, "_semantic_sections"):
+            self._refresh_section_container_minimum_height()
+            QTimer.singleShot(0, self._refresh_section_container_minimum_height)
 
     def _collect_channel_labels(self) -> dict:
         if not getattr(self, "custom_channel_name_checkbox", None) or not self.custom_channel_name_checkbox.isChecked():
@@ -472,15 +480,23 @@ class ReferenceSpectrumConfigWindow(SemanticAnalysisConfigDialogBase):
 
     def _on_advanced_visibility_changed(self, state):
         self.advanced_container.setVisible(state == Qt.Checked)
+        self.advanced_container.updateGeometry()
+        self._refresh_section_container_minimum_height()
 
     def _on_band_visibility_changed(self, state):
         self.band_container.setVisible(state == Qt.Checked)
+        self.band_container.updateGeometry()
+        self._refresh_section_container_minimum_height()
 
     def _on_threshold_visibility_changed(self, state):
         self.threshold_container.setVisible(state == Qt.Checked)
+        self.threshold_container.updateGeometry()
+        self._refresh_section_container_minimum_height()
 
     def _on_channel_name_visibility_changed(self, state):
         self.channel_name_container.setVisible(state == Qt.Checked)
+        self.channel_name_container.updateGeometry()
+        self._refresh_section_container_minimum_height()
 
     def _generate_reference_data(self):
         source_path = self.reference_source_path_edit.text().strip()

--- a/ui/ui_analysis_config/spec_config_dialog.py
+++ b/ui/ui_analysis_config/spec_config_dialog.py
@@ -99,7 +99,7 @@ class SpecConfigWindow(SemanticAnalysisConfigDialogBase):
 
     def _on_spectrum_mode_changed(self, _index=None):
         self.mel_param_group.setVisible(self._selected_spectrum_mode() == spec_consts.SPEC_MODE_MEL)
-        self.section_container.setMinimumHeight(0)
+        self.mel_param_group.updateGeometry()
         QTimer.singleShot(0, self._resize_after_spectrum_mode_changed)
 
     def _resize_after_spectrum_mode_changed(self):

--- a/unit_test/ui/test_analysis_config_common_widgets.py
+++ b/unit_test/ui/test_analysis_config_common_widgets.py
@@ -4,7 +4,7 @@ os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 import pytest
 from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QApplication, QWidget, QVBoxLayout
+from PyQt5.QtWidgets import QApplication, QSizePolicy, QWidget, QVBoxLayout
 
 from consts.harmonic_detection_consts import (
     HARMONIC_DETECTION_METHOD_FOURIER,
@@ -207,6 +207,90 @@ def _filler_widget(min_height=120):
     layout = QVBoxLayout(widget)
     layout.addWidget(ChannelSelectorWidget({"analysis_channel": 0}, [0]))
     return widget
+
+
+def test_semantic_dialog_refresh_respects_nested_group_size_hint(qapp):
+    dialog = SemanticAnalysisConfigDialogBase()
+    nested = QWidget()
+    layout = QVBoxLayout(nested)
+    layout.setContentsMargins(0, 0, 0, 0)
+    layout.addWidget(_filler_widget(80))
+    layout.addWidget(_filler_widget(80))
+    dialog.add_semantic_section("compute", widget=nested)
+    dialog.show()
+    qapp.processEvents()
+
+    dialog._refresh_section_container_minimum_height()
+
+    assert dialog._semantic_sections["compute"].height() >= (
+        dialog._semantic_sections["compute"].layout().sizeHint().height()
+    )
+    dialog.close()
+
+
+def test_semantic_dialog_refresh_protected_maximum_height(qapp):
+    dialog = SemanticAnalysisConfigDialogBase()
+    capped = QWidget()
+    capped_layout = QVBoxLayout(capped)
+    capped_layout.addWidget(_filler_widget(80))
+    capped_layout.addWidget(_filler_widget(80))
+    capped.setMaximumHeight(64)
+    dialog.add_semantic_section("compute", widget=capped)
+    dialog.show()
+    qapp.processEvents()
+
+    dialog._refresh_section_container_minimum_height()
+
+    assert capped.maximumHeight() == 64
+    assert capped.minimumHeight() <= capped.maximumHeight()
+    dialog.close()
+
+
+def test_semantic_dialog_refresh_protected_fixed_height(qapp):
+    dialog = SemanticAnalysisConfigDialogBase()
+    fixed = _filler_widget(80)
+    fixed.setFixedHeight(64)
+    dialog.add_semantic_section("compute", widget=fixed)
+    dialog.show()
+    qapp.processEvents()
+
+    dialog._refresh_section_container_minimum_height()
+
+    assert fixed.height() == 64
+    assert fixed.minimumHeight() == 64
+    assert fixed.maximumHeight() == 64
+    dialog.close()
+
+
+def test_semantic_dialog_refresh_protected_fixed_vertical_policy(qapp):
+    dialog = SemanticAnalysisConfigDialogBase()
+    fixed_policy = _filler_widget(80)
+    fixed_policy.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+    dialog.add_semantic_section("compute", widget=fixed_policy)
+    dialog.show()
+    qapp.processEvents()
+
+    dialog._refresh_section_container_minimum_height()
+
+    assert fixed_policy.sizePolicy().verticalPolicy() == QSizePolicy.Fixed
+    dialog.close()
+
+
+def test_semantic_dialog_refresh_protected_visible_container_height(qapp):
+    dialog = SemanticAnalysisConfigDialogBase()
+    dialog.add_semantic_section("input", widget=_filler_widget(90))
+    dialog.add_semantic_section("compute", widget=_filler_widget(110))
+    dialog.add_semantic_section("display", widget=_filler_widget(100))
+    dialog.show()
+    qapp.processEvents()
+
+    dialog._refresh_section_container_minimum_height()
+
+    visible_sections = [section for section in dialog._semantic_sections.values() if section.isVisible()]
+    expected = sum(section.sizeHint().height() for section in visible_sections)
+    expected += dialog.section_layout.spacing() * max(0, len(visible_sections) - 1)
+    assert dialog.section_container.minimumHeight() >= expected - 2
+    dialog.close()
 
 
 def test_semantic_dialog_registers_only_added_groups(qapp):

--- a/unit_test/ui/test_analysis_config_dialog_migration.py
+++ b/unit_test/ui/test_analysis_config_dialog_migration.py
@@ -132,6 +132,72 @@ def assert_vertical_golden_size(window):
     assert round(window.minimumWidth() / window.minimumHeight(), 2) == 0.75
 
 
+def _process_layout(qapp, widget):
+    widget.show()
+    for _ in range(3):
+        qapp.processEvents()
+        widget.updateGeometry()
+        layout = widget.layout()
+        if layout is not None:
+            layout.activate()
+
+
+def _global_rect(widget):
+    top_left = widget.mapToGlobal(widget.rect().topLeft())
+    return top_left.x(), top_left.y(), widget.width(), widget.height()
+
+
+def _rects_overlap_2d(left, right, tolerance=1):
+    lx, ly, lw, lh = left
+    rx, ry, rw, rh = right
+    x_overlap = min(lx + lw, rx + rw) - max(lx, rx)
+    y_overlap = min(ly + lh, ry + rh) - max(ly, ry)
+    return x_overlap > tolerance and y_overlap > tolerance
+
+
+def _visible_layout_leaf_widgets(widget):
+    widgets = []
+
+    def collect(layout):
+        if layout is None:
+            return
+        layout.activate()
+        for index in range(layout.count()):
+            item = layout.itemAt(index)
+            child_widget = item.widget()
+            if child_widget is not None:
+                if not child_widget.isVisible() or child_widget.width() <= 0 or child_widget.height() <= 0:
+                    continue
+                child_layout = child_widget.layout()
+                if child_layout is not None and child_layout.count() > 0:
+                    collect(child_layout)
+                else:
+                    widgets.append(child_widget)
+                continue
+            child_layout = item.layout()
+            if child_layout is not None:
+                collect(child_layout)
+
+    collect(widget.layout())
+    return widgets
+
+
+def _assert_visible_layout_children_do_not_overlap(widget):
+    visible_widgets = _visible_layout_leaf_widgets(widget)
+    for left_index, left_widget in enumerate(visible_widgets):
+        for right_widget in visible_widgets[left_index + 1 :]:
+            assert not _rects_overlap_2d(
+                _global_rect(left_widget),
+                _global_rect(right_widget),
+            ), f"{left_widget!r} overlaps {right_widget!r}"
+
+
+def _assert_semantic_section_fits_layout(window, group_key):
+    section = window._semantic_sections[group_key]
+    assert section.height() >= section.layout().sizeHint().height()
+    _assert_visible_layout_children_do_not_overlap(section)
+
+
 def create_threshold_widget(qapp, load_config, limit_value_semantics_provider=None):
     from ui.ui_analysis_config.threshold_config_widget import ThresholdConfigWidget
 
@@ -2144,6 +2210,48 @@ def test_spec_dialog_shows_mel_parameters_for_mel_mode(qapp):
     assert "core_range_hz" not in config
 
 
+def test_spec_dialog_mel_parameters_fit_after_mode_toggle(qapp):
+    from ui.ui_analysis_config.spec_config_dialog import SpecConfigWindow
+
+    config_manager = FakeConfigManager(
+        {
+            "Spec": {
+                "n_fft": 2048,
+                "hop_length": 256,
+                "window_func": "hann",
+                "color_map": "magma",
+                "freq_scale_type": "mel",
+                "mel_n_mels": 64,
+                "mel_fmin_hz": 50,
+                "mel_fmax_mode": spec_consts.MEL_FMAX_MODE_MANUAL,
+                "mel_fmax_hz": 12000,
+                "analysis_channel": 1,
+            }
+        }
+    )
+    window = SpecConfigWindow(config_manager, "Spec", available_channels=[0, 1])
+
+    _process_layout(qapp, window)
+
+    assert window.mel_param_group.height() >= window.mel_param_group.layout().sizeHint().height()
+    assert window._semantic_sections["compute"].height() >= (
+        window._semantic_sections["compute"].layout().sizeHint().height()
+    )
+    _assert_visible_layout_children_do_not_overlap(window.mel_param_group)
+
+    window.freq_scale_box.setCurrentIndex(window.freq_scale_box.findData("log"))
+    _process_layout(qapp, window)
+    window.freq_scale_box.setCurrentIndex(window.freq_scale_box.findData("mel"))
+    _process_layout(qapp, window)
+
+    assert window.mel_param_group.height() >= window.mel_param_group.layout().sizeHint().height()
+    assert window._semantic_sections["compute"].height() >= (
+        window._semantic_sections["compute"].layout().sizeHint().height()
+    )
+    _assert_visible_layout_children_do_not_overlap(window.mel_param_group)
+    window.close()
+
+
 def test_spl_dialog_preserves_saved_keys_after_shared_control_migration(qapp):
     from ui.ui_analysis_config.spl_config_dialog import SplConfigWindow
 
@@ -2574,6 +2682,37 @@ def test_fba_dialog_preserves_saved_keys_after_shared_control_migration(qapp):
     }
 
 
+def test_fba_dialog_custom_strategy_refreshes_semantic_layout(qapp):
+    from ui.ui_analysis_config.fba_config_dialog import FbaConfigWindow
+
+    config_manager = FakeConfigManager(
+        {
+            "FBA": {
+                "band_strategy": "1/3 倍频程",
+                "f_min": 50,
+                "f_max": 16000,
+                "bandwidth": 200,
+                "weighting": "Z（None）",
+                "limit_checked": False,
+                "limit_data": None,
+            }
+        }
+    )
+    window = FbaConfigWindow(config_manager, "FBA", available_channels=[1, 3])
+
+    _process_layout(qapp, window)
+    window.strategy_combo.setCurrentText("自定义")
+    _process_layout(qapp, window)
+
+    assert window.custom_widget.isVisible()
+    assert window._semantic_sections["compute"].height() >= (
+        window._semantic_sections["compute"].layout().sizeHint().height()
+    )
+    assert window.threshold_widget.maximumHeight() == 360
+    assert window.threshold_widget.minimumHeight() <= 360
+    window.close()
+
+
 def test_hd_dialog_uses_shared_harmonic_and_golden_widgets(qapp):
     from ui.ui_analysis_config.hd_config_dialog import HdConfigWindow
 
@@ -2804,6 +2943,121 @@ def test_rsc_dialog_keeps_smoothing_key_after_shared_selector_migration(qapp, mo
     assert config["enable_threshold_judgment"] is True
     assert config["lower_offset_db"] == -2.0
     assert config["upper_offset_db"] == 2.0
+
+
+def test_rsc_dialog_optional_sections_refresh_without_overlap(qapp, monkeypatch):
+    from ui.ui_analysis_config import reference_spectrum_config_dialog as rsc_dialog
+
+    monkeypatch.setattr(rsc_dialog, "get_reference_data_state", lambda **_: "not_generated")
+    config_manager = FakeConfigManager(
+        {
+            "RSC": {
+                "reference_source_path": "",
+                "reference_data_path": "",
+                "use_custom_band": False,
+                "start_freq_hz": 100,
+                "end_freq_hz": 1000,
+                "highlight_analysis_band": False,
+                "enable_threshold_judgment": False,
+                "channel_labels": {},
+                "window": "hann",
+                "nperseg": 4096,
+                "overlap_ratio": 0.5,
+                "smoothing": 0,
+            }
+        }
+    )
+    window = rsc_dialog.ReferenceSpectrumConfigWindow(config_manager, "RSC")
+
+    _process_layout(qapp, window)
+
+    optional_paths = [
+        (window.custom_band_checkbox, window.band_container, "compute"),
+        (window.show_advanced_checkbox, window.advanced_container, "compute"),
+        (window.enable_threshold_checkbox, window.threshold_container, "judgment"),
+        (window.custom_channel_name_checkbox, window.channel_name_container, "display"),
+    ]
+    for checkbox, container, group_key in optional_paths:
+        checkbox.setChecked(True)
+        _process_layout(qapp, window)
+        assert container.isVisible()
+        assert container.height() > 0
+        _assert_semantic_section_fits_layout(window, group_key)
+
+    window._rebuild_channel_name_rows(3)
+    _process_layout(qapp, window)
+    assert window.channel_name_group.height() >= window.channel_name_group.layout().sizeHint().height()
+    _assert_visible_layout_children_do_not_overlap(window.channel_name_group)
+
+    window._probe_audio_file = lambda _path: (np.zeros((16, 3), dtype=np.float32), 48000)
+    window._probe_and_refresh_reference_meta("dummy.wav")
+    _process_layout(qapp, window)
+    assert window.channel_name_group.height() >= window.channel_name_group.layout().sizeHint().height()
+    _assert_visible_layout_children_do_not_overlap(window.channel_name_group)
+    window.close()
+
+
+def test_loudness_dialog_dynamic_visibility_refreshes_semantic_layout(qapp):
+    from ui.ui_analysis_config.loudness_config_dialog import LoudnessConfigWindow
+
+    config_manager = FakeConfigManager(
+        {
+            "LOUD": {
+                "advanced": {},
+                "display": {"summary_metrics": [], "curves": [], "heatmaps": []},
+                "limit_checked": False,
+            }
+        }
+    )
+    window = LoudnessConfigWindow(config_manager, "LOUD")
+    panel = window.panel
+
+    _process_layout(qapp, window)
+
+    panel.background_noise_enabled_box.setChecked(True)
+    _process_layout(qapp, window)
+    assert panel.background_noise_file_widget.isVisible()
+    assert panel.background_noise_file_widget.height() > 0
+    _assert_semantic_section_fits_layout(window, "compute")
+
+    panel.show_specific_exceedance_box.setChecked(True)
+    _process_layout(qapp, window)
+    assert panel.specific_exceedance_threshold_widget.isVisible()
+    assert panel.specific_exceedance_threshold_widget.height() > 0
+    _assert_semantic_section_fits_layout(window, "display")
+
+    panel.specific_exceedance_mode_combo.setCurrentText("参考曲线 (SSTS)")
+    _process_layout(qapp, window)
+    assert panel.specific_exceedance_t_widget.isHidden()
+    assert panel.specific_exceedance_ref_widget.isVisible()
+    assert panel.specific_exceedance_ref_widget.height() > 0
+    _assert_semantic_section_fits_layout(window, "display")
+
+    panel.specific_exceedance_mode_combo.setCurrentText("固定限值 T")
+    _process_layout(qapp, window)
+    assert panel.specific_exceedance_t_widget.isVisible()
+    assert panel.specific_exceedance_t_widget.height() > 0
+    assert panel.specific_exceedance_ref_widget.isHidden()
+    _assert_semantic_section_fits_layout(window, "display")
+
+    panel.show_curve_box.setChecked(True)
+    _process_layout(qapp, window)
+    assert panel.curve_y_unit_widget.isVisible()
+    assert panel.curve_y_unit_widget.height() > 0
+    _assert_semantic_section_fits_layout(window, "display")
+
+    panel.show_specific_profile_box.setChecked(True)
+    _process_layout(qapp, window)
+    assert panel.specific_profile_mode_widget.isVisible()
+    assert panel.specific_profile_mode_widget.height() > 0
+    _assert_semantic_section_fits_layout(window, "display")
+
+    panel.show_specific_box.setChecked(True)
+    _process_layout(qapp, window)
+    assert panel.specific_colormap_widget.isVisible()
+    assert panel.specific_colormap_widget.height() > 0
+    _assert_semantic_section_fits_layout(window, "display")
+    window.close()
 
 
 def test_excel_dialog_preserves_output_config_after_semantic_migration(qapp):

--- a/unit_test/ui/test_sequence_count_board_splitter.py
+++ b/unit_test/ui/test_sequence_count_board_splitter.py
@@ -1,0 +1,600 @@
+import json
+import os
+from datetime import datetime
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QApplication, QHBoxLayout, QSizePolicy, QSplitter, QVBoxLayout, QWidget
+
+import ui.sequence.sequencement_count_board as count_board_module
+from ui.sequence.channel_plot_workspace import ChannelPlotWorkspace
+from ui.sequence.sequence_widget import SequenceWindow
+from ui.sequence.sequencement_count_board import SequenceCountBoard
+
+
+class _SequenceWindowHarness(SequenceWindow):
+    def __init__(self, count_board):
+        QWidget.__init__(self)
+        self.count_board = count_board
+        self.toolsbar = QWidget()
+
+    def add_file_to_using_file_combobox(self):
+        pass
+
+    def showEvent(self, event):
+        QWidget.showEvent(self, event)
+
+    def closeEvent(self, event):
+        QWidget.closeEvent(self, event)
+
+
+def _build_sequence_window_harness(count_board, size=(900, 500)):
+    window = _SequenceWindowHarness(count_board)
+    layout = SequenceWindow.create_waveform_layout(window)
+    window.setLayout(layout)
+    window.resize(*size)
+    window.show()
+    return window, layout
+
+
+def _scaled_px(value):
+    return count_board_module.ui_style_const.scale_size_px(value)
+
+
+def _splitter_available_width(window):
+    sizes = window.waveform_splitter.sizes()
+    if sizes:
+        return sum(sizes)
+    return max(0, window.waveform_splitter.width() - window.waveform_splitter.handleWidth())
+
+
+def _vertical_gap(parent, upper_widget, lower_widget):
+    upper_top = upper_widget.mapTo(parent, upper_widget.rect().topLeft()).y()
+    lower_top = lower_widget.mapTo(parent, lower_widget.rect().topLeft()).y()
+    return lower_top - (upper_top + upper_widget.height())
+
+
+def _mode_row_layout(board):
+    return board.content_widget.layout().itemAt(0).layout()
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    app = QApplication.instance() or QApplication([])
+    yield app
+
+
+@pytest.fixture
+def count_board_runtime(tmp_path, monkeypatch):
+    root = tmp_path
+    mark_path = root / "ui" / "ui_config" / "mark_result.json"
+    mark_path.parent.mkdir(parents=True, exist_ok=True)
+    mark_path.write_text(
+        json.dumps({"total": 3, "ok": 2, "ng": 1, "not_labels": 0, "datatime": "2026-07-24"}),
+        encoding="utf-8",
+    )
+
+    today = datetime.now().strftime("%Y-%m-%d")
+    test_path = root / "log" / "test_result_log" / f"{today}.dat"
+    test_path.parent.mkdir(parents=True, exist_ok=True)
+    test_path.write_text(
+        f"total: 5\nok: 4\nng: 1\nok_percent: 80%\ndatatime: {today}\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(count_board_module, "DEFAULT_DIR", root.as_posix() + "/")
+    monkeypatch.setattr(count_board_module, "ensure_test_result_file", lambda analysis_config: None)
+    return root
+
+
+def test_count_board_collapse_toggle_is_idempotent(qapp, count_board_runtime):
+    board = SequenceCountBoard({})
+    board.show()
+    qapp.processEvents()
+    emissions = []
+    board.collapsed_changed.connect(emissions.append)
+
+    assert board.is_collapsed() is False
+    assert board.content_widget.isVisible() is True
+    assert board.collapse_toggle_btn.isVisible() is True
+
+    board.set_collapsed(True)
+
+    assert board.is_collapsed() is True
+    assert board.content_widget.isVisible() is False
+    assert board.collapse_toggle_btn.isVisible() is True
+    assert emissions == [True]
+
+    board.set_collapsed(True)
+
+    assert emissions == [True]
+
+    board.toggle_collapsed()
+
+    assert board.is_collapsed() is False
+    assert board.content_widget.isVisible() is True
+    assert emissions == [True, False]
+
+    board.close()
+
+
+def test_count_board_collapse_toggle_button_background_is_transparent(qapp, count_board_runtime):
+    board = SequenceCountBoard({})
+    board.show()
+    qapp.processEvents()
+
+    button_style = board.collapse_toggle_btn.styleSheet()
+
+    assert "background-color: transparent" in button_style
+    assert "border: none" in button_style
+
+    board.close()
+
+
+def test_count_board_collapse_preserves_mode_and_count_values(qapp, count_board_runtime):
+    board = SequenceCountBoard({})
+    board.show()
+    qapp.processEvents()
+    board.on_test_btn_clicked()
+    board.total_line_edit.setText("12")
+    board.ok_line_edit.setText("10")
+    board.ng_line_edit.setText("2")
+
+    board.set_collapsed(True)
+    board.set_collapsed(False)
+
+    assert board.mode == "test"
+    assert board.stacked_widget.currentIndex() == 0
+    assert board.total_line_edit.text() == "12"
+    assert board.ok_line_edit.text() == "10"
+    assert board.ng_line_edit.text() == "2"
+
+    board.close()
+
+
+def test_count_board_expanded_minimum_tracks_button_width_and_splitter_gap(qapp, count_board_runtime):
+    board = SequenceCountBoard({})
+    board.show()
+    qapp.processEvents()
+
+    assert board.is_collapsed() is False
+    assert board._minimum_content_width == board.btn_width + count_board_module.ui_style_const.scale_size_px(20)
+    assert board.content_widget.minimumSizeHint().width() == board._minimum_content_width
+    assert board.lineedit_width == board._minimum_content_width - board.label_width
+    assert board.expanded_width_hint() == (
+        board._minimum_content_width + board._collapse_bar_width + board._splitter_gap_width
+    )
+    assert board.collapsed_width_hint() == board._collapse_bar_width + board._splitter_gap_width
+    assert board.layout().contentsMargins().right() == board._splitter_gap_width
+
+    board.close()
+
+
+def test_count_board_minimum_width_is_enforced_by_widget_geometry(qapp, count_board_runtime):
+    board = SequenceCountBoard({})
+    board.resize(board.expanded_width_hint(), 420)
+    board.show()
+    qapp.processEvents()
+
+    expected_content_width = board.btn_width + _scaled_px(20)
+    expected_lineedit_width = expected_content_width - board.label_width
+    expected_board_width = expected_content_width + board._collapse_bar_width + _scaled_px(5)
+
+    assert board.width() >= expected_board_width
+    assert board.minimumWidth() == expected_board_width
+    assert board.content_widget.width() >= expected_content_width
+    assert board.mark_total_edit.minimumWidth() == expected_lineedit_width
+    assert board.mark_total_edit.width() >= expected_lineedit_width
+
+    board.close()
+
+
+def test_count_board_starts_with_expanded_safe_minimum_until_compact_resize_enabled(qapp, count_board_runtime):
+    board = SequenceCountBoard({})
+    board.show()
+    qapp.processEvents()
+
+    expanded_width = board.expanded_width_hint()
+    collapsed_width = board.collapsed_width_hint()
+
+    assert board.minimumSizeHint().width() >= expanded_width
+    assert board.minimumWidth() >= expanded_width
+
+    board.set_compact_resize_enabled(True)
+
+    assert board.minimumSizeHint().width() == collapsed_width
+    assert board.minimumWidth() == collapsed_width
+
+    board.close()
+
+
+def test_count_board_line_edits_expand_horizontally_but_keep_fixed_height(qapp, count_board_runtime):
+    board = SequenceCountBoard({})
+    board.resize(board.expanded_width_hint() + 160, 500)
+    board.show()
+    qapp.processEvents()
+
+    assert board.mark_total_edit.sizePolicy().horizontalPolicy() == QSizePolicy.Expanding
+    assert board.mark_total_edit.sizePolicy().verticalPolicy() == QSizePolicy.Fixed
+    assert board.mark_total_edit.height() == board.lineedit_height
+    assert board.mark_total_edit.minimumWidth() == board.lineedit_width
+    assert board.mark_total_edit.width() > board.lineedit_width
+
+    board.close()
+
+
+def test_count_board_vertical_layout_stays_compact_when_tall(qapp, count_board_runtime):
+    board = SequenceCountBoard({})
+    board.resize(board.expanded_width_hint() + 160, 700)
+    board.show()
+    qapp.processEvents()
+
+    test_layout = board.stacked_widget.widget(0).layout()
+    mark_layout = board.stacked_widget.widget(1).layout()
+    total_top = board.mark_total_edit.mapTo(board, board.mark_total_edit.rect().topLeft()).y()
+    ng_top = board.ng_btn.mapTo(board, board.ng_btn.rect().topLeft()).y()
+
+    assert all(test_layout.itemAt(index).spacerItem() is None for index in range(test_layout.count() - 1))
+    assert test_layout.itemAt(test_layout.count() - 1).spacerItem() is not None
+    assert mark_layout.itemAt(mark_layout.count() - 1).spacerItem() is not None
+    assert test_layout.spacing() == count_board_module.ui_style_const.scale_size_px(7)
+    assert mark_layout.spacing() == count_board_module.ui_style_const.scale_size_px(7)
+    assert total_top < 90
+    assert ng_top < 320
+
+    board.close()
+
+
+def test_count_board_line_edit_row_gaps_match_scaled_default_in_mark_and_test_modes(qapp, count_board_runtime):
+    board = SequenceCountBoard({})
+    board.resize(board.expanded_width_hint() + 160, 700)
+    board.show()
+    qapp.processEvents()
+
+    expected_gap = _scaled_px(7)
+
+    board.on_mark_btn_clicked()
+    qapp.processEvents()
+    assert [
+        _vertical_gap(board, board.mark_total_edit, board.mark_ok_edit),
+        _vertical_gap(board, board.mark_ok_edit, board.mark_ng_edit),
+    ] == [expected_gap, expected_gap]
+
+    board.on_test_btn_clicked()
+    qapp.processEvents()
+    assert [
+        _vertical_gap(board, board.total_line_edit, board.ok_line_edit),
+        _vertical_gap(board, board.ok_line_edit, board.ng_line_edit),
+    ] == [expected_gap, expected_gap]
+
+    board.close()
+
+
+def test_mode_buttons_fit_within_minimum_content_width(qapp, count_board_runtime):
+    board = SequenceCountBoard({})
+    board.show()
+    qapp.processEvents()
+
+    mode_row_width = board.mode_label_width + board.test_btn.width() + board.mark_btn.width()
+
+    assert board.test_btn.width() == board.mode_button_width
+    assert board.mark_btn.width() == board.mode_button_width
+    assert mode_row_width <= board._minimum_content_width
+
+    board.close()
+
+
+def test_mode_row_keeps_label_left_and_buttons_right_aligned(qapp, count_board_runtime):
+    board = SequenceCountBoard({})
+    board.resize(board.expanded_width_hint() + 160, 420)
+    board.show()
+    qapp.processEvents()
+
+    mode_layout = _mode_row_layout(board)
+    mode_label = mode_layout.itemAt(0).widget()
+    content_rect = board.content_widget.contentsRect()
+
+    assert mode_label.geometry().left() == content_rect.left()
+    assert board.mark_btn.geometry().left() == board.test_btn.geometry().right() + 1
+    assert abs(board.mark_btn.geometry().right() - content_rect.right()) <= 1
+    assert board.test_btn.geometry().left() > mode_label.geometry().right()
+
+    board.close()
+
+
+def test_sequence_waveform_layout_uses_horizontal_splitter(qapp, count_board_runtime):
+    board = SequenceCountBoard({})
+    window, layout = _build_sequence_window_harness(board)
+    qapp.processEvents()
+
+    assert isinstance(layout, QHBoxLayout)
+    assert isinstance(window.waveform_splitter, QSplitter)
+    assert window.waveform_splitter.orientation() == Qt.Horizontal
+    assert "#b8b8b8" in window.waveform_splitter.styleSheet()
+    assert f"margin-left: {_scaled_px(3)}px" in window.waveform_splitter.styleSheet()
+    assert f"margin-right: {_scaled_px(3)}px" in window.waveform_splitter.styleSheet()
+    assert window.waveform_splitter.widget(0) is board
+    assert isinstance(window.waveform_splitter.widget(1), ChannelPlotWorkspace)
+    assert window.channel_workspace is window.waveform_splitter.widget(1)
+
+    handle = window.waveform_splitter.handle(1)
+    handle_rect = handle.geometry()
+    image = window.waveform_splitter.grab().toImage()
+    layout_gap_left = window.waveform_splitter.widget(0).geometry().right() + 1
+    layout_gap_right = window.waveform_splitter.widget(1).geometry().left() - 1
+    layout_gap_width = layout_gap_right - layout_gap_left + 1
+    scan_y = handle_rect.center().y()
+    gray_offsets = [
+        offset
+        for offset in range(layout_gap_width)
+        if image.pixelColor(layout_gap_left + offset, scan_y).name() == "#b8b8b8"
+    ]
+    assert gray_offsets
+    assert gray_offsets == list(range(gray_offsets[0], gray_offsets[-1] + 1))
+
+    left_empty_width = gray_offsets[0]
+    gray_width = len(gray_offsets)
+    right_empty_width = layout_gap_width - gray_offsets[-1] - 1
+    side_padding = _scaled_px(3)
+    assert (
+        layout_gap_width,
+        left_empty_width,
+        gray_width,
+        right_empty_width,
+    ) == (
+        side_padding * 2 + 1,
+        side_padding,
+        1,
+        side_padding,
+    )
+    assert window.waveform_splitter.handleWidth() == 1
+
+    window.close()
+
+
+def test_sequence_layout_keeps_toolbar_tight_to_top(qapp, count_board_runtime):
+    board = SequenceCountBoard({})
+    window = _SequenceWindowHarness(board)
+    SequenceWindow.init_ui(window)
+    window.resize(900, 500)
+    window.show()
+    qapp.processEvents()
+
+    layout = window.layout()
+    assert isinstance(layout, QVBoxLayout)
+    assert layout.alignment() & Qt.AlignTop
+    assert layout.spacing() == 0
+    assert window.toolsbar.geometry().top() <= 1
+
+    window.close()
+
+
+def test_initial_splitter_size_preserves_expanded_count_board_width(qapp, count_board_runtime):
+    board = SequenceCountBoard({})
+    window, _layout = _build_sequence_window_harness(board)
+    qapp.processEvents()
+    qapp.processEvents()
+
+    expanded_width = board.expanded_width_hint()
+    assert window.waveform_splitter.width() > expanded_width + 1
+    assert window.waveform_splitter.sizes()[0] >= expanded_width
+    assert window.waveform_splitter.sizes()[0] <= window._count_board_max_width
+
+    window.close()
+
+
+def test_constrained_initial_splitter_layout_collapses_count_board(qapp, count_board_runtime):
+    board = SequenceCountBoard({})
+    window, _layout = _build_sequence_window_harness(board, size=(120, 220))
+    qapp.processEvents()
+    qapp.processEvents()
+
+    assert _splitter_available_width(window) < board.expanded_width_hint() + 1
+    assert board.is_collapsed() is True
+    assert board.content_widget.isVisible() is False
+    assert window.waveform_splitter.sizes()[0] <= window._count_board_collapse_threshold
+
+    window.close()
+
+
+def test_count_board_splitter_left_side_is_capped(qapp, count_board_runtime):
+    board = SequenceCountBoard({})
+    window, _layout = _build_sequence_window_harness(board)
+    qapp.processEvents()
+
+    max_width = window._count_board_max_width
+    window._last_count_board_expanded_width = max_width + 200
+    window._apply_count_board_splitter_sizes(False)
+    qapp.processEvents()
+
+    assert board.maximumWidth() == max_width
+    assert window.waveform_splitter.sizes()[0] <= max_width
+    assert max_width > board.expanded_width_hint()
+
+    window.close()
+
+
+def test_constrained_programmatic_expansion_keeps_content_hidden(qapp, count_board_runtime):
+    board = SequenceCountBoard({})
+    window, _layout = _build_sequence_window_harness(board, size=(120, 220))
+    qapp.processEvents()
+    qapp.processEvents()
+
+    board.set_collapsed(True)
+    qapp.processEvents()
+    assert _splitter_available_width(window) < board.expanded_width_hint() + 1
+
+    board.set_collapsed(False)
+    qapp.processEvents()
+
+    assert board.is_collapsed() is True
+    assert board.content_widget.isVisible() is False
+    assert board.content_widget.width() < board._minimum_content_width
+
+    window.resize(900, 500)
+    window.waveform_splitter.setSizes([board.expanded_width_hint(), 600])
+    qapp.processEvents()
+
+    board.set_collapsed(False)
+    qapp.processEvents()
+
+    assert board.is_collapsed() is False
+    assert board.content_widget.isVisible() is True
+    assert board.content_widget.width() >= board._minimum_content_width
+
+    window.close()
+
+
+def test_constrained_toggle_expansion_keeps_content_hidden(qapp, count_board_runtime):
+    board = SequenceCountBoard({})
+    window, _layout = _build_sequence_window_harness(board, size=(120, 220))
+    qapp.processEvents()
+    qapp.processEvents()
+
+    board.set_collapsed(True)
+    qapp.processEvents()
+    assert _splitter_available_width(window) < board.expanded_width_hint() + 1
+
+    board.collapse_toggle_btn.click()
+    qapp.processEvents()
+
+    assert board.is_collapsed() is True
+    assert board.content_widget.isVisible() is False
+    assert board.content_widget.width() < board._minimum_content_width
+
+    window.resize(900, 500)
+    window.waveform_splitter.setSizes([board.expanded_width_hint(), 600])
+    qapp.processEvents()
+
+    board.collapse_toggle_btn.click()
+    qapp.processEvents()
+
+    assert board.is_collapsed() is False
+    assert board.content_widget.isVisible() is True
+    assert board.content_widget.width() >= board._minimum_content_width
+
+    window.close()
+
+
+def test_splitter_drag_collapses_and_expands_count_board(qapp, count_board_runtime):
+    board = SequenceCountBoard({})
+    window, _layout = _build_sequence_window_harness(board)
+    qapp.processEvents()
+
+    window.waveform_splitter.setSizes([board.expanded_width_hint(), 600])
+    window.waveform_splitter.moveSplitter(window._count_board_collapsed_width, 1)
+    qapp.processEvents()
+
+    assert board.is_collapsed() is True
+    assert window.waveform_splitter.sizes()[0] <= window._count_board_collapse_threshold
+
+    expand_width = board.expanded_width_hint() + 1
+    assert expand_width <= window._count_board_max_width
+    window.waveform_splitter.moveSplitter(expand_width, 1)
+    qapp.processEvents()
+
+    assert board.is_collapsed() is False
+    assert window._last_count_board_expanded_width >= expand_width
+
+    window.close()
+
+
+def test_splitter_drag_to_intermediate_width_collapses_instead_of_clipping(qapp, count_board_runtime):
+    board = SequenceCountBoard({})
+    window, _layout = _build_sequence_window_harness(board)
+    qapp.processEvents()
+
+    intermediate_width = window._count_board_expand_threshold + _scaled_px(40)
+    assert window._count_board_expand_threshold < intermediate_width < board.expanded_width_hint()
+
+    window.waveform_splitter.setSizes([intermediate_width, 600])
+    window._on_waveform_splitter_moved(intermediate_width, 1)
+
+    assert board.is_collapsed() is True
+    assert board.content_widget.isVisible() is False
+    assert board.content_widget.width() < board._minimum_content_width
+
+    window.close()
+
+
+def test_direct_splitter_set_sizes_collapses_instead_of_clipping_count_board(qapp, count_board_runtime):
+    board = SequenceCountBoard({})
+    window, _layout = _build_sequence_window_harness(board)
+    qapp.processEvents()
+    qapp.processEvents()
+
+    safe_expanded_width = board.expanded_width_hint() + _scaled_px(24)
+    window.waveform_splitter.setSizes([safe_expanded_width, 600])
+    qapp.processEvents()
+    assert board.is_collapsed() is False
+    assert board.content_widget.isVisible() is True
+    assert board.content_widget.width() >= board._minimum_content_width
+
+    intermediate_width = window._count_board_expand_threshold + _scaled_px(40)
+    assert window._count_board_expand_threshold < intermediate_width < board.expanded_width_hint()
+
+    window.waveform_splitter.setSizes([intermediate_width, 600])
+    qapp.processEvents()
+    qapp.processEvents()
+
+    assert board.is_collapsed() is True
+    assert board.content_widget.isVisible() is False
+    assert window.waveform_splitter.sizes()[0] <= window._count_board_collapse_threshold
+    assert not (board.content_widget.isVisible() and board.content_widget.width() < board._minimum_content_width)
+
+    window.close()
+
+
+def test_parent_resize_narrower_collapses_expanded_count_board(qapp, count_board_runtime):
+    board = SequenceCountBoard({})
+    window, _layout = _build_sequence_window_harness(board)
+    qapp.processEvents()
+    qapp.processEvents()
+
+    assert board.is_collapsed() is False
+    assert board.content_widget.isVisible() is True
+    assert board.content_widget.width() >= board._minimum_content_width
+
+    window.resize(120, 220)
+    qapp.processEvents()
+    qapp.processEvents()
+
+    assert board.is_collapsed() is True
+    assert board.content_widget.isVisible() is False
+    assert window.waveform_splitter.sizes()[0] <= window._count_board_collapse_threshold
+    assert not (board.content_widget.isVisible() and board.content_widget.width() < board._minimum_content_width)
+
+    window.resize(900, 500)
+    qapp.processEvents()
+    window.waveform_splitter.setSizes([board.expanded_width_hint(), 600])
+    board.set_collapsed(False)
+    qapp.processEvents()
+
+    assert board.is_collapsed() is False
+    assert board.content_widget.isVisible() is True
+    assert board.content_widget.width() >= board._minimum_content_width
+
+    window.close()
+
+
+def test_splitter_resize_event_filter_is_quiet_with_lightweight_harness(qapp, count_board_runtime, capsys):
+    board = SequenceCountBoard({})
+    window, _layout = _build_sequence_window_harness(board)
+    qapp.processEvents()
+    qapp.processEvents()
+    capsys.readouterr()
+
+    window.resize(120, 220)
+    qapp.processEvents()
+    qapp.processEvents()
+
+    captured = capsys.readouterr()
+    assert board.is_collapsed() is True
+    assert window.waveform_splitter.sizes()[0] <= window._count_board_collapse_threshold
+    assert "Traceback" not in captured.err
+    assert "_analysis_window_key_by_obj" not in captured.err
+    assert "default_logger" not in captured.err
+
+    window.close()


### PR DESCRIPTION
## Summary
- Add a collapsible horizontal splitter for the sequence count board so narrow waveform layouts do not clip the count controls.
- Refresh semantic analysis dialog section sizing after dynamic controls change to prevent hidden or overlapping controls.
- Ignore the local `.tmp` pytest workspace used for reliable Windows test runs.

## Test Plan
- `git diff --cached --check`
- `python -m pytest --basetemp .tmp\pytest-basetemp unit_test/ui/test_sequence_count_board_splitter.py unit_test/ui/test_analysis_config_common_widgets.py unit_test/ui/test_analysis_config_dialog_migration.py` (149 passed, 18 warnings)

Closes #781