### PR TITLE
BUG20260730-fix-manual-limit-endpoint-plotting

### DIFF
--- a/base/golden_sample_comparison.py
+++ b/base/golden_sample_comparison.py
@@ -227,3 +227,150 @@ def build_interpolated_golden_envelope_plot(
         lower_offset,
     )
     return display_x, display_y, absolute_upper, absolute_lower
+
+
+def _sorted_unique_baseline(data_x, baseline_aligned):
+    x_arr = np.asarray(data_x, dtype=float)
+    baseline_arr = np.asarray(baseline_aligned, dtype=float)
+    baseline_mask = np.isfinite(x_arr) & np.isfinite(baseline_arr) & (x_arr > 0)
+    baseline_x = x_arr[baseline_mask]
+    baseline_y = baseline_arr[baseline_mask]
+    if baseline_x.size > 1:
+        sort_indices = np.argsort(baseline_x, kind="stable")
+        baseline_x = baseline_x[sort_indices]
+        baseline_y = baseline_y[sort_indices]
+        baseline_x, unique_indices = np.unique(baseline_x, return_index=True)
+        baseline_y = baseline_y[unique_indices]
+    return baseline_x, baseline_y
+
+
+def _manual_value_between(start_x, start_y, end_x, end_y, target_x):
+    if not np.isfinite(start_y) or not np.isfinite(end_y):
+        return np.nan
+    if start_x == end_x:
+        return float(end_y)
+    ratio = (target_x - start_x) / (end_x - start_x)
+    return float(start_y + ratio * (end_y - start_y))
+
+
+def _enrich_manual_geometry_run(
+    run_x,
+    run_upper,
+    run_lower,
+    baseline_x,
+):
+    enriched_x = [float(run_x[0])]
+    enriched_upper = [float(run_upper[0])]
+    enriched_lower = [float(run_lower[0])]
+
+    for index in range(1, run_x.size):
+        start_x = float(run_x[index - 1])
+        end_x = float(run_x[index])
+        low_x = min(start_x, end_x)
+        high_x = max(start_x, end_x)
+        interior_x = baseline_x[(baseline_x > low_x) & (baseline_x < high_x)]
+        if end_x < start_x:
+            interior_x = interior_x[::-1]
+
+        for sample_x in interior_x:
+            sample_x = float(sample_x)
+            enriched_x.append(sample_x)
+            enriched_upper.append(
+                _manual_value_between(
+                    start_x,
+                    run_upper[index - 1],
+                    end_x,
+                    run_upper[index],
+                    sample_x,
+                )
+            )
+            enriched_lower.append(
+                _manual_value_between(
+                    start_x,
+                    run_lower[index - 1],
+                    end_x,
+                    run_lower[index],
+                    sample_x,
+                )
+            )
+
+        enriched_x.append(end_x)
+        enriched_upper.append(float(run_upper[index]))
+        enriched_lower.append(float(run_lower[index]))
+
+    return enriched_x, enriched_upper, enriched_lower
+
+
+def build_manual_endpoint_golden_envelope_plot(
+    data_x,
+    raw_y,
+    baseline_aligned,
+    plot_x,
+    upper_offsets,
+    lower_offsets,
+):
+    """Build a raw display curve and endpoint-aware manual golden envelope."""
+    x_arr = np.asarray(data_x, dtype=float)
+    raw_arr = np.asarray(raw_y, dtype=float)
+    display_mask = np.isfinite(x_arr) & np.isfinite(raw_arr) & (x_arr > 0)
+    display_x = x_arr[display_mask]
+    display_y = raw_arr[display_mask]
+    if display_x.size > 1:
+        sort_indices = np.argsort(display_x, kind="stable")
+        display_x = display_x[sort_indices]
+        display_y = display_y[sort_indices]
+
+    baseline_x, baseline_y = _sorted_unique_baseline(data_x, baseline_aligned)
+    geometry_x = np.asarray(plot_x, dtype=float)
+    geometry_upper = np.asarray(upper_offsets, dtype=float)
+    geometry_lower = np.asarray(lower_offsets, dtype=float)
+
+    limit_x = []
+    enriched_upper = []
+    enriched_lower = []
+    run_start = 0
+    while run_start < geometry_x.size:
+        if not np.isfinite(geometry_x[run_start]):
+            if limit_x and not np.isnan(limit_x[-1]):
+                limit_x.append(np.nan)
+                enriched_upper.append(np.nan)
+                enriched_lower.append(np.nan)
+            run_start += 1
+            continue
+
+        run_end = run_start + 1
+        while run_end < geometry_x.size and np.isfinite(geometry_x[run_end]):
+            run_end += 1
+        run_values = _enrich_manual_geometry_run(
+            geometry_x[run_start:run_end],
+            geometry_upper[run_start:run_end],
+            geometry_lower[run_start:run_end],
+            baseline_x,
+        )
+        limit_x.extend(run_values[0])
+        enriched_upper.extend(run_values[1])
+        enriched_lower.extend(run_values[2])
+        run_start = run_end
+
+    limit_x_arr = np.asarray(limit_x, dtype=float)
+    upper_offset_arr = np.asarray(enriched_upper, dtype=float)
+    lower_offset_arr = np.asarray(enriched_lower, dtype=float)
+    baseline_at_limit = np.full(limit_x_arr.shape, np.nan, dtype=float)
+    if baseline_x.size:
+        finite_limit = np.isfinite(limit_x_arr)
+        in_baseline_range = (
+            finite_limit
+            & (limit_x_arr >= baseline_x[0])
+            & (limit_x_arr <= baseline_x[-1])
+        )
+        baseline_at_limit[in_baseline_range] = np.interp(
+            limit_x_arr[in_baseline_range],
+            baseline_x,
+            baseline_y,
+        )
+    absolute_upper, absolute_lower = build_golden_envelope_limits(
+        baseline_at_limit,
+        upper_offset_arr,
+        lower_offset_arr,
+    )
+    return display_x, display_y, limit_x_arr, absolute_upper, absolute_lower

--- a/ui/signal_analysis_window.py
+++ b/ui/signal_analysis_window.py
@@ -50,6 +50,7 @@ from base.golden_sample_comparison import (
     build_golden_curve_comparison as _build_golden_curve_comparison,
     build_golden_envelope_limits as _build_golden_envelope_limits,
     build_interpolated_golden_envelope_plot as _build_interpolated_golden_envelope_plot,
+    build_manual_endpoint_golden_envelope_plot as _build_manual_endpoint_golden_envelope_plot,
     build_golden_offset_deviation_limits as _build_golden_offset_deviation_limits,
     golden_offset_comparison_mask as _golden_offset_comparison_mask,
     interpolate_relative_limits as _interpolate_relative_limits,
@@ -91,6 +92,7 @@ from ui.reference_spectrum_analysis_window import ReferenceSpectrumCompareWindow
 from ui.ui_analysis_config.manual_limit_segments import (
     ManualLimitValidationError,
     limits_from_manual_segments,
+    manual_limit_plot_data,
 )
 
 
@@ -102,6 +104,46 @@ def _golden_limit_value_semantics(analysis_config) -> str:
     ):
         return LIMIT_VALUE_SEMANTICS_OFFSET
     return LIMIT_VALUE_SEMANTICS_BOUNDS
+
+
+def _resolve_manual_runtime_plot_data(
+    analysis_config,
+    measured_x,
+    display_mode,
+    *,
+    raw_y=None,
+    baseline_aligned=None,
+    log_x=False,
+    positive_x_support=None,
+):
+    """Resolve display-only manual geometry without changing judgment arrays."""
+    if log_x and positive_x_support is None:
+        positive_x_support = measured_x
+    plot_x, plot_upper, plot_lower = manual_limit_plot_data(
+        analysis_config,
+        value_semantics=_golden_limit_value_semantics(analysis_config),
+        positive_x_support=positive_x_support if log_x else None,
+    )
+    if (
+        display_mode == GOLDEN_SAMPLE_DISPLAY_ENVELOPE
+        and raw_y is not None
+        and baseline_aligned is not None
+    ):
+        return _build_manual_endpoint_golden_envelope_plot(
+            measured_x,
+            raw_y,
+            baseline_aligned,
+            plot_x,
+            plot_upper,
+            plot_lower,
+    )
+    return (
+        np.asarray(measured_x, dtype=float),
+        None if raw_y is None else np.asarray(raw_y, dtype=float),
+        np.asarray(plot_x, dtype=float),
+        np.asarray(plot_upper, dtype=float),
+        np.asarray(plot_lower, dtype=float),
+    )
 
 
 def _clear_golden_envelope_result(widget) -> None:
@@ -320,6 +362,11 @@ def _sorted_finite_positive_x_for_limits(x_values, y_values):
     if x_valid.size > 1:
         x_valid = x_valid[np.argsort(x_valid)]
     return x_valid
+
+
+def _finite_positive_x_support(x_values):
+    x_arr = np.asarray(x_values, dtype=float)
+    return x_arr[np.isfinite(x_arr) & (x_arr > 0)]
 
 
 class AnalysisResultSummaryWindow(QWidget):
@@ -702,10 +749,24 @@ class Distortion(AnalysisGraphWidget):
             limit_mode = str(analysis_config.get("limit_mode", "csv") or "csv").lower()
             if limit_mode == "manual" and valid_data:
                 try:
-                    csv_freq_list, csv_upper_list, csv_lower_list = limits_from_manual_segments(
+                    judgment_x, judgment_upper, judgment_lower = limits_from_manual_segments(
                         analysis_config,
                         freq_value,
                         value_semantics=_golden_limit_value_semantics(analysis_config),
+                    )
+                    (
+                        plot_data_x,
+                        plot_data_y,
+                        plot_limit_x,
+                        plot_upper,
+                        plot_lower,
+                    ) = _resolve_manual_runtime_plot_data(
+                        analysis_config,
+                        freq_value,
+                        _normalize_golden_sample_display_mode(analysis_config),
+                        raw_y=display_y,
+                        baseline_aligned=baseline_aligned,
+                        log_x=True,
                     )
                 except ManualLimitValidationError as exc:
                     MessageBox.warning(self, "提示", str(exc))
@@ -714,30 +775,36 @@ class Distortion(AnalysisGraphWidget):
                 result = analysis_config.get("limit_data")
                 if not result:
                     return
-                csv_freq_list, csv_upper_list, csv_lower_list = result
+                judgment_x, judgment_upper, judgment_lower = result
 
             if valid_data:
-                plot_limit_x = csv_freq_list
-                plot_upper = csv_upper_list
-                plot_lower = csv_lower_list
+                upper_offset = None
+                lower_offset = None
                 if envelope_mode:
                     upper_offset, lower_offset = _match_nearest_relative_limits(
                         freq_value,
-                        csv_freq_list,
-                        csv_upper_list,
-                        csv_lower_list,
+                        judgment_x,
+                        judgment_upper,
+                        judgment_lower,
                     )
-                    plot_upper, plot_lower = _build_golden_envelope_limits(
-                        baseline_aligned,
-                        upper_offset,
-                        lower_offset,
-                    )
-                    plot_limit_x = freq_value
+                if limit_mode != "manual":
+                    plot_data_x = freq_value
+                    plot_data_y = display_y
+                    plot_limit_x = judgment_x
+                    plot_upper = judgment_upper
+                    plot_lower = judgment_lower
+                    if envelope_mode:
+                        plot_upper, plot_lower = _build_golden_envelope_limits(
+                            baseline_aligned,
+                            upper_offset,
+                            lower_offset,
+                        )
+                        plot_limit_x = freq_value
                 # Use common function for plot setup
                 LimitPlotUtils.setup_limit_plot(
                     self.analysis_plot,
-                    freq_value,
-                    display_y,
+                    plot_data_x,
+                    plot_data_y,
                     plot_limit_x,
                     plot_upper,
                     plot_lower,
@@ -751,10 +818,10 @@ class Distortion(AnalysisGraphWidget):
                 if self.selected_label is not None:
                     self.analysis_plot.setTitle(f"The Distortion of {self.selected_label.text()} order")
                 # Highlight out-of-limit segments
-                judgment_upper, judgment_lower = (
-                    _build_golden_offset_deviation_limits(csv_upper_list, csv_lower_list)
+                comparison_upper, comparison_lower = (
+                    _build_golden_offset_deviation_limits(judgment_upper, judgment_lower)
                     if envelope_mode
-                    else (csv_upper_list, csv_lower_list)
+                    else (judgment_upper, judgment_lower)
                 )
                 if envelope_mode:
                     comparison_mask = _golden_offset_comparison_mask(
@@ -769,9 +836,9 @@ class Distortion(AnalysisGraphWidget):
                 self._highlight_out_of_range_curve(
                     freq_value,
                     thd,
-                    csv_freq_list,
-                    judgment_upper,
-                    judgment_lower,
+                    judgment_x,
+                    comparison_upper,
+                    comparison_lower,
                     covered_limit_margins_only=(
                         limit_mode == "manual" or envelope_mode
                     ),
@@ -1128,10 +1195,24 @@ class PerceptualRubAndBuzz(RubAndBuzz):
             limit_mode = str(analysis_config.get("limit_mode", "csv") or "csv").lower()
             if limit_mode == "manual" and valid_data:
                 try:
-                    csv_freq_list, csv_upper_list, csv_lower_list = limits_from_manual_segments(
+                    judgment_x, judgment_upper, judgment_lower = limits_from_manual_segments(
                         analysis_config,
                         freq_value,
                         value_semantics=_golden_limit_value_semantics(analysis_config),
+                    )
+                    (
+                        plot_data_x,
+                        plot_data_y,
+                        plot_limit_x,
+                        plot_upper,
+                        plot_lower,
+                    ) = _resolve_manual_runtime_plot_data(
+                        analysis_config,
+                        freq_value,
+                        _normalize_golden_sample_display_mode(analysis_config),
+                        raw_y=display_y,
+                        baseline_aligned=baseline_aligned,
+                        log_x=True,
                     )
                 except ManualLimitValidationError as exc:
                     MessageBox.warning(self, "提示", str(exc))
@@ -1140,31 +1221,37 @@ class PerceptualRubAndBuzz(RubAndBuzz):
                 result = analysis_config.get("limit_data")
                 if not result:
                     return
-                csv_freq_list, csv_upper_list, csv_lower_list = result
+                judgment_x, judgment_upper, judgment_lower = result
 
             if valid_data:
-                plot_limit_x = csv_freq_list
-                plot_upper = csv_upper_list
-                plot_lower = csv_lower_list
+                upper_offset = None
+                lower_offset = None
                 if envelope_mode:
                     upper_offset, lower_offset = _match_nearest_relative_limits(
                         freq_value,
-                        csv_freq_list,
-                        csv_upper_list,
-                        csv_lower_list,
+                        judgment_x,
+                        judgment_upper,
+                        judgment_lower,
                     )
-                    plot_upper, plot_lower = _build_golden_envelope_limits(
-                        baseline_aligned,
-                        upper_offset,
-                        lower_offset,
-                    )
-                    plot_limit_x = freq_value
+                if limit_mode != "manual":
+                    plot_data_x = freq_value
+                    plot_data_y = display_y
+                    plot_limit_x = judgment_x
+                    plot_upper = judgment_upper
+                    plot_lower = judgment_lower
+                    if envelope_mode:
+                        plot_upper, plot_lower = _build_golden_envelope_limits(
+                            baseline_aligned,
+                            upper_offset,
+                            lower_offset,
+                        )
+                        plot_limit_x = freq_value
 
                 # 1) Plot main curve + limit curves (same as THD)
                 LimitPlotUtils.setup_limit_plot(
                     self.analysis_plot,
-                    freq_value,
-                    display_y,
+                    plot_data_x,
+                    plot_data_y,
                     plot_limit_x,
                     plot_upper,
                     plot_lower,
@@ -1180,10 +1267,10 @@ class PerceptualRubAndBuzz(RubAndBuzz):
 
                 # 2) Use parent's _highlight_out_of_range_curve() for limit check + highlight
                 #    This uses nearest-neighbor matching and highlights on original data points
-                judgment_upper, judgment_lower = (
-                    _build_golden_offset_deviation_limits(csv_upper_list, csv_lower_list)
+                comparison_upper, comparison_lower = (
+                    _build_golden_offset_deviation_limits(judgment_upper, judgment_lower)
                     if envelope_mode
-                    else (csv_upper_list, csv_lower_list)
+                    else (judgment_upper, judgment_lower)
                 )
                 if envelope_mode:
                     comparison_mask = _golden_offset_comparison_mask(
@@ -1198,9 +1285,9 @@ class PerceptualRubAndBuzz(RubAndBuzz):
                 self._highlight_out_of_range_curve(
                     freq_value,
                     perceptual_loudness,
-                    csv_freq_list,
-                    judgment_upper,
-                    judgment_lower,
+                    judgment_x,
+                    comparison_upper,
+                    comparison_lower,
                     covered_limit_margins_only=(
                         limit_mode == "manual" or envelope_mode
                     ),
@@ -1316,10 +1403,21 @@ class Spl(AnalysisGraphWidget):
         limit_checked = self.analysis_config.get("limit_checked")
         if limit_checked:
             limit_mode = str(self.analysis_config.get("limit_mode", "csv") or "csv").lower()
+            plot_time_list = None
+            plot_upper_list = None
+            plot_lower_list = None
             if limit_mode == "manual":
                 try:
                     csv_time_list, csv_upper_list, csv_lower_list = limits_from_manual_segments(
                         self.analysis_config, signal_duration
+                    )
+                    _, _, plot_time_list, plot_upper_list, plot_lower_list = (
+                        _resolve_manual_runtime_plot_data(
+                            self.analysis_config,
+                            signal_duration,
+                            GOLDEN_SAMPLE_DISPLAY_DEVIATION,
+                            log_x=False,
+                        )
                     )
                 except ManualLimitValidationError as exc:
                     MessageBox.warning(self, "提示", str(exc))
@@ -1329,7 +1427,16 @@ class Spl(AnalysisGraphWidget):
                 if not result:
                     return False
                 csv_time_list, csv_upper_list, csv_lower_list = result
-            self.plot_spl_with_limits(signal_duration, signal_spl, csv_time_list, csv_upper_list, csv_lower_list)
+            self.plot_spl_with_limits(
+                signal_duration,
+                signal_spl,
+                csv_time_list,
+                csv_upper_list,
+                csv_lower_list,
+                plot_time_list=plot_time_list,
+                plot_upper_list=plot_upper_list,
+                plot_lower_list=plot_lower_list,
+            )
         else:
             self.plot_spl(signal_duration, signal_spl)
         self._set_overall_spl_title(overall_spl)
@@ -1342,7 +1449,18 @@ class Spl(AnalysisGraphWidget):
             self.result["overall_spl"] = overall_spl
         return self.result
 
-    def plot_spl_with_limits(self, signal_duration, signal_spl, csv_time_list, csv_upper_list, csv_lower_list):
+    def plot_spl_with_limits(
+        self,
+        signal_duration,
+        signal_spl,
+        csv_time_list,
+        csv_upper_list,
+        csv_lower_list,
+        *,
+        plot_time_list=None,
+        plot_upper_list=None,
+        plot_lower_list=None,
+    ):
         """
         Plot SPL time-domain curve and highlight out-of-limit segments.
 
@@ -1358,16 +1476,23 @@ class Spl(AnalysisGraphWidget):
             csv_time_list: CSV time point list
             csv_upper_list: Upper limit list
             csv_lower_list: Lower limit list
+            plot_time_list: Optional plot-only time points
+            plot_upper_list: Optional plot-only upper-limit points
+            plot_lower_list: Optional plot-only lower-limit points
         """
+        plot_time_list = csv_time_list if plot_time_list is None else plot_time_list
+        plot_upper_list = csv_upper_list if plot_upper_list is None else plot_upper_list
+        plot_lower_list = csv_lower_list if plot_lower_list is None else plot_lower_list
+
         # === 1. Common plot setup (clear, draw main curve and limit curves, set axes) ===
         # Note: SPL time-domain uses linear scale (log_x=False), Y label is dynamic
         LimitPlotUtils.setup_limit_plot(
             self.analysis_plot,
             signal_duration,
             signal_spl,
-            csv_time_list,
-            csv_upper_list,
-            csv_lower_list,
+            plot_time_list,
+            plot_upper_list,
+            plot_lower_list,
             x_label="Time (s)",
             y_label=self._get_spl_label(),
             log_x=False,
@@ -1543,6 +1668,7 @@ class SplFrequency(AnalysisGraphWidget):
             self.plot_spl_frequency(frequency_list, spl_db_raw)
         elif limit_checked:
             limit_mode = str(analysis_config.get("limit_mode", "csv") or "csv").lower()
+            manual_plot_data = None
             if limit_mode == "manual":
                 try:
                     manual_limit_x = _sorted_finite_positive_x_for_limits(frequency_list, spl_db)
@@ -1550,6 +1676,15 @@ class SplFrequency(AnalysisGraphWidget):
                         analysis_config,
                         manual_limit_x,
                         value_semantics=_golden_limit_value_semantics(analysis_config),
+                    )
+                    manual_plot_data = _resolve_manual_runtime_plot_data(
+                        analysis_config,
+                        frequency_list,
+                        _normalize_golden_sample_display_mode(analysis_config),
+                        raw_y=spl_db_raw,
+                        baseline_aligned=baseline_aligned,
+                        log_x=True,
+                        positive_x_support=_finite_positive_x_support(frequency_list),
                     )
                 except ManualLimitValidationError as exc:
                     MessageBox.warning(self, "提示", str(exc))
@@ -1568,6 +1703,7 @@ class SplFrequency(AnalysisGraphWidget):
                 raw_y=spl_db_raw,
                 baseline_aligned=baseline_aligned,
                 display_mode=_normalize_golden_sample_display_mode(analysis_config),
+                manual_plot_data=manual_plot_data,
             )
         else:
             display_y = (
@@ -1596,6 +1732,7 @@ class SplFrequency(AnalysisGraphWidget):
         raw_y=None,
         baseline_aligned=None,
         display_mode=GOLDEN_SAMPLE_DISPLAY_DEVIATION,
+        manual_plot_data=None,
     ):
         """
         Plot SPLF (SPL-Frequency) curve and highlight out-of-limit segments.
@@ -1633,19 +1770,25 @@ class SplFrequency(AnalysisGraphWidget):
         display_x = freq_valid
         display_y = display_valid
         if envelope_mode:
-            display_x, display_y, plot_upper, plot_lower = _build_interpolated_golden_envelope_plot(
-                freq_arr,
-                raw_y,
-                baseline_aligned,
-                csv_freq_list,
-                csv_upper_list,
-                csv_lower_list,
-            )
-            plot_limit_x = display_x
+            if manual_plot_data is not None:
+                display_x, display_y, plot_limit_x, plot_upper, plot_lower = manual_plot_data
+            else:
+                display_x, display_y, plot_upper, plot_lower = _build_interpolated_golden_envelope_plot(
+                    freq_arr,
+                    raw_y,
+                    baseline_aligned,
+                    csv_freq_list,
+                    csv_upper_list,
+                    csv_lower_list,
+                )
+                plot_limit_x = display_x
         else:
-            plot_limit_x = csv_freq_list
-            plot_upper = csv_upper_list
-            plot_lower = csv_lower_list
+            if manual_plot_data is not None:
+                _, _, plot_limit_x, plot_upper, plot_lower = manual_plot_data
+            else:
+                plot_limit_x = csv_freq_list
+                plot_upper = csv_upper_list
+                plot_lower = csv_lower_list
 
         # === 2. Common plot setup (use sorted data for both green and red curves) ===
         LimitPlotUtils.setup_limit_plot(
@@ -1836,6 +1979,7 @@ class Frequency(AnalysisGraphWidget):
             self.plot_fr(frequency_list, fr_raw)
         elif limit_checked:
             limit_mode = str(analysis_config.get("limit_mode", "csv") or "csv").lower()
+            manual_plot_data = None
             if limit_mode == "manual":
                 try:
                     manual_limit_x = _sorted_finite_positive_x_for_limits(frequency_list, fr)
@@ -1843,6 +1987,15 @@ class Frequency(AnalysisGraphWidget):
                         analysis_config,
                         manual_limit_x,
                         value_semantics=_golden_limit_value_semantics(analysis_config),
+                    )
+                    manual_plot_data = _resolve_manual_runtime_plot_data(
+                        analysis_config,
+                        frequency_list,
+                        _normalize_golden_sample_display_mode(analysis_config),
+                        raw_y=fr_raw,
+                        baseline_aligned=baseline_aligned,
+                        log_x=True,
+                        positive_x_support=_finite_positive_x_support(frequency_list),
                     )
                 except ManualLimitValidationError as exc:
                     MessageBox.warning(self, "提示", str(exc))
@@ -1861,6 +2014,7 @@ class Frequency(AnalysisGraphWidget):
                 raw_y=fr_raw,
                 baseline_aligned=baseline_aligned,
                 display_mode=_normalize_golden_sample_display_mode(analysis_config),
+                manual_plot_data=manual_plot_data,
             )
         else:
             display_y = (
@@ -1981,6 +2135,7 @@ class Frequency(AnalysisGraphWidget):
         raw_y=None,
         baseline_aligned=None,
         display_mode=GOLDEN_SAMPLE_DISPLAY_DEVIATION,
+        manual_plot_data=None,
     ):
         """
         Plot Frequency Response (FR) curve and highlight out-of-limit segments.
@@ -2021,19 +2176,25 @@ class Frequency(AnalysisGraphWidget):
         display_x = freq_valid
         display_y = display_valid
         if envelope_mode:
-            display_x, display_y, plot_upper, plot_lower = _build_interpolated_golden_envelope_plot(
-                freq_arr,
-                raw_y,
-                baseline_aligned,
-                csv_freq_list,
-                csv_upper_list,
-                csv_lower_list,
-            )
-            plot_limit_x = display_x
+            if manual_plot_data is not None:
+                display_x, display_y, plot_limit_x, plot_upper, plot_lower = manual_plot_data
+            else:
+                display_x, display_y, plot_upper, plot_lower = _build_interpolated_golden_envelope_plot(
+                    freq_arr,
+                    raw_y,
+                    baseline_aligned,
+                    csv_freq_list,
+                    csv_upper_list,
+                    csv_lower_list,
+                )
+                plot_limit_x = display_x
         else:
-            plot_limit_x = csv_freq_list
-            plot_upper = csv_upper_list
-            plot_lower = csv_lower_list
+            if manual_plot_data is not None:
+                _, _, plot_limit_x, plot_upper, plot_lower = manual_plot_data
+            else:
+                plot_limit_x = csv_freq_list
+                plot_upper = csv_upper_list
+                plot_lower = csv_lower_list
 
         # === 2. Common plot setup (use sorted data for both green and red curves) ===
         LimitPlotUtils.setup_limit_plot(

--- a/ui/ui_analysis_config/manual_limit_segments.py
+++ b/ui/ui_analysis_config/manual_limit_segments.py
@@ -89,6 +89,91 @@ def limits_from_manual_segments(
     return x_values.tolist(), upper_values.tolist(), lower_values.tolist()
 
 
+def assemble_manual_plot_data(
+    upper_segments: Sequence[Mapping[str, float]],
+    lower_segments: Sequence[Mapping[str, float]],
+    *,
+    positive_x_support=None,
+) -> tuple[list[float], list[float], list[float]]:
+    """Assemble plot-only geometry from ordered, finite manual segments."""
+    upper_x, upper_y = _assemble_side_plot_data(
+        upper_segments,
+        positive_x_support=positive_x_support,
+    )
+    lower_x, lower_y = _assemble_side_plot_data(
+        lower_segments,
+        positive_x_support=positive_x_support,
+    )
+
+    if upper_x and lower_x:
+        separator = [np.nan]
+        x_values = upper_x + separator + lower_x
+        upper_values = upper_y + separator + [np.nan] * len(lower_x)
+        lower_values = [np.nan] * len(upper_x) + separator + lower_y
+        return x_values, upper_values, lower_values
+    if upper_x:
+        return upper_x, upper_y, [np.nan] * len(upper_x)
+    if lower_x:
+        return lower_x, [np.nan] * len(lower_x), lower_y
+    return [], [], []
+
+
+def manual_limit_plot_data(
+    config: dict,
+    *,
+    value_semantics: str = LIMIT_VALUE_SEMANTICS_BOUNDS,
+    positive_x_support=None,
+) -> tuple[list[float], list[float], list[float]]:
+    """Build validated runtime plot geometry from exact configured endpoints."""
+    upper_enabled, lower_enabled, upper_segments, lower_segments = _normalized_enabled_segments(
+        config,
+        value_semantics=value_semantics,
+    )
+    return assemble_manual_plot_data(
+        upper_segments if upper_enabled else [],
+        lower_segments if lower_enabled else [],
+        positive_x_support=positive_x_support,
+    )
+
+
+def _assemble_side_plot_data(
+    segments: Sequence[Mapping[str, float]],
+    *,
+    positive_x_support=None,
+) -> tuple[list[float], list[float]]:
+    support = None
+    if positive_x_support is not None:
+        support = np.asarray(positive_x_support, dtype=float).reshape(-1)
+        support = support[np.isfinite(support) & (support > 0)]
+
+    x_values: list[float] = []
+    y_values: list[float] = []
+    previous_segment_rendered = False
+
+    for segment in segments:
+        start_x = float(segment["start_x"])
+        start_y = float(segment["start_y"])
+        end_x = float(segment["end_x"])
+        end_y = float(segment["end_y"])
+
+        if support is not None and start_x <= 0:
+            supported_x = support[(support > start_x) & (support <= end_x)]
+            if supported_x.size == 0:
+                previous_segment_rendered = False
+                continue
+            start_x = float(np.min(supported_x))
+            start_y = float(_segment_value_at(segment, start_x))
+
+        if x_values and not previous_segment_rendered:
+            x_values.append(np.nan)
+            y_values.append(np.nan)
+        x_values.extend([start_x, end_x])
+        y_values.extend([start_y, end_y])
+        previous_segment_rendered = True
+
+    return x_values, y_values
+
+
 def _normalized_enabled_segments(
     config: dict | None,
     *,
@@ -137,20 +222,49 @@ def _validate_lower_not_above_upper(
     upper_segments: list[dict[str, float]],
     lower_segments: list[dict[str, float]],
 ) -> None:
-    for upper_index, upper_segment in enumerate(upper_segments, start=1):
-        for lower_index, lower_segment in enumerate(lower_segments, start=1):
-            left = max(upper_segment["start_x"], lower_segment["start_x"])
-            right = min(upper_segment["end_x"], lower_segment["end_x"])
+    effective_upper = _effective_segments_with_connectors(upper_segments)
+    effective_lower = _effective_segments_with_connectors(lower_segments)
+
+    for upper_piece in effective_upper:
+        for lower_piece in effective_lower:
+            left = max(upper_piece["start_x"], lower_piece["start_x"])
+            right = min(upper_piece["end_x"], lower_piece["end_x"])
             if right <= left:
                 continue
 
             for x_value in (left, right):
-                upper_y = _segment_value_at(upper_segment, x_value)
-                lower_y = _segment_value_at(lower_segment, x_value)
+                upper_y = _segment_value_at(upper_piece, x_value)
+                lower_y = _segment_value_at(lower_piece, x_value)
                 if lower_y > upper_y:
                     raise ManualLimitValidationError(
-                        f"下限不能大于上限：上限第{upper_index}段与下限第{lower_index}段在重叠区间内不合法"
+                        "下限不能大于上限：有效阈值线在重叠区间内不合法"
                     )
+
+
+def _effective_segments_with_connectors(
+    segments: Sequence[Mapping[str, float]],
+) -> list[dict[str, float]]:
+    effective = []
+    previous = None
+    for segment in segments:
+        current = {
+            "start_x": float(segment["start_x"]),
+            "start_y": float(segment["start_y"]),
+            "end_x": float(segment["end_x"]),
+            "end_y": float(segment["end_y"]),
+        }
+        if previous is not None and current["start_x"] > previous["end_x"]:
+            effective.append(
+                {
+                    "start_x": previous["end_x"],
+                    "start_y": previous["end_y"],
+                    "end_x": current["start_x"],
+                    "end_y": current["start_y"],
+                }
+            )
+        effective.append(current)
+        previous = current
+    return effective
 
 
 def _apply_segments(
@@ -158,7 +272,7 @@ def _apply_segments(
     x_values: np.ndarray,
     segments: list[dict[str, float]],
 ) -> None:
-    for segment in segments:
+    for segment in _effective_segments_with_connectors(segments):
         mask = (x_values > segment["start_x"]) & (x_values <= segment["end_x"])
         output_values[mask] = _segment_value_at(segment, x_values[mask])
 

--- a/ui/ui_analysis_config/threshold_config_widget.py
+++ b/ui/ui_analysis_config/threshold_config_widget.py
@@ -39,6 +39,7 @@ from ui.curve_style import (
 from ui.custom_ui_widget.widgets import CheckBox, GroupBox, LineEdit, MessageBox, PushButton, RadioButton, TableWidget, Menu
 from ui.ui_analysis_config.manual_limit_segments import (
     ManualLimitValidationError,
+    assemble_manual_plot_data,
     validate_manual_limit_config,
 )
 from ui.ui_analysis_config.threshold_csv_manual import (
@@ -180,25 +181,10 @@ class _ManualLimitEditorWidget(QWidget):
         lower_enabled = bool(self.manual_lower_check.isChecked())
         upper_segments = self._complete_manual_table_segments(self.manual_upper_table) if upper_enabled else []
         lower_segments = self._complete_manual_table_segments(self.manual_lower_table) if lower_enabled else []
-        x_values, upper_values, lower_values = [], [], []
-
-        def append_gap_if_needed():
-            if x_values:
-                x_values.append(np.nan)
-                upper_values.append(np.nan)
-                lower_values.append(np.nan)
-
-        for segment in upper_segments:
-            append_gap_if_needed()
-            x_values.extend([segment["start_x"], segment["end_x"]])
-            upper_values.extend([segment["start_y"], segment["end_y"]])
-            lower_values.extend([np.nan, np.nan])
-
-        for segment in lower_segments:
-            append_gap_if_needed()
-            x_values.extend([segment["start_x"], segment["end_x"]])
-            upper_values.extend([np.nan, np.nan])
-            lower_values.extend([segment["start_y"], segment["end_y"]])
+        x_values, upper_values, lower_values = assemble_manual_plot_data(
+            upper_segments,
+            lower_segments,
+        )
 
         if not x_values:
             return ([0.0], [np.nan], [np.nan])

--- a/unit_test/base/test_golden_sample_comparison.py
+++ b/unit_test/base/test_golden_sample_comparison.py
@@ -1,10 +1,12 @@
 import numpy as np
+import pytest
 
 from base.golden_sample_comparison import (
     build_golden_curve_comparison,
     build_golden_envelope_limits,
     build_golden_offset_deviation_limits,
     build_interpolated_golden_envelope_plot,
+    build_manual_endpoint_golden_envelope_plot,
     golden_offset_comparison_mask,
     has_valid_golden_overlap,
     interpolate_relative_limits,
@@ -185,6 +187,113 @@ def test_interpolated_envelope_keeps_full_raw_curve_but_gaps_limits_outside_gold
     np.testing.assert_allclose(display_y, [80.0, 90.0, 92.0, 96.0])
     np.testing.assert_allclose(upper, [np.nan, 92.0, 96.0, np.nan], equal_nan=True)
     np.testing.assert_allclose(lower, [np.nan, 86.0, 86.0, np.nan], equal_nan=True)
+
+
+def test_manual_envelope_plot_keeps_exact_endpoints_and_interior_baseline_samples():
+    data_x = np.array([50.0, 75.0, 100.0, 110.0, 1000.0])
+    raw_y = np.array([20.0, 21.0, 22.0, 23.0, 24.0])
+    baseline = np.array([10.0, 11.0, 12.0, 13.0, 14.0])
+
+    display_x, display_y, limit_x, upper, lower = (
+        build_manual_endpoint_golden_envelope_plot(
+            data_x,
+            raw_y,
+            baseline,
+            [50.0, 100.0, 100.1, 1000.0],
+            [4.0, 4.0, 3.0, 3.0],
+            [np.nan, np.nan, np.nan, np.nan],
+        )
+    )
+
+    assert display_x.tolist() == data_x.tolist()
+    assert display_y.tolist() == raw_y.tolist()
+    assert limit_x.tolist() == [50.0, 75.0, 100.0, 100.1, 110.0, 1000.0]
+    assert upper[3] == pytest.approx(15.01)
+    assert np.isnan(lower).all()
+
+
+def test_manual_envelope_plot_keeps_duplicate_boundary_for_vertical_step():
+    _, _, limit_x, upper, _ = build_manual_endpoint_golden_envelope_plot(
+        np.array([50.0, 75.0, 100.0, 110.0, 1000.0]),
+        np.array([20.0, 21.0, 22.0, 23.0, 24.0]),
+        np.array([10.0, 11.0, 12.0, 13.0, 14.0]),
+        [50.0, 100.0, 100.0, 1000.0],
+        [4.0, 4.0, 3.0, 3.0],
+        [np.nan, np.nan, np.nan, np.nan],
+    )
+
+    assert limit_x.tolist() == [50.0, 75.0, 100.0, 100.0, 110.0, 1000.0]
+    assert upper[2:4].tolist() == [16.0, 15.0]
+
+
+def test_manual_envelope_plot_does_not_extrapolate_outside_baseline_overlap():
+    _, _, limit_x, upper, _ = build_manual_endpoint_golden_envelope_plot(
+        np.array([50.0, 100.0, 1000.0]),
+        np.array([20.0, 22.0, 24.0]),
+        np.array([10.0, 12.0, 14.0]),
+        [40.0, 50.0, 1000.0, 1100.0],
+        [4.0, 4.0, 3.0, 3.0],
+        [np.nan, np.nan, np.nan, np.nan],
+    )
+
+    assert limit_x[[0, -1]].tolist() == [40.0, 1100.0]
+    assert np.isnan(upper[[0, -1]]).all()
+
+
+def test_manual_envelope_plot_keeps_upper_and_lower_runs_independent():
+    _, _, limit_x, upper, lower = build_manual_endpoint_golden_envelope_plot(
+        np.array([50.0, 75.0, 100.0]),
+        np.array([20.0, 21.0, 22.0]),
+        np.array([10.0, 11.0, 12.0]),
+        [50.0, 100.0, np.nan, 50.0, 100.0],
+        [4.0, 4.0, np.nan, np.nan, np.nan],
+        [np.nan, np.nan, np.nan, -3.0, -3.0],
+    )
+
+    np.testing.assert_allclose(
+        limit_x,
+        [50.0, 75.0, 100.0, np.nan, 50.0, 75.0, 100.0],
+        equal_nan=True,
+    )
+    np.testing.assert_allclose(
+        upper,
+        [14.0, 15.0, 16.0, np.nan, np.nan, np.nan, np.nan],
+        equal_nan=True,
+    )
+    np.testing.assert_allclose(
+        lower,
+        [np.nan, np.nan, np.nan, np.nan, 7.0, 8.0, 9.0],
+        equal_nan=True,
+    )
+
+
+def test_manual_envelope_uses_baseline_samples_excluded_from_raw_display():
+    display_x, _, limit_x, upper, _ = build_manual_endpoint_golden_envelope_plot(
+        np.array([50.0, 75.0, 100.0]),
+        np.array([20.0, np.nan, 22.0]),
+        np.array([10.0, 11.0, 12.0]),
+        [50.0, 100.0],
+        [2.0, 4.0],
+        [np.nan, np.nan],
+    )
+
+    assert display_x.tolist() == [50.0, 100.0]
+    assert limit_x.tolist() == [50.0, 75.0, 100.0]
+    assert upper.tolist() == pytest.approx([12.0, 14.0, 16.0])
+
+
+def test_manual_envelope_sorts_baseline_and_keeps_first_duplicate():
+    _, _, limit_x, upper, _ = build_manual_endpoint_golden_envelope_plot(
+        np.array([100.0, 50.0, 100.0, 75.0]),
+        np.array([22.0, 20.0, 99.0, 21.0]),
+        np.array([12.0, 10.0, 99.0, 11.0]),
+        [50.0, 100.0],
+        [2.0, 4.0],
+        [np.nan, np.nan],
+    )
+
+    assert limit_x.tolist() == [50.0, 75.0, 100.0]
+    assert upper.tolist() == pytest.approx([12.0, 14.0, 16.0])
 
 
 def test_nearest_relative_limits_keep_hd_rb_prb_boundary_rule():

--- a/unit_test/ui/test_analysis_config_dialog_migration.py
+++ b/unit_test/ui/test_analysis_config_dialog_migration.py
@@ -704,7 +704,37 @@ def test_threshold_widget_manual_mode_recomputes_scroll_height_after_being_enabl
     window.close()
 
 
-def test_threshold_widget_manual_preview_inserts_gap_between_disconnected_segments(qapp):
+def test_manual_limit_preview_exact_endpoints(qapp):
+    widget = create_threshold_widget(
+        qapp,
+        {
+            "limit_checked": True,
+            "limit_mode": "manual",
+            "manual_upper_enabled": True,
+            "manual_lower_enabled": False,
+            "manual_upper_segments": [
+                {"start_x": 50.0, "start_y": 4.0, "end_x": 100.0, "end_y": 4.0},
+                {"start_x": 100.1, "start_y": 3.0, "end_x": 1000.0, "end_y": 3.0},
+            ],
+        },
+    )
+    dialog = create_manual_dialog(widget)
+
+    x_values, upper_values, lower_values = dialog.editor.manual_limit_preview_data()
+
+    assert x_values == [50.0, 100.0, 100.1, 1000.0]
+    assert upper_values == [4.0, 4.0, 3.0, 3.0]
+    assert np.all(np.isnan(lower_values))
+
+    set_table_cell(dialog.editor.manual_upper_table, 0, 1, "100.0")
+    x_values, upper_values, lower_values = dialog.editor.manual_limit_preview_data()
+
+    assert x_values == [50.0, 100.0, 100.0, 1000.0]
+    assert upper_values == [4.0, 4.0, 3.0, 3.0]
+    assert np.all(np.isnan(lower_values))
+
+
+def test_manual_limit_preview_partial_columns_are_omitted(qapp):
     widget = create_threshold_widget(
         qapp,
         {
@@ -715,17 +745,18 @@ def test_threshold_widget_manual_preview_inserts_gap_between_disconnected_segmen
         },
     )
     dialog = create_manual_dialog(widget)
-    set_segment_column(dialog.editor.manual_upper_table, 0, [0, 10, 1, 20])
-    set_segment_column(dialog.editor.manual_upper_table, 1, [2, 30, 3, 40])
+    table = dialog.editor.manual_upper_table
+    set_segment_column(table, 0, [50, 4, 100, 4])
+    table.setColumnCount(5)
+    dialog.editor._ensure_manual_table_items(table)
+    set_table_cell(table, 0, 1, "100.1")
+    set_segment_column(table, 2, [100.1, 3, 1000, "nan"])
+    set_segment_column(table, 3, [100.1, "not-a-number", 1000, 3])
 
     x_values, upper_values, lower_values = dialog.editor.manual_limit_preview_data()
 
-    assert x_values[:2] == [0.0, 1.0]
-    assert np.isnan(x_values[2])
-    assert x_values[3:] == [2.0, 3.0]
-    assert upper_values[:2] == [10.0, 20.0]
-    assert np.isnan(upper_values[2])
-    assert upper_values[3:] == [30.0, 40.0]
+    assert x_values == [50.0, 100.0]
+    assert upper_values == [4.0, 4.0]
     assert np.all(np.isnan(lower_values))
 
 
@@ -747,7 +778,7 @@ def test_manual_limit_preview_highlight_current_upper_column_only(qapp):
     items = plot_data_snapshot(dialog.limit_graph)
     np.testing.assert_equal(
         items[0],
-        ([0.0, 1.0, np.nan, 1.0, 2.0, np.nan, 2.0, 3.0], [10.0, 20.0, np.nan, 20.0, 30.0, np.nan, 30.0, 40.0]),
+        ([0.0, 1.0, 1.0, 2.0, 2.0, 3.0], [10.0, 20.0, 20.0, 30.0, 30.0, 40.0]),
     )
     assert items[1:] == [([2.0, 3.0], [30.0, 40.0])]
 
@@ -1172,12 +1203,8 @@ def test_threshold_widget_initial_manual_mode_seeds_loaded_limit_data_and_previe
     x_data, y_data = widget.limit_graph.listDataItems()[0].getData()
     x_values = np.asarray(x_data).tolist()
     y_values = np.asarray(y_data).tolist()
-    assert x_values[:2] == [0.0, 1.0]
-    assert np.isnan(x_values[2])
-    assert x_values[3:] == [1.0, 2.0]
-    assert y_values[:2] == [10.0, 20.0]
-    assert np.isnan(y_values[2])
-    assert y_values[3:] == [20.0, 30.0]
+    assert x_values == [0.0, 1.0, 1.0, 2.0]
+    assert y_values == [10.0, 20.0, 20.0, 30.0]
 
 
 def test_manual_limit_dialog_reject_keeps_parent_config_unchanged(qapp, monkeypatch):
@@ -1980,6 +2007,40 @@ def test_manual_limit_dialog_invalid_warning_is_chinese_and_dialog_stays_open(qa
     dialog = create_manual_dialog(widget)
     set_segment_column(dialog.editor.manual_upper_table, 0, [0, 0, 1, 0])
     set_segment_column(dialog.editor.manual_lower_table, 0, [0, 1, 1, 0])
+    confirm_dialog(dialog)
+
+    assert warnings
+    assert "下限不能大于上限" in warnings[-1][2]
+    assert dialog.result() != dialog.Accepted
+    assert dialog.isVisible() is True
+
+
+def test_manual_limit_dialog_rejects_effective_connector_inversion_on_confirm(
+    qapp,
+    monkeypatch,
+):
+    from ui.ui_analysis_config import threshold_config_widget
+
+    warnings = []
+    monkeypatch.setattr(
+        threshold_config_widget.MessageBox,
+        "warning",
+        lambda *args, **kwargs: warnings.append(args),
+    )
+    widget = create_threshold_widget(
+        qapp,
+        {
+            "limit_checked": True,
+            "limit_mode": "manual",
+            "manual_upper_enabled": True,
+            "manual_lower_enabled": True,
+        },
+    )
+    dialog = create_manual_dialog(widget)
+    set_segment_column(dialog.editor.manual_upper_table, 0, [0, 10, 10, 10])
+    set_segment_column(dialog.editor.manual_upper_table, 1, [30, 0, 40, 0])
+    set_segment_column(dialog.editor.manual_lower_table, 0, [15, 8, 25, 8])
+
     confirm_dialog(dialog)
 
     assert warnings

--- a/unit_test/ui/test_manual_limit_runtime.py
+++ b/unit_test/ui/test_manual_limit_runtime.py
@@ -24,8 +24,9 @@ def qapp():
 
 @pytest.fixture
 def captured_limit_utils(monkeypatch):
-    captured = {"setup": [], "check": [], "out": []}
+    captured = {"setup": [], "check": [], "compare": [], "out": []}
     original_check_interp_limits = saw.LimitPlotUtils.check_interp_limits
+    original_compare_with_limits = saw.LimitPlotUtils.compare_with_limits
 
     def setup_limit_plot(
         plot_widget,
@@ -44,6 +45,7 @@ def captured_limit_utils(monkeypatch):
                 "csv_x": np.asarray(csv_x, dtype=float),
                 "csv_upper": np.asarray(csv_upper, dtype=float),
                 "csv_lower": np.asarray(csv_lower, dtype=float),
+                "kwargs": kwargs,
             }
         )
 
@@ -61,6 +63,19 @@ def captured_limit_utils(monkeypatch):
         )
         return result
 
+    def compare_with_limits(plot_y, upper_limits, lower_limits, valid_mask=None):
+        result = original_compare_with_limits(plot_y, upper_limits, lower_limits, valid_mask)
+        captured["compare"].append(
+            {
+                "plot_y": np.asarray(plot_y, dtype=float),
+                "upper_limits": np.asarray(upper_limits, dtype=float),
+                "lower_limits": np.asarray(lower_limits, dtype=float),
+                "valid_mask": np.asarray(valid_mask, dtype=bool),
+                "result": result,
+            }
+        )
+        return result
+
     def plot_out_segments(plot_widget, x_data, y_data, out_mask, *args, **kwargs):
         captured["out"].append(
             {
@@ -72,6 +87,7 @@ def captured_limit_utils(monkeypatch):
 
     monkeypatch.setattr(saw.LimitPlotUtils, "setup_limit_plot", staticmethod(setup_limit_plot))
     monkeypatch.setattr(saw.LimitPlotUtils, "check_interp_limits", staticmethod(check_interp_limits))
+    monkeypatch.setattr(saw.LimitPlotUtils, "compare_with_limits", staticmethod(compare_with_limits))
     monkeypatch.setattr(saw.LimitPlotUtils, "plot_out_segments", staticmethod(plot_out_segments))
     return captured
 
@@ -90,6 +106,40 @@ def _manual_upper_config(segments, *, scalar_upper=999.0):
     }
 
 
+def _exact_gap_segments():
+    return [
+        {"start_x": 50.0, "start_y": 4.0, "end_x": 100.0, "end_y": 4.0},
+        {"start_x": 100.1, "start_y": 3.0, "end_x": 1000.0, "end_y": 3.0},
+    ]
+
+
+def _capture_highlight_judgment(widget):
+    captured = {}
+    original_highlight = widget._highlight_out_of_range_curve
+
+    def capture(freq_value, y_data, limit_x, upper, lower, **kwargs):
+        captured.update(
+            {
+                "freq_value": np.asarray(freq_value, dtype=float),
+                "y_data": np.asarray(y_data, dtype=float),
+                "limit_x": np.asarray(limit_x, dtype=float),
+                "upper": np.asarray(upper, dtype=float),
+                "lower": np.asarray(lower, dtype=float),
+            }
+        )
+        return original_highlight(
+            freq_value,
+            y_data,
+            limit_x,
+            upper,
+            lower,
+            **kwargs,
+        )
+
+    widget._highlight_out_of_range_curve = capture
+    return captured
+
+
 def _assert_upper_with_gap(actual, expected_middle):
     assert np.isnan(actual[0])
     assert actual[1] == pytest.approx(expected_middle)
@@ -102,6 +152,62 @@ def _recording_widget(widget, analysis_config):
     widget.data_struct.store_wave_data = np.ones(3, dtype=np.float32)
     widget.data_struct.store_wave_data_multi = None
     return widget
+
+
+def _frequency_analysis_config(config):
+    config.update(
+        {
+            "analysis_channel": 0,
+            "splf_calc_mode": "fundamental",
+            "stimulus_method": "steps",
+            "stimulus_type": "linear",
+            "start_freq": 50,
+            "stop_freq": 1000,
+            "num_steps": 5,
+            "total_time": 0.5,
+            "repeat_times": 1,
+        }
+    )
+    return config
+
+
+def _frequency_analysis_widget(monkeypatch, analysis_kind, config, measured_x, measured_y):
+    if analysis_kind == "splf":
+        widget = _recording_widget(saw.SplFrequency("SPLF"), config)
+        widget.data_struct.sample_rate = 48000
+        widget.data_struct.stimulus_info = dict(config)
+        monkeypatch.setattr(widget, "_resolve_v2pa_factor_for_analysis", lambda: True)
+
+        class FakeSplFrequencyAnalyzer:
+            def __init__(self, sample_rate):
+                pass
+
+            def compute(self, recorded_signal, *, stimulus_metadata, v2pa_factor, splf_calc_mode):
+                return types.SimpleNamespace(
+                    frequencies_hz=np.asarray(measured_x, dtype=float),
+                    spl_db=np.asarray(measured_y, dtype=float),
+                )
+
+        monkeypatch.setattr(saw, "SplFrequencyAnalyzer", FakeSplFrequencyAnalyzer)
+        return widget, widget.calculate_spl
+
+    widget = _recording_widget(saw.Frequency("FR"), config)
+    widget.data_struct.sample_rate = 48000
+    widget.data_struct.stimulus_data = np.ones(3, dtype=np.float32)
+    widget.data_struct.stimulus_info = dict(config)
+
+    class FakeFrequencyResponseAnalyzer:
+        def __init__(self, sample_rate):
+            pass
+
+        def compute(self, stimulus_signal, recorded_signal, *, stimulus_metadata, method):
+            return types.SimpleNamespace(
+                frequencies_hz=np.asarray(measured_x, dtype=float),
+                magnitude_db=np.asarray(measured_y, dtype=float),
+            )
+
+    monkeypatch.setattr(saw, "FrequencyResponseAnalyzer", FakeFrequencyResponseAnalyzer)
+    return widget, widget.calculate_fr
 
 
 @pytest.mark.parametrize("golden_case", ["missing_file", "missing_field", "no_overlap"])
@@ -427,13 +533,75 @@ def test_spl_time_domain_manual_segments_drive_limit_arrays_and_out_of_range(
 
     assert result is not False
     setup = captured_limit_utils["setup"][-1]
-    np.testing.assert_allclose(setup["csv_x"], [0.0, 0.1, 0.2])
-    assert np.isnan(setup["csv_upper"][0])
-    np.testing.assert_allclose(setup["csv_upper"][1:], [8.0, 8.0])
+    np.testing.assert_allclose(setup["csv_x"], [0.0, 0.2])
+    np.testing.assert_allclose(setup["csv_upper"], [8.0, 8.0])
     assert np.all(np.isnan(setup["csv_lower"]))
+    comparison = captured_limit_utils["compare"][-1]
+    np.testing.assert_allclose(comparison["upper_limits"][1:], [8.0, 8.0])
+    assert np.isnan(comparison["upper_limits"][0])
+    assert np.isnan(comparison["lower_limits"]).all()
     out = captured_limit_utils["out"][-1]
     assert out["out_mask"].tolist() == [False, True, False]
     assert widget.data_struct.analysis_result_dict["SPL"] == (False, 4.0)
+
+
+def test_time_spl_exact_plot_endpoints_keep_measured_judgment_and_linear_geometry(
+    qapp, monkeypatch, captured_limit_utils
+):
+    config = _manual_upper_config(
+        [
+            {"start_x": 0.09, "start_y": 8.0, "end_x": 0.100, "end_y": 8.0},
+            {"start_x": 0.101, "start_y": 7.0, "end_x": 0.120, "end_y": 7.0},
+        ]
+    )
+    config.update({"analysis_channel": 0, "weighting": "Z", "smooth_checked": False})
+    widget = _recording_widget(saw.Spl("SPL"), config)
+    widget.data_struct.sample_rate = 2000
+    widget.data_struct.store_wave_data = np.ones(41, dtype=np.float32)
+    monkeypatch.setattr(widget, "_resolve_v2pa_factor_for_analysis", lambda: True)
+    monkeypatch.setattr(
+        widget,
+        "_apply_spl_analysis_time_range",
+        lambda recorded_signal, sample_rate: (recorded_signal, 180),
+    )
+
+    def spl_calculation(self, recorded_signal, reference_pressure=20e-6, **kwargs):
+        spl_values = np.full(41, 6.0)
+        spl_values[21] = 9.0
+        return spl_values
+
+    manual_plot_calls = []
+    original_manual_limit_plot_data = saw.manual_limit_plot_data
+
+    def capture_manual_limit_plot_data(config_arg, **kwargs):
+        manual_plot_calls.append(kwargs)
+        return original_manual_limit_plot_data(config_arg, **kwargs)
+
+    monkeypatch.setattr(saw.AudioThdFrequencyResponseAnalysis, "spl_calculation", spl_calculation)
+    monkeypatch.setattr(saw, "manual_limit_plot_data", capture_manual_limit_plot_data)
+
+    result = widget.calculate_spl()
+
+    assert result is not False
+    setup = captured_limit_utils["setup"][-1]
+    np.testing.assert_allclose(setup["csv_x"], [0.09, 0.100, 0.101, 0.120])
+    np.testing.assert_allclose(setup["csv_upper"], [8.0, 8.0, 7.0, 7.0])
+    assert np.isnan(setup["csv_lower"]).all()
+    assert setup["kwargs"]["log_x"] is False
+
+    comparison = captured_limit_utils["compare"][-1]
+    measured_time = np.asarray(result["signal_duration"], dtype=float)
+    expected_spl = np.full(41, 6.0)
+    expected_spl[21] = 9.0
+    np.testing.assert_allclose(comparison["plot_y"], expected_spl)
+    assert comparison["upper_limits"].shape == measured_time.shape
+    gap_index = int(np.flatnonzero(np.isclose(measured_time, 0.1005))[0])
+    assert gap_index == 21
+    assert comparison["upper_limits"][gap_index] == pytest.approx(7.5)
+    assert comparison["valid_mask"][gap_index]
+    assert captured_limit_utils["out"][-1]["out_mask"][gap_index]
+    assert widget.data_struct.analysis_result_dict["SPL"] == pytest.approx((False, 1.5))
+    assert manual_plot_calls[-1]["positive_x_support"] is None
 
 
 def test_spl_frequency_manual_segments_with_gaps_drive_interp_check_and_out_of_range(
@@ -632,6 +800,313 @@ def test_frequency_response_manual_segments_stay_aligned_for_unsorted_analyzer_o
     assert widget.data_struct.analysis_result_dict["FR"] == (False, 2.0)
 
 
+@pytest.mark.parametrize(
+    "display_config",
+    [
+        {},
+        {
+            "golden_sample_checked": True,
+            "golden_sample_display_mode": "deviation",
+        },
+    ],
+    ids=["normal", "deviation"],
+)
+def test_splf_exact_plot_endpoints_keep_connector_judgment(
+    qapp,
+    monkeypatch,
+    captured_limit_utils,
+    tmp_path,
+    display_config,
+):
+    measured_x = np.array([50.0, 100.0, 100.05, 110.0, 1000.0])
+    config = _frequency_analysis_config(_manual_upper_config(_exact_gap_segments()))
+    config.update(display_config)
+    if display_config:
+        golden_path = tmp_path / "splf_deviation_golden.json"
+        golden_path.write_text(
+            json.dumps(
+                {
+                    "items": {
+                        "SPLF": {
+                            "result": {
+                                "frequency_list": measured_x.tolist(),
+                                "spl_db": np.zeros(measured_x.size).tolist(),
+                            }
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        config["golden_sample_result_path"] = str(golden_path)
+    monkeypatch.setattr(saw.MessageBox, "warning", lambda *args: None)
+    widget, calculate = _frequency_analysis_widget(
+        monkeypatch,
+        "splf",
+        config,
+        measured_x,
+        np.array([0.0, 0.0, 100.0, 0.0, 0.0]),
+    )
+
+    result = calculate()
+
+    assert result is not False
+    setup = captured_limit_utils["setup"][-1]
+    np.testing.assert_allclose(setup["csv_x"], [50.0, 100.0, 100.1, 1000.0])
+    np.testing.assert_allclose(setup["csv_upper"], [4.0, 4.0, 3.0, 3.0])
+    assert np.isnan(setup["csv_lower"]).all()
+    check = captured_limit_utils["check"][-1]
+    np.testing.assert_allclose(check["csv_x"], measured_x)
+    np.testing.assert_allclose(
+        check["csv_upper"],
+        [np.nan, 4.0, 3.5, 3.0, 3.0],
+        equal_nan=True,
+    )
+    out_mask, _plot_x, _plot_y, deviation, is_ok = check["result"]
+    assert out_mask.tolist() == [False, False, True, False, False]
+    assert deviation == pytest.approx(96.5)
+    assert is_ok is False
+    assert widget.data_struct.analysis_result_dict["SPLF"] == pytest.approx((False, 96.5))
+
+
+@pytest.mark.parametrize(
+    "display_config",
+    [
+        {},
+        {
+            "golden_sample_checked": True,
+            "golden_sample_display_mode": "deviation",
+        },
+    ],
+    ids=["normal", "deviation"],
+)
+def test_fr_exact_plot_endpoints_keep_connector_judgment(
+    qapp,
+    monkeypatch,
+    captured_limit_utils,
+    tmp_path,
+    display_config,
+):
+    measured_x = np.array([50.0, 100.0, 100.05, 110.0, 1000.0])
+    config = _frequency_analysis_config(_manual_upper_config(_exact_gap_segments()))
+    config.update(display_config)
+    if display_config:
+        golden_path = tmp_path / "fr_deviation_golden.json"
+        golden_path.write_text(
+            json.dumps(
+                {
+                    "items": {
+                        "FR": {
+                            "result": {
+                                "frequency_list": measured_x.tolist(),
+                                "fr": np.zeros(measured_x.size).tolist(),
+                            }
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        config["golden_sample_result_path"] = str(golden_path)
+    monkeypatch.setattr(saw.MessageBox, "warning", lambda *args: None)
+    widget, calculate = _frequency_analysis_widget(
+        monkeypatch,
+        "fr",
+        config,
+        measured_x,
+        np.array([0.0, 0.0, 100.0, 0.0, 0.0]),
+    )
+
+    result = calculate()
+
+    assert result is not False
+    setup = captured_limit_utils["setup"][-1]
+    np.testing.assert_allclose(setup["csv_x"], [50.0, 100.0, 100.1, 1000.0])
+    np.testing.assert_allclose(setup["csv_upper"], [4.0, 4.0, 3.0, 3.0])
+    assert np.isnan(setup["csv_lower"]).all()
+    check = captured_limit_utils["check"][-1]
+    np.testing.assert_allclose(check["csv_x"], measured_x)
+    np.testing.assert_allclose(
+        check["csv_upper"],
+        [np.nan, 4.0, 3.5, 3.0, 3.0],
+        equal_nan=True,
+    )
+    out_mask, _plot_x, _plot_y, deviation, is_ok = check["result"]
+    assert out_mask.tolist() == [False, False, True, False, False]
+    assert deviation == pytest.approx(96.5)
+    assert is_ok is False
+    assert widget.data_struct.analysis_result_dict["FR"] == pytest.approx((False, 96.5))
+
+
+@pytest.mark.parametrize("analysis_kind", ["splf", "fr"])
+def test_splf_fr_manual_envelope_uses_exact_geometry_without_extrapolation(
+    qapp,
+    monkeypatch,
+    captured_limit_utils,
+    tmp_path,
+    analysis_kind,
+):
+    measured_x = np.array([50.0, 100.0, 100.05, 110.0, 1000.0])
+    baseline = np.array([10.0, 12.0, 12.5, 13.0, 14.0])
+    title = "SPLF" if analysis_kind == "splf" else "FR"
+    baseline_key = "spl_db" if analysis_kind == "splf" else "fr"
+    golden_path = tmp_path / f"{analysis_kind}_golden.json"
+    golden_path.write_text(
+        json.dumps(
+            {
+                "items": {
+                    title: {
+                        "result": {
+                            "frequency_list": measured_x.tolist(),
+                            baseline_key: baseline.tolist(),
+                        }
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    segments = [
+        {"start_x": 40.0, "start_y": 4.0, "end_x": 100.0, "end_y": 4.0},
+        {"start_x": 100.1, "start_y": 3.0, "end_x": 1100.0, "end_y": 3.0},
+    ]
+    config = _frequency_analysis_config(_manual_upper_config(segments))
+    config.update(
+        {
+            "golden_sample_checked": True,
+            "golden_sample_display_mode": "envelope",
+            "golden_sample_result_path": str(golden_path),
+        }
+    )
+    measured_y = baseline.copy()
+    measured_y[2] += 100.0
+    widget, calculate = _frequency_analysis_widget(
+        monkeypatch,
+        analysis_kind,
+        config,
+        measured_x,
+        measured_y,
+    )
+
+    result = calculate()
+
+    assert result is not False
+    setup = captured_limit_utils["setup"][-1]
+    np.testing.assert_allclose(
+        setup["csv_x"],
+        [40.0, 50.0, 100.0, 100.05, 100.1, 110.0, 1000.0, 1100.0],
+    )
+    assert np.isnan(setup["csv_upper"][[0, -1]]).all()
+    endpoint_index = setup["csv_x"].tolist().index(100.1)
+    assert setup["csv_upper"][endpoint_index] == pytest.approx(
+        np.interp(100.1, measured_x, baseline) + 3.0
+    )
+    comparison = captured_limit_utils["compare"][-1]
+    np.testing.assert_allclose(
+        comparison["upper_limits"],
+        [4.0, 4.0, 3.5, 3.0, 3.0],
+        equal_nan=True,
+    )
+    out_mask, deviation, is_ok = comparison["result"]
+    assert out_mask.tolist() == [False, False, True, False, False]
+    assert deviation == pytest.approx(96.5)
+    assert is_ok is False
+    assert captured_limit_utils["out"][-1]["out_mask"].tolist() == [
+        False,
+        False,
+        True,
+        False,
+        False,
+    ]
+    assert widget.data_struct.analysis_result_dict[title] == pytest.approx((False, 96.5))
+
+
+@pytest.mark.parametrize("analysis_kind", ["splf", "fr"])
+def test_splf_fr_zero_start_clips_plot_only_and_keeps_measured_judgment(
+    qapp,
+    monkeypatch,
+    captured_limit_utils,
+    analysis_kind,
+):
+    measured_x = np.array([0.0, 10.0, 20.0, 30.0])
+    config = _frequency_analysis_config(
+        _manual_upper_config(
+            [{"start_x": 0.0, "start_y": 0.0, "end_x": 20.0, "end_y": 20.0}]
+        )
+    )
+    manual_plot_calls = []
+    original_manual_limit_plot_data = saw.manual_limit_plot_data
+
+    def capture_manual_limit_plot_data(config_arg, **kwargs):
+        manual_plot_calls.append(kwargs)
+        return original_manual_limit_plot_data(config_arg, **kwargs)
+
+    monkeypatch.setattr(saw, "manual_limit_plot_data", capture_manual_limit_plot_data)
+    widget, calculate = _frequency_analysis_widget(
+        monkeypatch,
+        analysis_kind,
+        config,
+        measured_x,
+        np.array([100.0, 0.0, 0.0, 100.0]),
+    )
+
+    result = calculate()
+
+    assert result is not False
+    setup = captured_limit_utils["setup"][-1]
+    np.testing.assert_allclose(setup["csv_x"], [10.0, 20.0])
+    np.testing.assert_allclose(setup["csv_upper"], [10.0, 20.0])
+    assert np.isnan(setup["csv_lower"]).all()
+    check = captured_limit_utils["check"][-1]
+    np.testing.assert_allclose(check["csv_x"], [10.0, 20.0, 30.0])
+    np.testing.assert_allclose(
+        check["csv_upper"],
+        [10.0, 20.0, np.nan],
+        equal_nan=True,
+    )
+    np.testing.assert_allclose(
+        manual_plot_calls[-1]["positive_x_support"],
+        [10.0, 20.0, 30.0],
+    )
+
+
+@pytest.mark.parametrize("analysis_kind", ["splf", "fr"])
+def test_splf_fr_zero_start_plot_support_keeps_x_with_nonfinite_y(
+    qapp,
+    monkeypatch,
+    captured_limit_utils,
+    analysis_kind,
+):
+    measured_x = np.array([10.0, 20.0, 40.0])
+    config = _frequency_analysis_config(
+        _manual_upper_config(
+            [{"start_x": 0.0, "start_y": 0.0, "end_x": 30.0, "end_y": 30.0}]
+        )
+    )
+    widget, calculate = _frequency_analysis_widget(
+        monkeypatch,
+        analysis_kind,
+        config,
+        measured_x,
+        np.array([np.nan, 1.0, 1.0]),
+    )
+
+    result = calculate()
+
+    assert result is not False
+    setup = captured_limit_utils["setup"][-1]
+    np.testing.assert_allclose(setup["csv_x"], [10.0, 30.0])
+    np.testing.assert_allclose(setup["csv_upper"], [10.0, 30.0])
+    assert np.isnan(setup["csv_lower"]).all()
+    check = captured_limit_utils["check"][-1]
+    np.testing.assert_allclose(check["csv_x"], [20.0, 40.0])
+    np.testing.assert_allclose(
+        check["csv_upper"],
+        [20.0, np.nan],
+        equal_nan=True,
+    )
+
+
 def test_distortion_plot_graph_uses_manual_segments_for_out_of_range_highlight(
     qapp, captured_limit_utils
 ):
@@ -647,11 +1122,69 @@ def test_distortion_plot_graph_uses_manual_segments_for_out_of_range_highlight(
     )
 
     setup = captured_limit_utils["setup"][-1]
-    np.testing.assert_allclose(setup["csv_x"], [100.0, 200.0, 300.0])
-    _assert_upper_with_gap(setup["csv_upper"], 10.0)
+    np.testing.assert_allclose(setup["csv_x"], [100.0, 250.0])
+    np.testing.assert_allclose(setup["csv_upper"], [10.0, 10.0])
+    assert np.isnan(setup["csv_lower"]).all()
     out = captured_limit_utils["out"][-1]
     assert out["out_mask"].tolist() == [False, True, False]
     assert widget.data_struct.analysis_result_dict["HD"] == (False, 2.0)
+
+
+@pytest.mark.parametrize(
+    "display_config",
+    [
+        {},
+        {
+            "golden_sample_checked": True,
+            "golden_sample_display_mode": "deviation",
+        },
+    ],
+    ids=["normal", "deviation"],
+)
+@pytest.mark.parametrize(
+    ("widget_class", "title"),
+    [
+        (saw.Distortion, "HD"),
+        (saw.RubAndBuzz, "RB"),
+    ],
+)
+def test_hd_rb_exact_plot_endpoints_keep_connector_judgment(
+    qapp,
+    captured_limit_utils,
+    display_config,
+    widget_class,
+    title,
+):
+    widget = widget_class(title)
+    config = _manual_upper_config(_exact_gap_segments())
+    config.update(display_config)
+    judgment = _capture_highlight_judgment(widget)
+    measured_x = np.array([50.0, 100.0, 100.05, 110.0, 1000.0])
+
+    widget.plot_graph(
+        measured_x,
+        np.array([0.0, 0.0, 100.0, 0.0, 0.0]),
+        config,
+    )
+
+    setup = captured_limit_utils["setup"][-1]
+    np.testing.assert_allclose(setup["csv_x"], [50.0, 100.0, 100.1, 1000.0])
+    np.testing.assert_allclose(setup["csv_upper"], [4.0, 4.0, 3.0, 3.0])
+    assert np.isnan(setup["csv_lower"]).all()
+    np.testing.assert_allclose(judgment["limit_x"], measured_x)
+    np.testing.assert_allclose(
+        judgment["upper"],
+        [np.nan, 4.0, 3.5, 3.0, 3.0],
+        equal_nan=True,
+    )
+    assert captured_limit_utils["out"][-1]["out_mask"].tolist() == [
+        False,
+        False,
+        True,
+        False,
+        False,
+    ]
+    assert widget.data_struct.analysis_result_dict[title] == pytest.approx((False, 96.5))
 
 
 def test_distortion_plot_graph_csv_passing_margin_preserves_legacy_limit_behavior(
@@ -731,28 +1264,26 @@ def test_distortion_plot_graph_csv_lower_only_margin_preserves_legacy_nan_side(
     assert np.isnan(deviation)
 
 
-def test_distortion_plot_graph_manual_gap_keeps_passing_deviation_finite(
+def test_distortion_plot_graph_connector_sample_sets_passing_margin(
     qapp, captured_limit_utils
 ):
     widget = saw.Distortion("HD")
-    config = _manual_upper_config(
-        [{"start_x": 400.0, "start_y": 10.0, "end_x": 500.0, "end_y": 10.0}]
-    )
+    config = _manual_upper_config(_exact_gap_segments())
+    judgment = _capture_highlight_judgment(widget)
 
     widget.plot_graph(
-        np.array([100.0, 200.0, 300.0]),
-        np.array([1.0, 2.0, 3.0]),
+        np.array([100.0, 100.05, 110.0]),
+        np.array([0.0, 3.25, 0.0]),
         config,
     )
 
     setup = captured_limit_utils["setup"][-1]
-    assert np.all(np.isnan(setup["csv_upper"]))
+    np.testing.assert_allclose(setup["csv_x"], [50.0, 100.0, 100.1, 1000.0])
+    np.testing.assert_allclose(setup["csv_upper"], [4.0, 4.0, 3.0, 3.0])
     out = captured_limit_utils["out"][-1]
+    assert judgment["upper"][1] == pytest.approx(3.5)
     assert out["out_mask"].tolist() == [False, False, False]
-    is_ok, deviation = widget.data_struct.analysis_result_dict["HD"]
-    assert is_ok is True
-    assert deviation == 0.0
-    assert np.isfinite(deviation)
+    assert widget.data_struct.analysis_result_dict["HD"] == pytest.approx((True, 0.25))
 
 
 @pytest.mark.parametrize("nonfinite_y", [np.nan, np.inf])
@@ -794,8 +1325,8 @@ def test_distortion_plot_graph_passing_margin_ignores_uncovered_manual_points(
     )
 
     setup = captured_limit_utils["setup"][-1]
-    assert np.isnan(setup["csv_upper"][0])
-    assert setup["csv_upper"][1] == pytest.approx(10.0)
+    np.testing.assert_allclose(setup["csv_x"], [100.0, 250.0])
+    np.testing.assert_allclose(setup["csv_upper"], [10.0, 10.0])
     out = captured_limit_utils["out"][-1]
     assert out["out_mask"].tolist() == [False, False]
     assert widget.data_struct.analysis_result_dict["HD"] == (True, 2.0)
@@ -816,35 +1347,186 @@ def test_perceptual_rub_and_buzz_plot_graph_uses_manual_segments_for_out_of_rang
     )
 
     setup = captured_limit_utils["setup"][-1]
-    np.testing.assert_allclose(setup["csv_x"], [100.0, 200.0, 300.0])
-    _assert_upper_with_gap(setup["csv_upper"], 10.0)
+    np.testing.assert_allclose(setup["csv_x"], [100.0, 250.0])
+    np.testing.assert_allclose(setup["csv_upper"], [10.0, 10.0])
+    assert np.isnan(setup["csv_lower"]).all()
     out = captured_limit_utils["out"][-1]
     assert out["out_mask"].tolist() == [False, True, False]
     assert widget.data_struct.analysis_result_dict["PRB"] == (False, 2.0)
 
 
-def test_perceptual_rub_and_buzz_plot_graph_manual_gap_keeps_passing_deviation_finite(
-    qapp, captured_limit_utils
+@pytest.mark.parametrize(
+    "display_config",
+    [
+        {},
+        {
+            "golden_sample_checked": True,
+            "golden_sample_display_mode": "deviation",
+        },
+    ],
+    ids=["normal", "deviation"],
+)
+def test_perceptual_exact_plot_endpoints_keep_connector_judgment(
+    qapp,
+    captured_limit_utils,
+    display_config,
 ):
     widget = saw.PerceptualRubAndBuzz("PRB")
-    config = _manual_upper_config(
-        [{"start_x": 400.0, "start_y": 10.0, "end_x": 500.0, "end_y": 10.0}]
-    )
+    config = _manual_upper_config(_exact_gap_segments())
+    config.update(display_config)
+    judgment = _capture_highlight_judgment(widget)
+    measured_x = np.array([50.0, 100.0, 100.05, 110.0, 1000.0])
 
     widget.plot_graph(
-        np.array([100.0, 200.0, 300.0]),
-        np.array([1.0, 2.0, 3.0]),
+        measured_x,
+        np.array([0.0, 0.0, 100.0, 0.0, 0.0]),
         config,
     )
 
     setup = captured_limit_utils["setup"][-1]
-    assert np.all(np.isnan(setup["csv_upper"]))
+    np.testing.assert_allclose(setup["csv_x"], [50.0, 100.0, 100.1, 1000.0])
+    np.testing.assert_allclose(setup["csv_upper"], [4.0, 4.0, 3.0, 3.0])
+    assert np.isnan(setup["csv_lower"]).all()
+    np.testing.assert_allclose(judgment["limit_x"], measured_x)
+    np.testing.assert_allclose(
+        judgment["upper"],
+        [np.nan, 4.0, 3.5, 3.0, 3.0],
+        equal_nan=True,
+    )
+    assert captured_limit_utils["out"][-1]["out_mask"].tolist() == [
+        False,
+        False,
+        True,
+        False,
+        False,
+    ]
+    assert widget.data_struct.analysis_result_dict["PRB"] == pytest.approx((False, 96.5))
+
+
+@pytest.mark.parametrize(
+    ("widget_class", "title"),
+    [
+        (saw.Distortion, "HD"),
+        (saw.RubAndBuzz, "RB"),
+        (saw.PerceptualRubAndBuzz, "PRB"),
+    ],
+)
+def test_hd_rb_manual_envelope_uses_endpoint_geometry_but_measured_judgment(
+    qapp,
+    captured_limit_utils,
+    widget_class,
+    title,
+):
+    widget = widget_class(title)
+    config = _manual_upper_config(_exact_gap_segments())
+    config.update(
+        {
+            "golden_sample_checked": True,
+            "golden_sample_display_mode": "envelope",
+        }
+    )
+    judgment = _capture_highlight_judgment(widget)
+    measured_x = np.array([50.0, 100.0, 100.05, 110.0, 1000.0])
+    baseline = np.array([10.0, 12.0, 12.5, 13.0, 14.0])
+
+    widget.plot_graph(
+        measured_x,
+        np.array([0.0, 0.0, 100.0, 0.0, 0.0]),
+        config,
+        raw_y=baseline,
+        baseline_aligned=baseline,
+    )
+
+    setup = captured_limit_utils["setup"][-1]
+    np.testing.assert_allclose(
+        setup["csv_x"],
+        [50.0, 100.0, 100.05, 100.1, 110.0, 1000.0],
+    )
+    endpoint_index = setup["csv_x"].tolist().index(100.1)
+    assert setup["csv_upper"][endpoint_index] == pytest.approx(
+        np.interp(100.1, measured_x, baseline) + 3.0
+    )
+    np.testing.assert_allclose(judgment["limit_x"], measured_x)
+    np.testing.assert_allclose(
+        judgment["upper"],
+        [np.nan, 4.0, 3.5, 3.0, 3.0],
+        equal_nan=True,
+    )
+    assert captured_limit_utils["out"][-1]["out_mask"].tolist() == [
+        False,
+        False,
+        True,
+        False,
+        False,
+    ]
+    assert widget.data_struct.analysis_result_dict[title] == pytest.approx((False, 96.5))
+
+
+@pytest.mark.parametrize(
+    ("widget_class", "title"),
+    [
+        (saw.Distortion, "HD"),
+        (saw.PerceptualRubAndBuzz, "PRB"),
+    ],
+)
+def test_hd_rb_zero_start_clips_plot_only_and_keeps_measured_judgment(
+    qapp,
+    captured_limit_utils,
+    widget_class,
+    title,
+):
+    widget = widget_class(title)
+    config = _manual_upper_config(
+        [{"start_x": 0.0, "start_y": 0.0, "end_x": 20.0, "end_y": 20.0}]
+    )
+    judgment = _capture_highlight_judgment(widget)
+    measured_x = np.array([0.0, 10.0, 20.0, 30.0])
+
+    widget.plot_graph(
+        measured_x,
+        np.array([100.0, 0.0, 0.0, 100.0]),
+        config,
+    )
+
+    setup = captured_limit_utils["setup"][-1]
+    np.testing.assert_allclose(setup["csv_x"], [10.0, 20.0])
+    np.testing.assert_allclose(setup["csv_upper"], [10.0, 20.0])
+    assert np.isnan(setup["csv_lower"]).all()
+    np.testing.assert_allclose(judgment["limit_x"], measured_x)
+    np.testing.assert_allclose(
+        judgment["upper"],
+        [np.nan, 10.0, 20.0, np.nan],
+        equal_nan=True,
+    )
+    assert captured_limit_utils["out"][-1]["out_mask"].tolist() == [
+        False,
+        False,
+        False,
+        False,
+    ]
+    assert widget.data_struct.analysis_result_dict[title] == (True, 10.0)
+
+
+def test_perceptual_rub_and_buzz_plot_graph_connector_sample_sets_passing_margin(
+    qapp, captured_limit_utils
+):
+    widget = saw.PerceptualRubAndBuzz("PRB")
+    config = _manual_upper_config(_exact_gap_segments())
+    judgment = _capture_highlight_judgment(widget)
+
+    widget.plot_graph(
+        np.array([100.0, 100.05, 110.0]),
+        np.array([0.0, 3.25, 0.0]),
+        config,
+    )
+
+    setup = captured_limit_utils["setup"][-1]
+    np.testing.assert_allclose(setup["csv_x"], [50.0, 100.0, 100.1, 1000.0])
+    np.testing.assert_allclose(setup["csv_upper"], [4.0, 4.0, 3.0, 3.0])
     out = captured_limit_utils["out"][-1]
+    assert judgment["upper"][1] == pytest.approx(3.5)
     assert out["out_mask"].tolist() == [False, False, False]
-    is_ok, deviation = widget.data_struct.analysis_result_dict["PRB"]
-    assert is_ok is True
-    assert deviation == 0.0
-    assert np.isfinite(deviation)
+    assert widget.data_struct.analysis_result_dict["PRB"] == pytest.approx((True, 0.25))
 
 
 @pytest.mark.parametrize("nonfinite_y", [np.nan, np.inf])
@@ -886,8 +1568,8 @@ def test_perceptual_rub_and_buzz_passing_margin_ignores_uncovered_manual_points(
     )
 
     setup = captured_limit_utils["setup"][-1]
-    assert np.isnan(setup["csv_upper"][0])
-    assert setup["csv_upper"][1] == pytest.approx(10.0)
+    np.testing.assert_allclose(setup["csv_x"], [100.0, 250.0])
+    np.testing.assert_allclose(setup["csv_upper"], [10.0, 10.0])
     out = captured_limit_utils["out"][-1]
     assert out["out_mask"].tolist() == [False, False]
     assert widget.data_struct.analysis_result_dict["PRB"] == (True, 2.0)

--- a/unit_test/ui/test_manual_limit_segments.py
+++ b/unit_test/ui/test_manual_limit_segments.py
@@ -10,10 +10,262 @@ from consts.acoustic_analysis.common_consts import LIMIT_VALUE_SEMANTICS_OFFSET
 from ui.ui_analysis_config.manual_limit_segments import (
     ManualLimitValidationError,
     limits_from_manual_segments,
+    manual_limit_plot_data,
     normalize_segments,
     validate_manual_limit_config,
     validate_manual_segments,
 )
+
+
+def test_manual_plot_geometry_uses_exact_gap_endpoints():
+    config = {
+        "manual_upper_enabled": True,
+        "manual_lower_enabled": False,
+        "manual_upper_segments": [
+            {"start_x": 50.0, "start_y": 4.0, "end_x": 100.0, "end_y": 4.0},
+            {"start_x": 100.1, "start_y": 3.0, "end_x": 1000.0, "end_y": 3.0},
+        ],
+    }
+
+    x_values, upper, lower = manual_limit_plot_data(config)
+
+    assert x_values == [50.0, 100.0, 100.1, 1000.0]
+    assert upper == [4.0, 4.0, 3.0, 3.0]
+    assert np.isnan(lower).all()
+
+
+def test_manual_plot_geometry_keeps_duplicate_shared_boundary():
+    config = {
+        "manual_upper_enabled": True,
+        "manual_lower_enabled": False,
+        "manual_upper_segments": [
+            {"start_x": 50.0, "start_y": 4.0, "end_x": 100.0, "end_y": 4.0},
+            {"start_x": 100.0, "start_y": 3.0, "end_x": 1000.0, "end_y": 3.0},
+        ],
+    }
+
+    x_values, upper, lower = manual_limit_plot_data(config)
+
+    assert x_values == [50.0, 100.0, 100.0, 1000.0]
+    assert upper == [4.0, 4.0, 3.0, 3.0]
+    assert np.isnan(lower).all()
+
+
+def test_manual_plot_geometry_preserves_sloped_segment_endpoints():
+    config = {
+        "manual_upper_enabled": True,
+        "manual_lower_enabled": False,
+        "manual_upper_segments": [
+            {"start_x": 1.0, "start_y": 2.0, "end_x": 3.0, "end_y": 4.0},
+        ],
+    }
+
+    x_values, upper, lower = manual_limit_plot_data(config)
+
+    assert x_values == [1.0, 3.0]
+    assert upper == [2.0, 4.0]
+    assert np.isnan(lower).all()
+
+
+def test_manual_plot_geometry_keeps_sides_independent():
+    config = {
+        "manual_upper_enabled": True,
+        "manual_lower_enabled": True,
+        "manual_upper_segments": [
+            {"start_x": 1.0, "start_y": 2.0, "end_x": 3.0, "end_y": 4.0},
+        ],
+        "manual_lower_segments": [
+            {"start_x": 1.0, "start_y": -2.0, "end_x": 3.0, "end_y": -4.0},
+        ],
+    }
+
+    x_values, upper, lower = manual_limit_plot_data(config)
+
+    np.testing.assert_allclose(
+        x_values, [1.0, 3.0, np.nan, 1.0, 3.0], equal_nan=True
+    )
+    np.testing.assert_allclose(
+        upper, [2.0, 4.0, np.nan, np.nan, np.nan], equal_nan=True
+    )
+    np.testing.assert_allclose(
+        lower, [np.nan, np.nan, np.nan, -2.0, -4.0], equal_nan=True
+    )
+
+
+def test_manual_plot_geometry_omits_explicitly_disabled_side():
+    config = {
+        "manual_upper_enabled": False,
+        "manual_lower_enabled": True,
+        "manual_upper_segments": [
+            {"start_x": 1.0, "start_y": 20.0, "end_x": 3.0, "end_y": 40.0},
+        ],
+        "manual_lower_segments": [
+            {"start_x": 1.0, "start_y": -2.0, "end_x": 3.0, "end_y": -4.0},
+        ],
+    }
+
+    x_values, upper, lower = manual_limit_plot_data(config)
+
+    assert x_values == [1.0, 3.0]
+    assert np.isnan(upper).all()
+    assert lower == [-2.0, -4.0]
+
+
+def test_manual_plot_geometry_clips_zero_start_to_positive_support():
+    config = {
+        "manual_upper_enabled": True,
+        "manual_lower_enabled": False,
+        "manual_upper_segments": [
+            {"start_x": 0.0, "start_y": 0.0, "end_x": 20.0, "end_y": 20.0},
+        ],
+    }
+
+    x_values, upper, _ = manual_limit_plot_data(
+        config,
+        positive_x_support=[10.0, 50.0, 100.0],
+    )
+
+    assert x_values == [10.0, 20.0]
+    assert upper == pytest.approx([10.0, 20.0])
+
+
+def test_manual_plot_geometry_omits_zero_start_segment_without_positive_support():
+    config = {
+        "manual_upper_enabled": True,
+        "manual_lower_enabled": False,
+        "manual_upper_segments": [
+            {"start_x": 0.0, "start_y": 0.0, "end_x": 20.0, "end_y": 20.0},
+        ],
+    }
+
+    x_values, upper, lower = manual_limit_plot_data(
+        config,
+        positive_x_support=[50.0, 100.0],
+    )
+
+    assert x_values == []
+    assert upper == []
+    assert lower == []
+
+
+def test_manual_plot_geometry_does_not_bridge_across_omitted_segment():
+    config = {
+        "manual_upper_enabled": True,
+        "manual_lower_enabled": False,
+        "manual_upper_segments": [
+            {"start_x": 0.0, "start_y": 0.0, "end_x": 20.0, "end_y": 20.0},
+            {"start_x": 30.0, "start_y": 3.0, "end_x": 40.0, "end_y": 3.0},
+        ],
+    }
+
+    x_values, upper, _ = manual_limit_plot_data(
+        config,
+        positive_x_support=[30.0, 40.0],
+    )
+
+    assert x_values == [30.0, 40.0]
+    assert upper == [3.0, 3.0]
+
+
+def test_manual_plot_geometry_connects_clipped_segment_to_next_segment():
+    config = {
+        "manual_upper_enabled": True,
+        "manual_lower_enabled": False,
+        "manual_upper_segments": [
+            {"start_x": 0.0, "start_y": 0.0, "end_x": 20.0, "end_y": 20.0},
+            {"start_x": 20.0, "start_y": 5.0, "end_x": 40.0, "end_y": 5.0},
+        ],
+    }
+
+    x_values, upper, _ = manual_limit_plot_data(
+        config,
+        positive_x_support=[10.0, 20.0, 30.0, 40.0],
+    )
+
+    assert x_values == [10.0, 20.0, 20.0, 40.0]
+    assert upper == pytest.approx([10.0, 20.0, 5.0, 5.0])
+
+
+def test_manual_limit_gap_connector_uses_left_open_right_closed_linear_threshold():
+    config = {
+        "manual_upper_enabled": True,
+        "manual_lower_enabled": False,
+        "manual_upper_segments": [
+            {"start_x": 50.0, "start_y": 4.0, "end_x": 100.0, "end_y": 4.0},
+            {"start_x": 100.1, "start_y": 3.0, "end_x": 1000.0, "end_y": 3.0},
+        ],
+    }
+
+    x_values, upper, lower = limits_from_manual_segments(
+        config,
+        [50.0, 100.0, 100.025, 100.05, 100.1, 100.101, 1000.0, 1000.1],
+    )
+
+    assert x_values == [
+        50.0,
+        100.0,
+        100.025,
+        100.05,
+        100.1,
+        100.101,
+        1000.0,
+        1000.1,
+    ]
+    np.testing.assert_allclose(
+        upper,
+        [np.nan, 4.0, 3.75, 3.5, 3.0, 3.0, 3.0, np.nan],
+        equal_nan=True,
+    )
+    assert np.isnan(lower).all()
+
+
+def test_manual_limit_shared_x_boundary_uses_previous_then_next_segment():
+    config = {
+        "manual_upper_enabled": True,
+        "manual_lower_enabled": False,
+        "manual_upper_segments": [
+            {"start_x": 0.0, "start_y": 4.0, "end_x": 1.0, "end_y": 4.0},
+            {"start_x": 1.0, "start_y": 3.0, "end_x": 2.0, "end_y": 3.0},
+        ],
+    }
+
+    _, upper, _ = limits_from_manual_segments(config, [1.0, 1.001])
+
+    assert upper == [4.0, 3.0]
+
+
+def test_manual_limit_lower_only_gap_connector_uses_same_semantics():
+    config = {
+        "manual_upper_enabled": False,
+        "manual_lower_enabled": True,
+        "manual_lower_segments": [
+            {"start_x": 0.0, "start_y": -4.0, "end_x": 1.0, "end_y": -4.0},
+            {"start_x": 2.0, "start_y": -2.0, "end_x": 3.0, "end_y": -2.0},
+        ],
+    }
+
+    _, upper, lower = limits_from_manual_segments(config, [1.0, 1.5, 2.0, 2.5])
+
+    assert np.isnan(upper).all()
+    assert lower == pytest.approx([-4.0, -3.0, -2.0, -2.0])
+
+
+def test_manual_limit_single_segment_has_no_outside_synthetic_coverage():
+    config = {
+        "manual_upper_enabled": True,
+        "manual_lower_enabled": False,
+        "manual_upper_segments": [
+            {"start_x": 1.0, "start_y": 2.0, "end_x": 2.0, "end_y": 4.0},
+        ],
+    }
+
+    _, upper, _ = limits_from_manual_segments(config, [0.5, 1.0, 1.5, 2.0, 2.5])
+
+    np.testing.assert_allclose(
+        upper,
+        [np.nan, np.nan, 3.0, 4.0, np.nan],
+        equal_nan=True,
+    )
 
 
 def test_manual_limit_validation_messages_are_chinese():
@@ -95,6 +347,89 @@ def test_lower_above_upper_detects_left_open_interval_violation():
 
     with pytest.raises(ManualLimitValidationError):
         limits_from_manual_segments(config, np.array([0.5, 1.0]))
+
+
+def test_manual_limit_validation_rejects_lower_above_upper_on_implicit_connector():
+    config = {
+        "manual_upper_enabled": True,
+        "manual_lower_enabled": True,
+        "manual_upper_segments": [
+            {"start_x": 0.0, "start_y": 10.0, "end_x": 10.0, "end_y": 10.0},
+            {"start_x": 30.0, "start_y": 0.0, "end_x": 40.0, "end_y": 0.0},
+        ],
+        "manual_lower_segments": [
+            {"start_x": 15.0, "start_y": 8.0, "end_x": 25.0, "end_y": 8.0},
+        ],
+    }
+
+    with pytest.raises(ManualLimitValidationError, match="下限不能大于上限"):
+        validate_manual_limit_config(config)
+
+
+def test_manual_limit_validation_rejects_connector_to_connector_crossing():
+    config = {
+        "manual_upper_enabled": True,
+        "manual_lower_enabled": True,
+        "manual_upper_segments": [
+            {"start_x": 0.0, "start_y": 10.0, "end_x": 10.0, "end_y": 10.0},
+            {"start_x": 30.0, "start_y": 0.0, "end_x": 40.0, "end_y": 0.0},
+        ],
+        "manual_lower_segments": [
+            {"start_x": 11.0, "start_y": 1.0, "end_x": 15.0, "end_y": 1.0},
+            {"start_x": 25.0, "start_y": 9.0, "end_x": 29.0, "end_y": 9.0},
+        ],
+    }
+
+    with pytest.raises(ManualLimitValidationError, match="下限不能大于上限"):
+        validate_manual_limit_config(config)
+
+
+def test_manual_limit_validation_allows_equality_on_effective_connector():
+    config = {
+        "manual_upper_enabled": True,
+        "manual_lower_enabled": True,
+        "manual_upper_segments": [
+            {"start_x": 0.0, "start_y": 10.0, "end_x": 10.0, "end_y": 10.0},
+            {"start_x": 30.0, "start_y": 0.0, "end_x": 40.0, "end_y": 0.0},
+        ],
+        "manual_lower_segments": [
+            {"start_x": 15.0, "start_y": 7.5, "end_x": 25.0, "end_y": 2.5},
+        ],
+    }
+
+    validate_manual_limit_config(config)
+
+
+def test_manual_limit_validation_ignores_segments_on_disabled_side():
+    config = {
+        "manual_upper_enabled": False,
+        "manual_lower_enabled": True,
+        "manual_upper_segments": [
+            {"start_x": 0.0, "start_y": -10.0, "end_x": 10.0, "end_y": -10.0},
+            {"start_x": 30.0, "start_y": -10.0, "end_x": 40.0, "end_y": -10.0},
+        ],
+        "manual_lower_segments": [
+            {"start_x": 15.0, "start_y": 8.0, "end_x": 25.0, "end_y": 8.0},
+        ],
+    }
+
+    validate_manual_limit_config(config)
+
+
+def test_manual_limit_validation_allows_non_overlapping_effective_coverage():
+    config = {
+        "manual_upper_enabled": True,
+        "manual_lower_enabled": True,
+        "manual_upper_segments": [
+            {"start_x": 0.0, "start_y": 10.0, "end_x": 10.0, "end_y": 10.0},
+            {"start_x": 20.0, "start_y": 0.0, "end_x": 30.0, "end_y": 0.0},
+        ],
+        "manual_lower_segments": [
+            {"start_x": 40.0, "start_y": 100.0, "end_x": 50.0, "end_y": 100.0},
+        ],
+    }
+
+    validate_manual_limit_config(config)
 
 
 def test_negative_first_start_empty_enabled_table_disabled_limits_and_nonfinite_values_fail():


### PR DESCRIPTION
## Summary
- 使用精确手动限值端点绘制曲线，同时保留基于测量采样点的运行时判定
- 支持段间线性连接、共享边界、对数坐标零起点裁剪及黄金样本包络显示
- 补充手动限值几何、配置迁移和运行时回归测试

## Test Plan
- `python -m pytest unit_test/base/test_golden_sample_comparison.py` (21 passed)
- `python -m pytest unit_test/ui/test_analysis_config_dialog_migration.py` (95 passed)
- `python -m pytest --basetemp .codex_pytest_tmp_783_final unit_test/ui/test_manual_limit_runtime.py` (64 passed)
- `python -m pytest unit_test/ui/test_manual_limit_segments.py` (49 passed)
- `git diff --check`

Closes #783