### PR TITLE
chore(gitignore): add Codex skills pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ build/
 *.spec
 .agents/
 .codex
+.codex/skills/
 .worktrees/
 docs/
 ui/ui_src/icon


### PR DESCRIPTION
## Summary

- Add an explicit `.codex/skills/` ignore pattern for repository-local Codex skill files.

## Changes

- `.gitignore`: ignore the Codex skills directory.

## Test Plan

- [x] Ran `git diff --check`.
- [x] Confirmed the commit contains only the `.gitignore` update.
- [x] No runtime tests required for an ignore-only change.