### PR TITLE
US20260805-add-selective-excel-export-outputs

### DIFF
--- a/base/excel_export_selection.py
+++ b/base/excel_export_selection.py
@@ -1,0 +1,273 @@
+"""Pure normalization and availability rules for Excel export selections."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+import numpy as np
+
+from base.golden_sample_comparison import normalize_golden_sample_display_modes
+from consts.acoustic_analysis.common_consts import (
+    GOLDEN_SAMPLE_CHECKED_KEY,
+    GOLDEN_SAMPLE_DISPLAY_DEVIATION,
+)
+from consts.excel_export_consts import (
+    EXCEL_OUTPUT_DEVIATION,
+    EXCEL_OUTPUT_MARGIN,
+    EXCEL_OUTPUT_ORDER,
+    EXCEL_OUTPUT_TEST_CURVE,
+    SAVE_ITEM_OUTPUTS_KEY,
+)
+
+
+def _is_finite_number(value: object) -> bool:
+    if isinstance(value, (bool, np.bool_)):
+        return False
+    try:
+        numeric_value = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return False
+    return math.isfinite(numeric_value)
+
+
+def _iterable_values(value: object) -> tuple[Any, ...] | None:
+    if isinstance(value, (str, bytes, bytearray, Mapping)):
+        return None
+    try:
+        return tuple(iter(value))
+    except TypeError:
+        return None
+
+
+def _has_aligned_finite_pair(x_values: object, side_values: object) -> bool:
+    x_sequence = _iterable_values(x_values)
+    side_sequence = _iterable_values(side_values)
+    if (
+        x_sequence is None
+        or side_sequence is None
+        or not x_sequence
+        or len(x_sequence) != len(side_sequence)
+    ):
+        return False
+    return any(
+        _is_finite_number(x_value) and _is_finite_number(side_value)
+        for x_value, side_value in zip(x_sequence, side_sequence)
+    )
+
+
+def _csv_limit_available(config: Mapping[str, Any]) -> bool:
+    limit_data = config.get("limit_data")
+    if isinstance(limit_data, (str, bytes, bytearray, Mapping)):
+        return False
+    try:
+        x_values, upper_values, lower_values = limit_data
+    except (TypeError, ValueError):
+        return False
+    x_values = _iterable_values(x_values)
+    upper_values = _iterable_values(upper_values)
+    lower_values = _iterable_values(lower_values)
+    return _has_aligned_finite_pair(
+        x_values,
+        upper_values,
+    ) or _has_aligned_finite_pair(x_values, lower_values)
+
+
+def _valid_manual_segment(segment: object) -> bool:
+    if not isinstance(segment, Mapping):
+        return False
+    coordinates = tuple(
+        segment.get(key) for key in ("start_x", "start_y", "end_x", "end_y")
+    )
+    return all(_is_finite_number(value) for value in coordinates) and float(
+        coordinates[2]
+    ) > float(coordinates[0])
+
+
+def _manual_segment_side_available(
+    config: Mapping[str, Any],
+    *,
+    side: str,
+) -> bool:
+    if not bool(config.get(f"manual_{side}_enabled", False)):
+        return False
+    segments = _iterable_values(config.get(f"manual_{side}_segments"))
+    return segments is not None and any(
+        _valid_manual_segment(segment) for segment in segments
+    )
+
+
+def _manual_limit_available(config: Mapping[str, Any]) -> bool:
+    segment_keys = {"manual_upper_segments", "manual_lower_segments"}
+    if segment_keys.intersection(config):
+        return _manual_segment_side_available(
+            config,
+            side="upper",
+        ) or _manual_segment_side_available(config, side="lower")
+
+    return any(
+        bool(config.get(f"manual_{side}_enabled", False))
+        and _is_finite_number(config.get(f"manual_{side}"))
+        for side in ("upper", "lower")
+    )
+
+
+def _current_loudness_limit_available(config: Mapping[str, Any]) -> bool | None:
+    switch_keys = {"curve_upper_enabled", "curve_lower_enabled"}
+    if not switch_keys.intersection(config):
+        return None
+    return any(
+        bool(config.get(f"curve_{side}_enabled", False))
+        and _is_finite_number(config.get(f"curve_{side}_value"))
+        for side in ("upper", "lower")
+    )
+
+
+def _legacy_loudness_limit_available(config: Mapping[str, Any]) -> bool:
+    metric = str(config.get("limit_metric", "") or "").lower()
+    if metric in {"steady_state_average", "mean"}:
+        prefix = "mean"
+    elif metric in {"max_transient", "nmax"}:
+        prefix = "nmax"
+    else:
+        return False
+    return any(
+        bool(config.get(f"{prefix}_{side}_enabled", False))
+        and _is_finite_number(config.get(f"{prefix}_{side}_sone"))
+        for side in ("upper", "lower")
+    )
+
+
+def is_margin_output_available(config: object) -> bool:
+    """Return whether a known enabled limit structure has a finite side."""
+    if not isinstance(config, Mapping):
+        return False
+
+    if "enable_threshold_judgment" in config:
+        return bool(config.get("enable_threshold_judgment")) and any(
+            _is_finite_number(config.get(key))
+            for key in ("upper_offset_db", "lower_offset_db")
+        )
+
+    if not bool(config.get("limit_checked", False)):
+        return False
+
+    if config.get("limit_mode") == "manual":
+        return _manual_limit_available(config)
+
+    current_loudness_available = _current_loudness_limit_available(config)
+    if current_loudness_available is not None:
+        return current_loudness_available
+    if _legacy_loudness_limit_available(config):
+        return True
+    return _csv_limit_available(config)
+
+
+def is_deviation_output_available(config: object) -> bool:
+    """Return whether golden-sample deviation display is currently enabled."""
+    if not isinstance(config, Mapping):
+        return False
+    return bool(config.get(GOLDEN_SAMPLE_CHECKED_KEY, False)) and (
+        GOLDEN_SAMPLE_DISPLAY_DEVIATION
+        in normalize_golden_sample_display_modes(config)
+    )
+
+
+def available_excel_outputs(config: object) -> tuple[str, ...]:
+    """Return available output identifiers in stable serialized/UI order."""
+    available = {EXCEL_OUTPUT_TEST_CURVE}
+    if is_margin_output_available(config):
+        available.add(EXCEL_OUTPUT_MARGIN)
+    if is_deviation_output_available(config):
+        available.add(EXCEL_OUTPUT_DEVIATION)
+    return tuple(output for output in EXCEL_OUTPUT_ORDER if output in available)
+
+
+def _canonical_outputs(outputs: object) -> tuple[str, ...]:
+    if isinstance(outputs, (str, bytes, bytearray, Mapping)):
+        return ()
+    try:
+        selected = {
+            output for output in outputs if isinstance(output, str)
+        }
+    except TypeError:
+        return ()
+    return tuple(output for output in EXCEL_OUTPUT_ORDER if output in selected)
+
+
+def _available_name_filter(available_items: Iterable[str]) -> set[str]:
+    if isinstance(available_items, (str, bytes, bytearray, Mapping)):
+        return set()
+    try:
+        return {name for name in available_items if isinstance(name, str)}
+    except TypeError:
+        return set()
+
+
+def normalize_save_item_outputs(
+    excel_cfg: object,
+    analysis_config: object,
+    *,
+    available_items: Iterable[str] | None = None,
+) -> dict[str, tuple[str, ...]]:
+    """Normalize authoritative new selections or migrate legacy item choices."""
+    if not isinstance(excel_cfg, Mapping):
+        return {}
+    configs = analysis_config if isinstance(analysis_config, Mapping) else {}
+    allowed_names = (
+        None if available_items is None else _available_name_filter(available_items)
+    )
+
+    if SAVE_ITEM_OUTPUTS_KEY in excel_cfg:
+        raw_mapping = excel_cfg.get(SAVE_ITEM_OUTPUTS_KEY)
+        if not isinstance(raw_mapping, Mapping):
+            return {}
+        normalized: dict[str, tuple[str, ...]] = {}
+        for name, raw_outputs in raw_mapping.items():
+            if not isinstance(name, str) or (
+                allowed_names is not None and name not in allowed_names
+            ):
+                continue
+            available = set(available_excel_outputs(configs.get(name)))
+            outputs = tuple(
+                output
+                for output in _canonical_outputs(raw_outputs)
+                if output in available
+            )
+            if outputs:
+                normalized[name] = outputs
+        return normalized
+
+    raw_items = excel_cfg.get("save_items", ())
+    if isinstance(raw_items, (str, bytes, bytearray, Mapping)):
+        return {}
+    try:
+        item_names = iter(raw_items)
+    except TypeError:
+        return {}
+
+    migrated: dict[str, tuple[str, ...]] = {}
+    for name in item_names:
+        if not isinstance(name, str) or (
+            allowed_names is not None and name not in allowed_names
+        ):
+            continue
+        migrated[name] = available_excel_outputs(configs.get(name))
+    return migrated
+
+
+def serialize_save_item_outputs(
+    selections: Mapping[str, Iterable[str]],
+) -> dict[str, list[str]]:
+    """Return JSON-ready, canonical selections without empty or unknown rows."""
+    if not isinstance(selections, Mapping):
+        return {}
+    serialized: dict[str, list[str]] = {}
+    for name, raw_outputs in selections.items():
+        if not isinstance(name, str):
+            continue
+        outputs = _canonical_outputs(raw_outputs)
+        if outputs:
+            serialized[name] = list(outputs)
+    return serialized

--- a/base/excel_result_exporter.py
+++ b/base/excel_result_exporter.py
@@ -5,6 +5,7 @@ import os
 import re
 import csv
 import threading
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Iterable
@@ -13,10 +14,21 @@ import numpy as np
 from openpyxl import Workbook, load_workbook
 import msvcrt  # Windows-only; used for runtime file locking
 
-from base.golden_sample_export_payload import parse_golden_sample_curve_exports
+from base.excel_export_selection import normalize_save_item_outputs
+from base.golden_sample_export_payload import (
+    parse_golden_sample_curve_exports,
+    parse_selected_golden_sample_curve_exports,
+)
 from consts.acoustic_analysis.common_consts import (
+    GOLDEN_SAMPLE_CURVE_EXPORTS_KEY,
     GOLDEN_SAMPLE_DISPLAY_DEVIATION,
     GOLDEN_SAMPLE_DISPLAY_ENVELOPE,
+)
+from consts.excel_export_consts import (
+    EXCEL_OUTPUT_DEVIATION,
+    EXCEL_OUTPUT_MARGIN,
+    EXCEL_OUTPUT_TEST_CURVE,
+    SAVE_ITEM_OUTPUTS_KEY,
 )
 from consts.running_consts import DEFAULT_DIR
 
@@ -401,6 +413,31 @@ def resolve_excel_max_points(excel_cfg: dict[str, Any]) -> int:
     return max(10, min(max_points, EXCEL_MAX_DATA_POINTS))
 
 
+def _exportable_analysis_item_names(
+    analysis_config: object,
+) -> list[str]:
+    if not isinstance(analysis_config, Mapping):
+        return []
+    return [
+        name
+        for name, config in analysis_config.items()
+        if isinstance(name, str)
+        and isinstance(config, Mapping)
+        and config.get("type") not in ("Excel", "Spec")
+    ]
+
+
+def _normalize_runtime_output_selections(
+    excel_cfg: Mapping[str, Any],
+    analysis_config: object,
+) -> dict[str, tuple[str, ...]]:
+    return normalize_save_item_outputs(
+        excel_cfg,
+        analysis_config,
+        available_items=_exportable_analysis_item_names(analysis_config),
+    )
+
+
 class ExcelExportSession:
     """
     Keep an Excel workbook in memory for repeated appends, and save on demand.
@@ -444,6 +481,7 @@ class ExcelExportSession:
         self,
         *,
         save_items: list[str],
+        save_item_outputs: Mapping[str, Iterable[str]] | None = None,
         max_points: int,
         sn: str,
         date_text: str,
@@ -451,10 +489,17 @@ class ExcelExportSession:
         analysis_config: dict[str, Any],
         analysis_result_dict: dict[str, tuple[bool, float]],
     ) -> ExportResult:
-        if not isinstance(save_items, list) or len(save_items) == 0:
+        excel_cfg: dict[str, Any] = {"save_items": save_items}
+        if save_item_outputs is not None:
+            excel_cfg[SAVE_ITEM_OUTPUTS_KEY] = save_item_outputs
+        selections = _normalize_runtime_output_selections(
+            excel_cfg,
+            analysis_config,
+        )
+        if not selections:
             return ExportResult(ok=False, message="未选择需要保存的分析项")
-        resolved_curves, error = _preflight_named_curve_exports(
-            save_items,
+        resolved_curves, error = _preflight_selected_named_curve_exports(
+            selections,
             analysis_items_data,
         )
         if error:
@@ -479,7 +524,7 @@ class ExcelExportSession:
             created_any_sheet = True
             return wb.create_sheet(title=desired_name)
 
-        for item_name in save_items:
+        for item_name, selected_outputs in selections.items():
             item_data = analysis_items_data.get(item_name)
             if not isinstance(item_data, dict):
                 continue
@@ -488,7 +533,7 @@ class ExcelExportSession:
                 # user-invisible: never export
                 continue
 
-            if item_type == "AI":
+            if item_type == "AI" and EXCEL_OUTPUT_TEST_CURVE in selected_outputs:
                 ws_name = _sanitize_sheet_name(item_name)
                 ws = wb[ws_name] if ws_name in wb.sheetnames else ensure_sheet(ws_name)
                 header = AI_SHEET_HEADER
@@ -499,7 +544,7 @@ class ExcelExportSession:
                 ng_score = item_data.get("ng_score")
                 model_name = item_data.get("model_name") or item_data.get("model") or ""
                 _append_row(ws, [sn, date_text, label, ok_score, ng_score, model_name])
-            else:
+            elif item_type != "AI":
                 named_curves = resolved_curves.get(item_name, [])
                 for curve_name, curve_x, curve_y in named_curves:
                     x, y = _downsample_xy(
@@ -537,7 +582,11 @@ class ExcelExportSession:
                     _append_row(ws, [sn, date_text] + y)
 
             result_tuple = analysis_result_dict.get(item_name)
-            if isinstance(result_tuple, tuple) and len(result_tuple) == 2:
+            if (
+                EXCEL_OUTPUT_MARGIN in selected_outputs
+                and isinstance(result_tuple, tuple)
+                and len(result_tuple) == 2
+            ):
                 ok_val, deviation = result_tuple
                 cfg = analysis_config.get(item_name) if isinstance(analysis_config, dict) else None
                 result_sheet_name = _make_margin_sheet_title(item_name)
@@ -744,6 +793,118 @@ def _preflight_named_curve_exports(
         result = item_data.get("result")
         curves, error = (
             _resolve_named_curve_exports(item_name, result)
+            if isinstance(result, dict)
+            else ([], None)
+        )
+        if error:
+            return {}, error
+        resolved[item_name] = curves
+    return resolved, None
+
+
+def _resolve_selected_named_curve_exports(
+    item_name: str,
+    result: dict[str, Any],
+    selected_outputs: Iterable[str],
+) -> tuple[list[tuple[str, list[Any], list[Any]]], str | None]:
+    outputs = set(selected_outputs)
+    requested_modes: list[str] = []
+    if EXCEL_OUTPUT_DEVIATION in outputs:
+        requested_modes.append(GOLDEN_SAMPLE_DISPLAY_DEVIATION)
+    if EXCEL_OUTPUT_TEST_CURVE in outputs:
+        requested_modes.append(GOLDEN_SAMPLE_DISPLAY_ENVELOPE)
+    if not requested_modes:
+        return [], None
+
+    is_legacy, parsed, error = parse_selected_golden_sample_curve_exports(
+        result,
+        requested_modes,
+    )
+    if error:
+        return [], f"当前黄金样本导出载荷不完整: {error}"
+    if is_legacy:
+        if EXCEL_OUTPUT_TEST_CURVE not in outputs:
+            return [], None
+        xy = _extract_curve_xy(result)
+        return ([] if xy is None else [(item_name, *xy)]), None
+
+    parsed_by_mode = {series.mode: series for series in parsed}
+    curves: list[tuple[str, list[Any], list[Any]]] = []
+    if EXCEL_OUTPUT_DEVIATION in outputs:
+        deviation = parsed_by_mode.get(GOLDEN_SAMPLE_DISPLAY_DEVIATION)
+        if (
+            deviation is not None
+            and deviation.available
+            and deviation.x is not None
+            and deviation.y is not None
+        ):
+            curves.append(
+                (
+                    _make_golden_curve_export_name(
+                        item_name,
+                        GOLDEN_SAMPLE_DISPLAY_DEVIATION,
+                    ),
+                    deviation.x,
+                    deviation.y,
+                )
+            )
+
+    if EXCEL_OUTPUT_TEST_CURVE in outputs:
+        payload = result[GOLDEN_SAMPLE_CURVE_EXPORTS_KEY]
+        envelope_declared = (
+            GOLDEN_SAMPLE_DISPLAY_ENVELOPE in payload["selected_modes"]
+        )
+        envelope = parsed_by_mode.get(GOLDEN_SAMPLE_DISPLAY_ENVELOPE)
+        if envelope_declared:
+            if (
+                envelope is not None
+                and envelope.available
+                and envelope.x is not None
+                and envelope.y is not None
+            ):
+                curves.append(
+                    (
+                        _make_golden_curve_export_name(
+                            item_name,
+                            GOLDEN_SAMPLE_DISPLAY_ENVELOPE,
+                        ),
+                        envelope.x,
+                        envelope.y,
+                    )
+                )
+        else:
+            xy = _extract_curve_xy(result)
+            if xy is not None:
+                curves.append(
+                    (
+                        _make_golden_curve_export_name(
+                            item_name,
+                            GOLDEN_SAMPLE_DISPLAY_ENVELOPE,
+                        ),
+                        *xy,
+                    )
+                )
+    return curves, None
+
+
+def _preflight_selected_named_curve_exports(
+    selections: Mapping[str, Iterable[str]],
+    analysis_items_data: Mapping[str, Any],
+) -> tuple[dict[str, list[tuple[str, list[Any], list[Any]]]], str | None]:
+    resolved: dict[str, list[tuple[str, list[Any], list[Any]]]] = {}
+    for item_name, selected_outputs in selections.items():
+        item_data = analysis_items_data.get(item_name)
+        if not isinstance(item_data, dict):
+            continue
+        if item_data.get("type") in ("AI", "Spec"):
+            continue
+        result = item_data.get("result")
+        curves, error = (
+            _resolve_selected_named_curve_exports(
+                item_name,
+                result,
+                selected_outputs,
+            )
             if isinstance(result, dict)
             else ([], None)
         )
@@ -1004,11 +1165,14 @@ def export_analysis_to_csv_spool(
     if not isinstance(excel_cfg, dict) or not excel_cfg.get("enabled", True):
         return ExportResult(ok=True, message="Excel导出未启用")
 
-    save_items = excel_cfg.get("save_items") or []
-    if not isinstance(save_items, list) or len(save_items) == 0:
+    selections = _normalize_runtime_output_selections(
+        excel_cfg,
+        analysis_config,
+    )
+    if not selections:
         return ExportResult(ok=False, message="未选择需要保存的分析项")
-    resolved_curves, error = _preflight_named_curve_exports(
-        save_items,
+    resolved_curves, error = _preflight_selected_named_curve_exports(
+        selections,
         analysis_items_data,
     )
     if error:
@@ -1058,7 +1222,7 @@ def export_analysis_to_csv_spool(
         except Exception as e:
             return ExportResult(ok=False, message=f"Excel加锁失败: {e}")
 
-    for item_name in save_items:
+    for item_name, selected_outputs in selections.items():
         item_data = analysis_items_data.get(item_name)
         if not isinstance(item_data, dict):
             continue
@@ -1066,7 +1230,7 @@ def export_analysis_to_csv_spool(
         if item_type == "Spec":
             continue
 
-        if item_type == "AI":
+        if item_type == "AI" and EXCEL_OUTPUT_TEST_CURVE in selected_outputs:
             sheet_name = _sanitize_sheet_name(item_name)
             csv_path = os.path.join(spool_dir, f"{_sanitize_filename(sheet_name)}.csv")
             header = AI_SHEET_HEADER
@@ -1102,7 +1266,11 @@ def export_analysis_to_csv_spool(
                     return ret
 
         result_tuple = analysis_result_dict.get(item_name)
-        if isinstance(result_tuple, tuple) and len(result_tuple) == 2:
+        if (
+            EXCEL_OUTPUT_MARGIN in selected_outputs
+            and isinstance(result_tuple, tuple)
+            and len(result_tuple) == 2
+        ):
             ok_val, deviation = result_tuple
             cfg = analysis_config.get(item_name) if isinstance(analysis_config, dict) else None
             sheet_name = _make_margin_sheet_title(item_name)
@@ -1291,11 +1459,14 @@ def export_analysis_to_excel(
     if not isinstance(excel_cfg, dict) or not excel_cfg.get("enabled", True):
         return ExportResult(ok=True, message="Excel导出未启用")
 
-    save_items = excel_cfg.get("save_items") or []
-    if not isinstance(save_items, list) or len(save_items) == 0:
+    selections = _normalize_runtime_output_selections(
+        excel_cfg,
+        analysis_config,
+    )
+    if not selections:
         return ExportResult(ok=False, message="未选择需要保存的分析项")
-    resolved_curves, error = _preflight_named_curve_exports(
-        save_items,
+    resolved_curves, error = _preflight_selected_named_curve_exports(
+        selections,
         analysis_items_data,
     )
     if error:
@@ -1346,7 +1517,7 @@ def export_analysis_to_excel(
         created_any_sheet = True
         return wb.create_sheet(title=desired_name)
 
-    for item_name in save_items:
+    for item_name, selected_outputs in selections.items():
         item_data = analysis_items_data.get(item_name)
         if not isinstance(item_data, dict):
             continue
@@ -1355,7 +1526,7 @@ def export_analysis_to_excel(
             # user-invisible: never export
             continue
 
-        if item_type == "AI":
+        if item_type == "AI" and EXCEL_OUTPUT_TEST_CURVE in selected_outputs:
             ws_name = _sanitize_sheet_name(item_name)
             ws = wb[ws_name] if ws_name in wb.sheetnames else ensure_sheet(ws_name)
             header = AI_SHEET_HEADER
@@ -1366,7 +1537,7 @@ def export_analysis_to_excel(
             ng_score = item_data.get("ng_score")
             model_name = item_data.get("model_name") or item_data.get("model") or ""
             _append_row(ws, [sn, date_text, label, ok_score, ng_score, model_name])
-        else:
+        elif item_type != "AI":
             named_curves = resolved_curves.get(item_name, [])
             for curve_name, curve_x, curve_y in named_curves:
                 x, y = _downsample_xy(
@@ -1404,7 +1575,11 @@ def export_analysis_to_excel(
                 _append_row(ws, [sn, date_text] + y)
 
         result_tuple = analysis_result_dict.get(item_name)
-        if isinstance(result_tuple, tuple) and len(result_tuple) == 2:
+        if (
+            EXCEL_OUTPUT_MARGIN in selected_outputs
+            and isinstance(result_tuple, tuple)
+            and len(result_tuple) == 2
+        ):
             ok_val, deviation = result_tuple
             cfg = analysis_config.get(item_name) if isinstance(analysis_config, dict) else None
             result_sheet_name = _make_margin_sheet_title(item_name)

--- a/base/golden_sample_export_payload.py
+++ b/base/golden_sample_export_payload.py
@@ -70,15 +70,15 @@ def _current_error(message: str) -> tuple[bool, list[GoldenCurveSeries], str]:
     return False, [], message
 
 
-def parse_golden_sample_curve_exports(
+def _parse_payload_structure(
     result: Mapping[str, Any],
-) -> tuple[bool, list[GoldenCurveSeries], str | None]:
+) -> tuple[bool, list[str], Mapping[str, Any] | None, str | None]:
     if GOLDEN_SAMPLE_CURVE_EXPORTS_KEY not in result:
-        return True, [], None
+        return True, [], None, None
 
     payload = result[GOLDEN_SAMPLE_CURVE_EXPORTS_KEY]
     if not isinstance(payload, Mapping):
-        return _current_error("载荷必须是对象")
+        return False, [], None, "载荷必须是对象"
 
     schema_version = payload.get("schema_version")
     if (
@@ -86,67 +86,116 @@ def parse_golden_sample_curve_exports(
         or isinstance(schema_version, bool)
         or schema_version != GOLDEN_SAMPLE_CURVE_EXPORTS_SCHEMA_VERSION
     ):
-        return _current_error(f"不支持的 schema_version: {schema_version!r}")
+        return False, [], None, f"不支持的 schema_version: {schema_version!r}"
 
     selected_modes = payload.get("selected_modes")
     if not isinstance(selected_modes, list) or not selected_modes:
-        return _current_error("selected_modes 必须是非空列表")
+        return False, [], None, "selected_modes 必须是非空列表"
     if (
         any(not isinstance(mode, str) or mode not in GOLDEN_SAMPLE_DISPLAY_MODES for mode in selected_modes)
         or len(set(selected_modes)) != len(selected_modes)
         or selected_modes
         != [mode for mode in GOLDEN_SAMPLE_DISPLAY_MODES if mode in selected_modes]
     ):
-        return _current_error("selected_modes 必须是规范化且无重复的支持模式列表")
+        return False, [], None, "selected_modes 必须是规范化且无重复的支持模式列表"
 
     series = payload.get("series")
     if not isinstance(series, Mapping):
-        return _current_error("series 必须是对象")
+        return False, [], None, "series 必须是对象"
     extra_modes = set(series) - set(selected_modes)
     if extra_modes:
         extra_labels = [
             repr(mode)
             for mode in sorted(extra_modes, key=lambda mode: str(mode))
         ]
-        return _current_error(f"series 包含未选择模式: {extra_labels!r}")
+        return False, [], None, f"series 包含未选择模式: {extra_labels!r}"
+
+    return False, selected_modes, series, None
+
+
+def _parse_series_entry(
+    mode: str,
+    entry: Any,
+) -> tuple[GoldenCurveSeries | None, str | None]:
+    if not isinstance(entry, Mapping):
+        return None, f"模式 {mode!r} 的 series 必须是对象"
+    available = entry.get("available")
+    if not isinstance(available, bool):
+        return None, f"模式 {mode!r} 的 available 必须是布尔值"
+    if not available:
+        if "x" in entry or "y" in entry:
+            return None, f"模式 {mode!r} available=false 时不能包含 x/y"
+        return GoldenCurveSeries(mode=mode, available=False), None
+
+    x = entry.get("x")
+    y = entry.get("y")
+    if not isinstance(x, list):
+        return None, f"模式 {mode!r} 的 x 必须是列表"
+    if not isinstance(y, list):
+        return None, f"模式 {mode!r} 的 y 必须是列表"
+    if not x or not y:
+        return None, f"模式 {mode!r} 的 x/y 不能为空"
+    if len(x) != len(y):
+        return None, f"模式 {mode!r} 的 x/y 长度不一致"
+    if not all(_valid_finite_number(value) for value in x + y):
+        return None, f"模式 {mode!r} 的 x/y 必须是有限数值"
+    return (
+        GoldenCurveSeries(
+            mode=mode,
+            available=True,
+            x=list(x),
+            y=list(y),
+        ),
+        None,
+    )
+
+
+def parse_selected_golden_sample_curve_exports(
+    result: Mapping[str, Any],
+    requested_modes: Iterable[str],
+) -> tuple[bool, list[GoldenCurveSeries], str | None]:
+    is_legacy, selected_modes, series, error = _parse_payload_structure(result)
+    if error or is_legacy:
+        return is_legacy, [], error
+    assert series is not None
+
+    requested_set = {
+        mode for mode in requested_modes if mode in GOLDEN_SAMPLE_DISPLAY_MODES
+    }
+    parsed: list[GoldenCurveSeries] = []
+    for mode in GOLDEN_SAMPLE_DISPLAY_MODES:
+        if mode not in requested_set:
+            continue
+        if mode not in selected_modes:
+            parsed.append(GoldenCurveSeries(mode=mode, available=False))
+            continue
+        if mode not in series:
+            return _current_error(f"series 缺少已选择模式 {mode!r}")
+        parsed_series, entry_error = _parse_series_entry(mode, series[mode])
+        if entry_error:
+            return _current_error(entry_error)
+        assert parsed_series is not None
+        parsed.append(parsed_series)
+
+    return False, parsed, None
+
+
+def parse_golden_sample_curve_exports(
+    result: Mapping[str, Any],
+) -> tuple[bool, list[GoldenCurveSeries], str | None]:
+    is_legacy, selected_modes, series, error = _parse_payload_structure(result)
+    if error or is_legacy:
+        return is_legacy, [], error
+    assert series is not None
 
     parsed: list[GoldenCurveSeries] = []
     for mode in selected_modes:
         if mode not in series:
             return _current_error(f"series 缺少已选择模式 {mode!r}")
-        entry = series[mode]
-        if not isinstance(entry, Mapping):
-            return _current_error(f"模式 {mode!r} 的 series 必须是对象")
-        available = entry.get("available")
-        if not isinstance(available, bool):
-            return _current_error(f"模式 {mode!r} 的 available 必须是布尔值")
-        if not available:
-            if "x" in entry or "y" in entry:
-                return _current_error(
-                    f"模式 {mode!r} available=false 时不能包含 x/y"
-                )
-            parsed.append(GoldenCurveSeries(mode=mode, available=False))
-            continue
-
-        x = entry.get("x")
-        y = entry.get("y")
-        if not isinstance(x, list):
-            return _current_error(f"模式 {mode!r} 的 x 必须是列表")
-        if not isinstance(y, list):
-            return _current_error(f"模式 {mode!r} 的 y 必须是列表")
-        if not x or not y:
-            return _current_error(f"模式 {mode!r} 的 x/y 不能为空")
-        if len(x) != len(y):
-            return _current_error(f"模式 {mode!r} 的 x/y 长度不一致")
-        if not all(_valid_finite_number(value) for value in x + y):
-            return _current_error(f"模式 {mode!r} 的 x/y 必须是有限数值")
-        parsed.append(
-            GoldenCurveSeries(
-                mode=mode,
-                available=True,
-                x=list(x),
-                y=list(y),
-            )
-        )
+        parsed_series, entry_error = _parse_series_entry(mode, series[mode])
+        if entry_error:
+            return _current_error(entry_error)
+        assert parsed_series is not None
+        parsed.append(parsed_series)
 
     return False, parsed, None

--- a/consts/excel_export_consts.py
+++ b/consts/excel_export_consts.py
@@ -1,0 +1,11 @@
+"""Stable serialized identifiers for selecting Excel export outputs."""
+
+SAVE_ITEM_OUTPUTS_KEY = "save_item_outputs"
+EXCEL_OUTPUT_TEST_CURVE = "test_curve"
+EXCEL_OUTPUT_MARGIN = "margin"
+EXCEL_OUTPUT_DEVIATION = "deviation"
+EXCEL_OUTPUT_ORDER = (
+    EXCEL_OUTPUT_TEST_CURVE,
+    EXCEL_OUTPUT_MARGIN,
+    EXCEL_OUTPUT_DEVIATION,
+)

--- a/ui/custom_ui_widget/widgets.py
+++ b/ui/custom_ui_widget/widgets.py
@@ -17,6 +17,7 @@ from PyQt5.QtWidgets import (
     QTextEdit,
     QTableView,
     QTreeView,
+    QTreeWidget,
     QToolButton,
     QAction,
     QPlainTextEdit,
@@ -228,6 +229,21 @@ class TreeView(QTreeView):
         self.font_size = scale_size_px(20)
         self.font = QFont()
         self.font.setFamily("SimSun")
+        self.font.setPixelSize(self.font_size)
+        self.setFont(self.font)
+
+
+class TreeWidget(QTreeWidget):
+    def __init__(self, parent=None):
+        super(TreeWidget, self).__init__(parent)
+        self.font_size = scale_size_px(20)
+        self.font = QFont()
+        self.font.setFamily("SimSun")
+        self.font.setPixelSize(self.font_size)
+        self.setFont(self.font)
+
+    def set_font_size(self, font_size):
+        self.font_size = scale_size_px(font_size)
         self.font.setPixelSize(self.font_size)
         self.setFont(self.font)
 

--- a/ui/operation_sequence.py
+++ b/ui/operation_sequence.py
@@ -35,6 +35,7 @@ from consts.acoustic_analysis.common_consts import (
     GOLDEN_SAMPLE_CHECKED_KEY,
     GOLDEN_SAMPLE_RESULT_PATH_KEY,
 )
+from consts.excel_export_consts import SAVE_ITEM_OUTPUTS_KEY
 from consts.running_consts import DEFAULT_DIR
 from ui.acquisition_config_window import (
     RecordConfigWindow,
@@ -64,6 +65,37 @@ from ui.ui_analysis_config.excel_config_dialog import ExcelConfigWindow
 from ui.ui_src import ui_resources
 
 GOLDEN_SAMPLE_ANALYSIS_TYPES_REQUIRING_V2PA = {"SPLF", "PRB"}
+
+
+def _delete_excel_selection_item(analysis_list, name):
+    if not isinstance(analysis_list, dict):
+        return
+    for config in analysis_list.values():
+        if not isinstance(config, dict) or config.get("type") != "Excel":
+            continue
+        save_items = config.get("save_items")
+        if isinstance(save_items, list):
+            config["save_items"] = [item for item in save_items if item != name]
+        save_item_outputs = config.get(SAVE_ITEM_OUTPUTS_KEY)
+        if isinstance(save_item_outputs, dict):
+            save_item_outputs.pop(name, None)
+
+
+def _rename_excel_selection_item(analysis_list, old_name, new_name):
+    if not isinstance(analysis_list, dict):
+        return
+    for config in analysis_list.values():
+        if not isinstance(config, dict) or config.get("type") != "Excel":
+            continue
+        save_items = config.get("save_items")
+        if isinstance(save_items, list):
+            config["save_items"] = [
+                new_name if item == old_name else item for item in save_items
+            ]
+        save_item_outputs = config.get(SAVE_ITEM_OUTPUTS_KEY)
+        if isinstance(save_item_outputs, dict) and old_name in save_item_outputs:
+            outputs = save_item_outputs.pop(old_name)
+            save_item_outputs[new_name] = outputs
 
 
 def _safe_dialog_attr(obj, name, default=None):
@@ -1117,17 +1149,7 @@ class OptionList(ListView):
         if not name:
             return
         # Remove deleted items from any Excel export selection list to avoid stale references
-        try:
-            for _, cfg in self.config[0].analysis_list.items():
-                if not isinstance(cfg, dict):
-                    continue
-                if cfg.get("type") != "Excel":
-                    continue
-                save_items = cfg.get("save_items")
-                if isinstance(save_items, list) and name in save_items:
-                    cfg["save_items"] = [x for x in save_items if x != name]
-        except Exception:
-            pass
+        _delete_excel_selection_item(self.config[0].analysis_list, name)
         if name in self.config[0].analysis_list:
             del self.config[0].analysis_list[name]
 
@@ -1177,18 +1199,11 @@ class OptionList(ListView):
             list[index] = new_name
 
         # Keep Excel export item's selection in sync when other items are renamed
-        try:
-            for _, cfg in self.config[0].analysis_list.items():
-                if not isinstance(cfg, dict):
-                    continue
-                if cfg.get("type") != "Excel":
-                    continue
-                save_items = cfg.get("save_items")
-                if isinstance(save_items, list) and old_name in save_items:
-                    cfg["save_items"] = [new_name if x == old_name else x for x in save_items]
-        except Exception:
-            # Never block rename flow
-            pass
+        _rename_excel_selection_item(
+            self.config[0].analysis_list,
+            old_name,
+            new_name,
+        )
 
     def is_edit_model_item(self, topLeft, bottomRight, roles):
         if Qt.EditRole in roles:

--- a/ui/ui_analysis_config/excel_config_dialog.py
+++ b/ui/ui_analysis_config/excel_config_dialog.py
@@ -1,10 +1,37 @@
 import os
 
-from PyQt5.QtWidgets import QFileDialog, QHBoxLayout, QScrollArea, QVBoxLayout, QWidget
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import (
+    QFileDialog,
+    QHeaderView,
+    QHBoxLayout,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
 
+from base.excel_export_selection import (
+    available_excel_outputs,
+    normalize_save_item_outputs,
+    serialize_save_item_outputs,
+)
+from consts.excel_export_consts import (
+    EXCEL_OUTPUT_ORDER,
+    EXCEL_OUTPUT_TEST_CURVE,
+    SAVE_ITEM_OUTPUTS_KEY,
+)
 from consts.running_consts import DEFAULT_DIR
 from ui.custom_ui_widget.popuputils import PopupUtils
-from ui.custom_ui_widget.widgets import PushButton, Label, GroupBox, CheckBox, LineEdit, SpinBox, MessageBox
+from ui.custom_ui_widget.widgets import (
+    CheckBox,
+    GroupBox,
+    Label,
+    LineEdit,
+    MessageBox,
+    PushButton,
+    SpinBox,
+    TableWidget,
+)
 from ui.ui_analysis_config.common_widgets import SemanticAnalysisConfigDialogBase
 
 
@@ -23,7 +50,7 @@ class ExcelConfigWindow(SemanticAnalysisConfigDialogBase):
         self.model_type = model_type
         self.load_config = self.config_manager.load_config().get(model_type, {})
 
-        self._item_checkbox_by_name: dict[str, CheckBox] = {}
+        self._output_checkbox_by_name: dict[str, dict[str, CheckBox]] = {}
 
         self.init_ui()
 
@@ -108,25 +135,56 @@ class ExcelConfigWindow(SemanticAnalysisConfigDialogBase):
         btn_row.addStretch()
         select_layout.addLayout(btn_row)
 
-        scroll = QScrollArea()
-        scroll.setWidgetResizable(True)
-        scroll_content = QWidget()
-        scroll_layout = QVBoxLayout()
+        available_items = self._get_available_analysis_items()
+        analysis_config = self.config_manager.load_config() or {}
+        selected_outputs = normalize_save_item_outputs(
+            self.load_config,
+            analysis_config,
+            available_items=available_items,
+        )
 
-        selected = self.load_config.get("save_items") or []
-        if not isinstance(selected, list):
-            selected = []
+        self.output_table = TableWidget(self)
+        self.output_table.setColumnCount(4)
+        self.output_table.setHorizontalHeaderLabels(
+            ["分析项", "测试曲线", "Margin", "偏差曲线"]
+        )
+        self.output_table.setRowCount(len(available_items))
+        self.output_table.verticalHeader().setVisible(False)
+        self.output_table.setSelectionMode(TableWidget.NoSelection)
+        header = self.output_table.horizontalHeader()
+        header.setSectionResizeMode(0, QHeaderView.Stretch)
+        for column in range(1, 4):
+            header.setSectionResizeMode(column, QHeaderView.ResizeToContents)
 
-        for name in self._get_available_analysis_items():
-            cb = CheckBox(name)
-            cb.setChecked(name in selected)
-            self._item_checkbox_by_name[name] = cb
-            scroll_layout.addWidget(cb)
+        for row, name in enumerate(available_items):
+            name_item = QTableWidgetItem(name)
+            name_item.setFlags(Qt.ItemIsEnabled)
+            self.output_table.setItem(row, 0, name_item)
 
-        scroll_layout.addStretch()
-        scroll_content.setLayout(scroll_layout)
-        scroll.setWidget(scroll_content)
-        select_layout.addWidget(scroll)
+            item_config = analysis_config.get(name, {})
+            available_outputs = set(available_excel_outputs(item_config))
+            row_checkboxes: dict[str, CheckBox] = {}
+            for column, output in enumerate(EXCEL_OUTPUT_ORDER, start=1):
+                checkbox = CheckBox()
+                is_rsc_test_curve = (
+                    item_config.get("type") == "RSC"
+                    and output == EXCEL_OUTPUT_TEST_CURVE
+                )
+                enabled = output in available_outputs and not is_rsc_test_curve
+                checkbox.setEnabled(enabled)
+                checkbox.setChecked(
+                    enabled and output in selected_outputs.get(name, ())
+                )
+                cell_widget = QWidget(self.output_table)
+                cell_layout = QHBoxLayout(cell_widget)
+                cell_layout.setContentsMargins(0, 0, 0, 0)
+                cell_layout.setAlignment(Qt.AlignCenter)
+                cell_layout.addWidget(checkbox)
+                self.output_table.setCellWidget(row, column, cell_widget)
+                row_checkboxes[output] = checkbox
+            self._output_checkbox_by_name[name] = row_checkboxes
+
+        select_layout.addWidget(self.output_table)
         select_box.setLayout(select_layout)
         basic_layout.addWidget(select_box)
 
@@ -277,12 +335,15 @@ class ExcelConfigWindow(SemanticAnalysisConfigDialogBase):
         MessageBox.warning(self, "保存目录不可用", msg)
 
     def on_select_all(self):
-        for cb in self._item_checkbox_by_name.values():
-            cb.setChecked(True)
+        for output_checkboxes in self._output_checkbox_by_name.values():
+            for checkbox in output_checkboxes.values():
+                if checkbox.isEnabled():
+                    checkbox.setChecked(True)
 
     def on_clear_all(self):
-        for cb in self._item_checkbox_by_name.values():
-            cb.setChecked(False)
+        for output_checkboxes in self._output_checkbox_by_name.values():
+            for checkbox in output_checkboxes.values():
+                checkbox.setChecked(False)
 
     def create_btn(self):
         btn_layout = QHBoxLayout()
@@ -302,7 +363,18 @@ class ExcelConfigWindow(SemanticAnalysisConfigDialogBase):
         lock_files = self.lock_files_chk.isChecked()
         add_model_dir = self.add_model_dir_chk.isChecked()
         max_points = int(self.max_points_spin.value())
-        save_items = [name for name, cb in self._item_checkbox_by_name.items() if cb.isChecked()]
+        save_item_outputs = serialize_save_item_outputs(
+            {
+                name: [
+                    output
+                    for output in EXCEL_OUTPUT_ORDER
+                    if output_checkboxes[output].isEnabled()
+                    and output_checkboxes[output].isChecked()
+                ]
+                for name, output_checkboxes in self._output_checkbox_by_name.items()
+            }
+        )
+        save_items = sorted(save_item_outputs)
         return {
             "enabled": True,
             "save_dir": save_dir,
@@ -313,6 +385,7 @@ class ExcelConfigWindow(SemanticAnalysisConfigDialogBase):
             "date_format": "%Y%m%d",
             "max_points": max_points,
             "save_items": save_items,
+            SAVE_ITEM_OUTPUTS_KEY: save_item_outputs,
             "save_mes_enabled": self.mes_chk.isChecked(),
             "mes_file_base": self.mes_file_base_edit.text() or None,
             "mes_file_name": self.mes_file_name_edit.text(),
@@ -333,7 +406,7 @@ class ExcelConfigWindow(SemanticAnalysisConfigDialogBase):
 
     def on_restore_default_btn_clicked(self):
         self.load_config = self.config_manager.load_config().get(self.model_type, {})
-        self._item_checkbox_by_name = {}
+        self._output_checkbox_by_name = {}
         self.clear_semantic_sections()
         self._build_semantic_sections()
 

--- a/ui/ui_analysis_config/excel_config_dialog.py
+++ b/ui/ui_analysis_config/excel_config_dialog.py
@@ -3,9 +3,8 @@ import os
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import (
     QFileDialog,
-    QHeaderView,
     QHBoxLayout,
-    QTableWidgetItem,
+    QTreeWidgetItem,
     QVBoxLayout,
     QWidget,
 )
@@ -16,6 +15,8 @@ from base.excel_export_selection import (
     serialize_save_item_outputs,
 )
 from consts.excel_export_consts import (
+    EXCEL_OUTPUT_DEVIATION,
+    EXCEL_OUTPUT_MARGIN,
     EXCEL_OUTPUT_ORDER,
     EXCEL_OUTPUT_TEST_CURVE,
     SAVE_ITEM_OUTPUTS_KEY,
@@ -30,7 +31,7 @@ from ui.custom_ui_widget.widgets import (
     MessageBox,
     PushButton,
     SpinBox,
-    TableWidget,
+    TreeWidget,
 )
 from ui.ui_analysis_config.common_widgets import SemanticAnalysisConfigDialogBase
 
@@ -50,7 +51,9 @@ class ExcelConfigWindow(SemanticAnalysisConfigDialogBase):
         self.model_type = model_type
         self.load_config = self.config_manager.load_config().get(model_type, {})
 
-        self._output_checkbox_by_name: dict[str, dict[str, CheckBox]] = {}
+        self._output_root_by_name: dict[str, QTreeWidgetItem] = {}
+        self._output_child_by_name: dict[str, dict[str, QTreeWidgetItem]] = {}
+        self._syncing_output_tree = False
 
         self.init_ui()
 
@@ -143,48 +146,48 @@ class ExcelConfigWindow(SemanticAnalysisConfigDialogBase):
             available_items=available_items,
         )
 
-        self.output_table = TableWidget(self)
-        self.output_table.setColumnCount(4)
-        self.output_table.setHorizontalHeaderLabels(
-            ["分析项", "测试曲线", "Margin", "偏差曲线"]
-        )
-        self.output_table.setRowCount(len(available_items))
-        self.output_table.verticalHeader().setVisible(False)
-        self.output_table.setSelectionMode(TableWidget.NoSelection)
-        header = self.output_table.horizontalHeader()
-        header.setSectionResizeMode(0, QHeaderView.Stretch)
-        for column in range(1, 4):
-            header.setSectionResizeMode(column, QHeaderView.ResizeToContents)
+        self.output_tree = TreeWidget(self)
+        self.output_tree.setColumnCount(1)
+        self.output_tree.setHeaderHidden(True)
+        self.output_tree.setSelectionMode(TreeWidget.NoSelection)
 
-        for row, name in enumerate(available_items):
-            name_item = QTableWidgetItem(name)
-            name_item.setFlags(Qt.ItemIsEnabled)
-            self.output_table.setItem(row, 0, name_item)
-
+        output_labels = {
+            EXCEL_OUTPUT_TEST_CURVE: "测试曲线",
+            EXCEL_OUTPUT_MARGIN: "Margin",
+            EXCEL_OUTPUT_DEVIATION: "偏差曲线",
+        }
+        for name in available_items:
             item_config = analysis_config.get(name, {})
             available_outputs = set(available_excel_outputs(item_config))
-            row_checkboxes: dict[str, CheckBox] = {}
-            for column, output in enumerate(EXCEL_OUTPUT_ORDER, start=1):
-                checkbox = CheckBox()
-                is_rsc_test_curve = (
-                    item_config.get("type") == "RSC"
-                    and output == EXCEL_OUTPUT_TEST_CURVE
-                )
-                enabled = output in available_outputs and not is_rsc_test_curve
-                checkbox.setEnabled(enabled)
-                checkbox.setChecked(
-                    enabled and output in selected_outputs.get(name, ())
-                )
-                cell_widget = QWidget(self.output_table)
-                cell_layout = QHBoxLayout(cell_widget)
-                cell_layout.setContentsMargins(0, 0, 0, 0)
-                cell_layout.setAlignment(Qt.AlignCenter)
-                cell_layout.addWidget(checkbox)
-                self.output_table.setCellWidget(row, column, cell_widget)
-                row_checkboxes[output] = checkbox
-            self._output_checkbox_by_name[name] = row_checkboxes
+            supported_outputs = [
+                output
+                for output in EXCEL_OUTPUT_ORDER
+                if output in available_outputs
+                and not (item_config.get("type") == "RSC" and output == EXCEL_OUTPUT_TEST_CURVE)
+            ]
+            if not supported_outputs:
+                continue
 
-        select_layout.addWidget(self.output_table)
+            root = QTreeWidgetItem([name])
+            root.setFlags(root.flags() | Qt.ItemIsUserCheckable)
+            self.output_tree.addTopLevelItem(root)
+            children: dict[str, QTreeWidgetItem] = {}
+            for output in supported_outputs:
+                child = QTreeWidgetItem(root, [output_labels[output]])
+                child.setFlags(child.flags() | Qt.ItemIsUserCheckable)
+                child.setCheckState(
+                    0,
+                    Qt.Checked if output in selected_outputs.get(name, ()) else Qt.Unchecked,
+                )
+                children[output] = child
+
+            self._output_root_by_name[name] = root
+            self._output_child_by_name[name] = children
+            self._refresh_output_root_state(root)
+            root.setExpanded(False)
+
+        self.output_tree.itemChanged.connect(self._on_output_tree_item_changed)
+        select_layout.addWidget(self.output_tree)
         select_box.setLayout(select_layout)
         basic_layout.addWidget(select_box)
 
@@ -335,15 +338,47 @@ class ExcelConfigWindow(SemanticAnalysisConfigDialogBase):
         MessageBox.warning(self, "保存目录不可用", msg)
 
     def on_select_all(self):
-        for output_checkboxes in self._output_checkbox_by_name.values():
-            for checkbox in output_checkboxes.values():
-                if checkbox.isEnabled():
-                    checkbox.setChecked(True)
+        self._set_all_output_children(Qt.Checked)
 
     def on_clear_all(self):
-        for output_checkboxes in self._output_checkbox_by_name.values():
-            for checkbox in output_checkboxes.values():
-                checkbox.setChecked(False)
+        self._set_all_output_children(Qt.Unchecked)
+
+    def _root_state_from_children(self, root: QTreeWidgetItem) -> Qt.CheckState:
+        states = [root.child(index).checkState(0) for index in range(root.childCount())]
+        if all(state == Qt.Checked for state in states):
+            return Qt.Checked
+        if any(state != Qt.Unchecked for state in states):
+            return Qt.PartiallyChecked
+        return Qt.Unchecked
+
+    def _refresh_output_root_state(self, root: QTreeWidgetItem) -> None:
+        root.setCheckState(0, self._root_state_from_children(root))
+
+    def _on_output_tree_item_changed(self, item: QTreeWidgetItem, column: int) -> None:
+        if self._syncing_output_tree or column != 0:
+            return
+        self._syncing_output_tree = True
+        try:
+            parent = item.parent()
+            if parent is None:
+                target = Qt.Unchecked if item.checkState(0) == Qt.Unchecked else Qt.Checked
+                for index in range(item.childCount()):
+                    item.child(index).setCheckState(0, target)
+                item.setCheckState(0, target)
+            else:
+                self._refresh_output_root_state(parent)
+        finally:
+            self._syncing_output_tree = False
+
+    def _set_all_output_children(self, state: Qt.CheckState) -> None:
+        self._syncing_output_tree = True
+        try:
+            for name, children in self._output_child_by_name.items():
+                for child in children.values():
+                    child.setCheckState(0, state)
+                self._output_root_by_name[name].setCheckState(0, state)
+        finally:
+            self._syncing_output_tree = False
 
     def create_btn(self):
         btn_layout = QHBoxLayout()
@@ -368,10 +403,9 @@ class ExcelConfigWindow(SemanticAnalysisConfigDialogBase):
                 name: [
                     output
                     for output in EXCEL_OUTPUT_ORDER
-                    if output_checkboxes[output].isEnabled()
-                    and output_checkboxes[output].isChecked()
+                    if output in children and children[output].checkState(0) == Qt.Checked
                 ]
-                for name, output_checkboxes in self._output_checkbox_by_name.items()
+                for name, children in self._output_child_by_name.items()
             }
         )
         save_items = sorted(save_item_outputs)
@@ -406,7 +440,9 @@ class ExcelConfigWindow(SemanticAnalysisConfigDialogBase):
 
     def on_restore_default_btn_clicked(self):
         self.load_config = self.config_manager.load_config().get(self.model_type, {})
-        self._output_checkbox_by_name = {}
+        self._output_root_by_name = {}
+        self._output_child_by_name = {}
+        self._syncing_output_tree = False
         self.clear_semantic_sections()
         self._build_semantic_sections()
 

--- a/unit_test/base/test_excel_export_selection.py
+++ b/unit_test/base/test_excel_export_selection.py
@@ -1,0 +1,563 @@
+import numpy as np
+import pytest
+
+from base.excel_export_selection import (
+    available_excel_outputs,
+    is_deviation_output_available,
+    is_margin_output_available,
+    normalize_save_item_outputs,
+    serialize_save_item_outputs,
+)
+from consts.excel_export_consts import (
+    EXCEL_OUTPUT_DEVIATION,
+    EXCEL_OUTPUT_MARGIN,
+    EXCEL_OUTPUT_ORDER,
+    EXCEL_OUTPUT_TEST_CURVE,
+    SAVE_ITEM_OUTPUTS_KEY,
+)
+
+
+def test_stable_output_contract_values_follow_ui_and_canonical_order():
+    assert SAVE_ITEM_OUTPUTS_KEY == "save_item_outputs"
+    assert EXCEL_OUTPUT_TEST_CURVE == "test_curve"
+    assert EXCEL_OUTPUT_MARGIN == "margin"
+    assert EXCEL_OUTPUT_DEVIATION == "deviation"
+    assert EXCEL_OUTPUT_ORDER == ("test_curve", "margin", "deviation")
+
+
+def test_new_mapping_is_authoritative_and_canonical():
+    excel_cfg = {
+        "save_items": ["SPLF", "FR"],
+        "save_item_outputs": {
+            "SPLF": ["deviation", "unknown", "test_curve", "test_curve"],
+        },
+    }
+    analysis_config = {
+        "SPLF": {
+            "golden_sample_checked": True,
+            "golden_sample_display_modes": ["deviation"],
+        },
+        "FR": {},
+    }
+
+    assert normalize_save_item_outputs(
+        excel_cfg,
+        analysis_config,
+        available_items=["SPLF", "FR"],
+    ) == {"SPLF": ("test_curve", "deviation")}
+
+
+def test_explicit_empty_new_mapping_does_not_fall_back_to_save_items():
+    assert normalize_save_item_outputs(
+        {"save_items": ["SPLF"], "save_item_outputs": {}},
+        {"SPLF": {}},
+        available_items=["SPLF"],
+    ) == {}
+
+
+def test_new_mapping_filters_stale_names_and_currently_unavailable_outputs():
+    excel_cfg = {
+        "save_item_outputs": {
+            "SPLF": ["test_curve", "margin", "deviation"],
+            "Deleted": ["test_curve"],
+        }
+    }
+
+    assert normalize_save_item_outputs(
+        excel_cfg,
+        {"SPLF": {}},
+        available_items=["SPLF"],
+    ) == {"SPLF": ("test_curve",)}
+
+
+@pytest.mark.parametrize(
+    ("config", "expected"),
+    [
+        (
+            {
+                "limit_checked": True,
+                "limit_mode": "csv",
+                "limit_data": ([100.0, 200.0], [10.0, np.nan], [np.nan, np.nan]),
+            },
+            True,
+        ),
+        (
+            {
+                "limit_checked": True,
+                "limit_data": ([100.0], [np.nan], ["-3.5"]),
+            },
+            True,
+        ),
+        (
+            {
+                "limit_checked": True,
+                "limit_data": ([100.0], [np.nan], [np.nan]),
+            },
+            False,
+        ),
+        ({"limit_checked": True, "limit_data": ([], [], [])}, False),
+        (
+            {
+                "limit_checked": True,
+                "limit_data": ([100.0, 200.0], [10.0], [np.nan, np.nan]),
+            },
+            False,
+        ),
+        (
+            {
+                "limit_checked": True,
+                "limit_data": ([100.0], [np.inf], [np.nan]),
+            },
+            False,
+        ),
+        (
+            {
+                "limit_checked": True,
+                "limit_data": ([np.inf], [10.0], [np.nan]),
+            },
+            False,
+        ),
+        (
+            {
+                "limit_checked": False,
+                "limit_data": ([100.0], [10.0], [np.nan]),
+            },
+            False,
+        ),
+        (
+            {
+                "limit_checked": True,
+                "limit_data": ([100.0], [True], [np.nan]),
+            },
+            False,
+        ),
+        (
+            {
+                "limit_checked": True,
+                "limit_data": ([True], [10.0], [np.nan]),
+            },
+            False,
+        ),
+        ({"limit_checked": True, "limit_data": ([100.0], [10.0])}, False),
+        ({"limit_checked": True, "limit_data": "invalid"}, False),
+    ],
+)
+def test_csv_margin_availability_requires_an_aligned_finite_pair(config, expected):
+    assert is_margin_output_available(config) is expected
+
+
+def test_csv_margin_reuses_iterable_x_values_when_only_lower_side_is_finite():
+    config = {
+        "limit_checked": True,
+        "limit_data": (
+            (value for value in [100.0]),
+            [np.nan],
+            [-3.0],
+        ),
+    }
+
+    assert is_margin_output_available(config) is True
+
+
+def _segment(start_x=0.0, start_y=10.0, end_x=1.0, end_y=20.0):
+    return {
+        "start_x": start_x,
+        "start_y": start_y,
+        "end_x": end_x,
+        "end_y": end_y,
+    }
+
+
+@pytest.mark.parametrize(
+    ("config", "expected"),
+    [
+        (
+            {
+                "limit_checked": True,
+                "limit_mode": "manual",
+                "manual_upper_enabled": True,
+                "manual_upper_segments": [_segment()],
+                "manual_lower_enabled": False,
+                "manual_lower_segments": [],
+            },
+            True,
+        ),
+        (
+            {
+                "limit_checked": True,
+                "limit_mode": "manual",
+                "manual_upper_enabled": False,
+                "manual_upper_segments": [],
+                "manual_lower_enabled": True,
+                "manual_lower_segments": [_segment(start_y=-5.0, end_y=-4.0)],
+            },
+            True,
+        ),
+        (
+            {
+                "limit_checked": True,
+                "limit_mode": "manual",
+                "manual_upper_enabled": False,
+                "manual_upper_segments": [_segment()],
+            },
+            False,
+        ),
+        (
+            {
+                "limit_checked": True,
+                "limit_mode": "manual",
+                "manual_upper_enabled": True,
+                "manual_upper_segments": [_segment(start_y=np.nan)],
+            },
+            False,
+        ),
+        (
+            {
+                "limit_checked": True,
+                "limit_mode": "manual",
+                "manual_upper_enabled": True,
+                "manual_upper_segments": [_segment(start_x=1.0, end_x=1.0)],
+            },
+            False,
+        ),
+        (
+            {
+                "limit_checked": True,
+                "limit_mode": "manual",
+                "manual_upper_enabled": True,
+                "manual_upper_segments": [_segment(start_x=2.0, end_x=1.0)],
+            },
+            False,
+        ),
+        (
+            {
+                "limit_checked": False,
+                "limit_mode": "manual",
+                "manual_upper_enabled": True,
+                "manual_upper_segments": [_segment()],
+            },
+            False,
+        ),
+    ],
+)
+def test_current_manual_margin_availability_requires_a_valid_enabled_segment(
+    config,
+    expected,
+):
+    assert is_margin_output_available(config) is expected
+
+
+@pytest.mark.parametrize(
+    ("config", "expected"),
+    [
+        (
+            {
+                "limit_checked": True,
+                "limit_mode": "manual",
+                "manual_upper_enabled": True,
+                "manual_upper": "12.5",
+            },
+            True,
+        ),
+        (
+            {
+                "limit_checked": True,
+                "limit_mode": "manual",
+                "manual_lower_enabled": True,
+                "manual_lower": -3.0,
+            },
+            True,
+        ),
+        (
+            {
+                "limit_checked": True,
+                "limit_mode": "manual",
+                "manual_upper_enabled": True,
+                "manual_upper": True,
+            },
+            False,
+        ),
+        (
+            {
+                "limit_checked": True,
+                "limit_mode": "manual",
+                "manual_upper_enabled": True,
+                "manual_upper": 12.5,
+                "manual_upper_segments": [],
+            },
+            False,
+        ),
+        (
+            {
+                "limit_checked": True,
+                "limit_mode": "manual",
+                "manual_upper_enabled": False,
+                "manual_upper": 12.5,
+            },
+            False,
+        ),
+    ],
+)
+def test_legacy_manual_scalar_is_used_only_without_segment_fields(config, expected):
+    assert is_margin_output_available(config) is expected
+
+
+@pytest.mark.parametrize(
+    ("config", "expected"),
+    [
+        (
+            {
+                "limit_checked": True,
+                "curve_upper_enabled": True,
+                "curve_upper_value": "20.5",
+                "curve_lower_enabled": False,
+            },
+            True,
+        ),
+        (
+            {
+                "limit_checked": True,
+                "curve_upper_enabled": False,
+                "curve_lower_enabled": True,
+                "curve_lower_value": 1.0,
+            },
+            True,
+        ),
+        (
+            {
+                "limit_checked": True,
+                "curve_upper_enabled": True,
+                "curve_upper_value": np.inf,
+            },
+            False,
+        ),
+        (
+            {
+                "limit_checked": True,
+                "curve_upper_enabled": True,
+                "curve_upper_value": True,
+            },
+            False,
+        ),
+        (
+            {
+                "limit_checked": False,
+                "curve_upper_enabled": True,
+                "curve_upper_value": 20.0,
+            },
+            False,
+        ),
+        (
+            {
+                "limit_checked": True,
+                "limit_metric": "steady_state_average",
+                "mean_upper_enabled": True,
+                "mean_upper_sone": 20.0,
+            },
+            True,
+        ),
+        (
+            {
+                "limit_checked": True,
+                "limit_metric": "max_transient",
+                "nmax_lower_enabled": True,
+                "nmax_lower_sone": "0.5",
+            },
+            True,
+        ),
+        (
+            {
+                "limit_checked": True,
+                "limit_metric": "steady_state_average",
+                "mean_upper_enabled": True,
+                "mean_upper_sone": 20.0,
+                "curve_upper_enabled": False,
+            },
+            False,
+        ),
+        (
+            {
+                "limit_checked": True,
+                "limit_metric": "max_transient",
+                "nmax_upper_enabled": True,
+                "nmax_upper_sone": np.nan,
+            },
+            False,
+        ),
+        (
+            {
+                "limit_checked": True,
+                "limit_metric": "curve_y",
+                "mean_upper_enabled": True,
+                "mean_upper_sone": 20.0,
+            },
+            False,
+        ),
+    ],
+)
+def test_loudness_margin_availability_prefers_current_fields_then_metric_legacy(
+    config,
+    expected,
+):
+    assert is_margin_output_available(config) is expected
+
+
+@pytest.mark.parametrize(
+    ("config", "expected"),
+    [
+        (
+            {
+                "enable_threshold_judgment": True,
+                "upper_offset_db": "3.0",
+                "lower_offset_db": np.nan,
+            },
+            True,
+        ),
+        (
+            {
+                "enable_threshold_judgment": True,
+                "upper_offset_db": np.nan,
+                "lower_offset_db": -5.0,
+            },
+            True,
+        ),
+        (
+            {
+                "enable_threshold_judgment": False,
+                "upper_offset_db": 3.0,
+                "lower_offset_db": -5.0,
+            },
+            False,
+        ),
+        (
+            {
+                "enable_threshold_judgment": True,
+                "upper_offset_db": True,
+                "lower_offset_db": np.inf,
+            },
+            False,
+        ),
+        ({"threshold": 3.0, "score_threshold": 0.8}, False),
+        ({"limit_checked": True, "upper_limit": 3.0}, False),
+        (None, False),
+        ("invalid", False),
+    ],
+)
+def test_rsc_and_unrelated_margin_availability(config, expected):
+    assert is_margin_output_available(config) is expected
+
+
+def test_deviation_requires_golden_sample_and_normalized_deviation_mode():
+    assert is_deviation_output_available(
+        {
+            "golden_sample_checked": True,
+            "golden_sample_display_modes": ["deviation", "envelope"],
+        }
+    ) is True
+    assert is_deviation_output_available(
+        {
+            "golden_sample_checked": True,
+            "golden_sample_display_mode": "deviation",
+        }
+    ) is True
+    assert is_deviation_output_available(
+        {
+            "golden_sample_checked": False,
+            "golden_sample_display_modes": ["deviation"],
+        }
+    ) is False
+    assert is_deviation_output_available(
+        {
+            "golden_sample_checked": True,
+            "golden_sample_display_modes": ["envelope"],
+        }
+    ) is False
+    assert is_deviation_output_available(None) is False
+
+
+def test_available_outputs_always_include_test_curve_and_use_canonical_order():
+    config = {
+        "limit_checked": True,
+        "limit_data": ([100.0], [10.0], [np.nan]),
+        "golden_sample_checked": True,
+        "golden_sample_display_modes": ["deviation"],
+    }
+
+    assert available_excel_outputs(config) == ("test_curve", "margin", "deviation")
+    assert available_excel_outputs(None) == ("test_curve",)
+
+
+def test_legacy_save_items_migrate_to_every_currently_available_output():
+    excel_cfg = {"save_items": ["SPLF"]}
+    analysis_config = {
+        "SPLF": {
+            "limit_checked": True,
+            "limit_data": ([100.0], [10.0], [float("nan")]),
+            "golden_sample_checked": True,
+            "golden_sample_display_modes": ["deviation"],
+        }
+    }
+    assert normalize_save_item_outputs(
+        excel_cfg,
+        analysis_config,
+        available_items=["SPLF"],
+    ) == {"SPLF": ("test_curve", "margin", "deviation")}
+
+
+def test_legacy_item_without_limit_or_golden_sample_migrates_to_test_only():
+    assert normalize_save_item_outputs(
+        {"save_items": ["FR"]},
+        {"FR": {}},
+        available_items=["FR"],
+    ) == {"FR": ("test_curve",)}
+
+
+def test_legacy_migration_filters_stale_items_only_when_filter_is_supplied():
+    excel_cfg = {"save_items": ["Current", "Deleted"]}
+    analysis_config = {"Current": {}}
+
+    assert normalize_save_item_outputs(
+        excel_cfg,
+        analysis_config,
+        available_items=["Current"],
+    ) == {"Current": ("test_curve",)}
+    assert normalize_save_item_outputs(excel_cfg, analysis_config) == {
+        "Current": ("test_curve",),
+        "Deleted": ("test_curve",),
+    }
+
+
+def test_serialization_filters_unknowns_deduplicates_and_omits_empty_rows():
+    assert serialize_save_item_outputs(
+        {
+            "SPLF": ["deviation", "unknown", "test_curve", "test_curve"],
+            "FR": [],
+            "RSC": ["margin"],
+        }
+    ) == {
+        "SPLF": ["test_curve", "deviation"],
+        "RSC": ["margin"],
+    }
+
+
+def test_unhashable_unknown_output_values_are_ignored_without_crashing():
+    selections = {
+        "SPLF": [
+            {"unexpected": "mapping"},
+            ["unexpected-list"],
+            "test_curve",
+        ]
+    }
+
+    assert serialize_save_item_outputs(selections) == {"SPLF": ["test_curve"]}
+    assert normalize_save_item_outputs(
+        {"save_item_outputs": selections},
+        {"SPLF": {}},
+        available_items=["SPLF"],
+    ) == {"SPLF": ("test_curve",)}
+
+
+@pytest.mark.parametrize("bad_config", [None, [], "config", 1, True])
+def test_malformed_top_level_configs_are_safely_normalized(bad_config):
+    assert normalize_save_item_outputs(bad_config, bad_config) == {}
+    assert serialize_save_item_outputs(bad_config) == {}

--- a/unit_test/base/test_excel_result_exporter.py
+++ b/unit_test/base/test_excel_result_exporter.py
@@ -3,6 +3,7 @@ import tempfile
 import csv
 
 import numpy as np
+import pytest
 from openpyxl import load_workbook
 
 from base.excel_result_exporter import (
@@ -95,7 +96,7 @@ def test_export_analysis_to_excel_creates_missing_explicit_parent(tmp_path):
                 "model_name": "demo",
             }
         },
-        analysis_config={},
+        analysis_config={"AI结果": {}},
         analysis_result_dict={},
         file_path=str(file_path),
     )
@@ -139,7 +140,16 @@ def _export_args(result, *, analysis_result_dict=None):
         "sn": "SN001",
         "date_text": "2026-07-30 14:30:45",
         "analysis_items_data": {"SPLF": {"type": "SPLF", "result": result}},
-        "analysis_config": {"SPLF": {}},
+        "analysis_config": {
+            "SPLF": {
+                "limit_checked": True,
+                "limit_mode": "manual",
+                "manual_upper_enabled": True,
+                "manual_upper": 1.0,
+                "golden_sample_checked": True,
+                "golden_sample_display_modes": ["deviation", "envelope"],
+            }
+        },
         "analysis_result_dict": analysis_result_dict or {},
     }
 
@@ -154,9 +164,392 @@ def _multi_export_args(items):
         "sn": "SN001",
         "date_text": "2026-07-30 14:30:45",
         "analysis_items_data": items,
-        "analysis_config": {item_name: {} for item_name in items},
+        "analysis_config": {
+            item_name: {
+                "limit_checked": True,
+                "limit_mode": "manual",
+                "manual_upper_enabled": True,
+                "manual_upper": 1.0,
+                "golden_sample_checked": True,
+                "golden_sample_display_modes": ["deviation", "envelope"],
+            }
+            for item_name in items
+        },
         "analysis_result_dict": {},
     }
+
+
+def _fully_available_analysis_config(item_name="SPLF"):
+    return {
+        item_name: {
+            "limit_checked": True,
+            "limit_mode": "manual",
+            "manual_upper_enabled": True,
+            "manual_upper": 1.0,
+            "golden_sample_checked": True,
+            "golden_sample_display_modes": ["deviation", "envelope"],
+        }
+    }
+
+
+def _selected_export_args(result, *, analysis_result_dict=None, item_name="SPLF"):
+    args = _export_args(result, analysis_result_dict=analysis_result_dict)
+    args["analysis_config"] = _fully_available_analysis_config(item_name)
+    return args
+
+
+@pytest.mark.parametrize(
+    ("outputs", "expected_sheets"),
+    [
+        (["margin"], {"SPLF margin"}),
+        (["deviation"], {"SPLF_偏差曲线"}),
+        (["test_curve"], {"SPLF_测试曲线"}),
+        (
+            ["test_curve", "margin", "deviation"],
+            {"SPLF margin", "SPLF_偏差曲线", "SPLF_测试曲线"},
+        ),
+    ],
+)
+def test_direct_excel_applies_independent_output_selections(
+    tmp_path,
+    outputs,
+    expected_sheets,
+):
+    file_path = tmp_path / f"{'-'.join(outputs)}.xlsx"
+    payload_result = _golden_item_result(
+        ("deviation", "envelope"),
+        {
+            "deviation": ([100.0, 200.0], [-1.0, 0.5]),
+            "envelope": ([100.0, 200.0], [31.0, 33.5]),
+        },
+        frequency_list=[100.0, 200.0],
+        spl_db_raw=[10.0, 20.0],
+    )
+
+    result = export_analysis_to_excel(
+        {
+            "enabled": True,
+            "save_items": ["SPLF"],
+            "save_item_outputs": {"SPLF": outputs},
+            "lock_files": False,
+        },
+        file_path=str(file_path),
+        **_selected_export_args(
+            payload_result,
+            analysis_result_dict={"SPLF": (True, 0.5)},
+        ),
+    )
+
+    assert result.ok is True
+    assert set(load_workbook(file_path).sheetnames) == expected_sheets
+
+
+def test_direct_excel_explicit_empty_mapping_is_authoritative(tmp_path):
+    file_path = tmp_path / "empty.xlsx"
+
+    result = export_analysis_to_excel(
+        {
+            "enabled": True,
+            "save_items": ["SPLF"],
+            "save_item_outputs": {},
+            "lock_files": False,
+        },
+        file_path=str(file_path),
+        **_selected_export_args(
+            {"frequency_list": [100.0], "spl_db_raw": [10.0]},
+        ),
+    )
+
+    assert result.ok is False
+    assert "未选择需要保存的分析项" in result.message
+    assert not file_path.exists()
+
+
+@pytest.mark.parametrize("golden_checked", [False, True])
+def test_direct_excel_without_current_payload_keeps_legacy_raw_name(
+    tmp_path,
+    golden_checked,
+):
+    file_path = tmp_path / f"legacy-{golden_checked}.xlsx"
+    analysis_config = {"SPLF": {"golden_sample_checked": golden_checked}}
+
+    result = export_analysis_to_excel(
+        {
+            "enabled": True,
+            "save_item_outputs": {"SPLF": ["test_curve"]},
+            "lock_files": False,
+        },
+        file_path=str(file_path),
+        **{
+            **_export_args(
+                {"frequency_list": [100.0], "spl_db_raw": [10.0]},
+            ),
+            "analysis_config": analysis_config,
+        },
+    )
+
+    assert result.ok is True
+    assert load_workbook(file_path).sheetnames == ["SPLF"]
+
+
+def test_direct_excel_current_payload_without_envelope_uses_suffixed_raw_fallback(tmp_path):
+    file_path = tmp_path / "raw-fallback.xlsx"
+    payload_result = _golden_item_result(
+        ("deviation",),
+        {"deviation": ([100.0], [-1.0])},
+        frequency_list=[100.0],
+        spl_db_raw=[10.0],
+    )
+
+    result = export_analysis_to_excel(
+        {
+            "enabled": True,
+            "save_item_outputs": {"SPLF": ["test_curve"]},
+            "lock_files": False,
+        },
+        file_path=str(file_path),
+        **_selected_export_args(payload_result),
+    )
+
+    assert result.ok is True
+    workbook = load_workbook(file_path, data_only=True)
+    assert workbook.sheetnames == ["SPLF_测试曲线"]
+    assert [cell.value for cell in workbook["SPLF_测试曲线"][2][2:]] == [10.0]
+
+
+@pytest.mark.parametrize(
+    ("outputs", "broken_mode", "expected_sheet"),
+    [
+        (["test_curve"], "deviation", "SPLF_测试曲线"),
+        (["deviation"], "envelope", "SPLF_偏差曲线"),
+    ],
+)
+def test_direct_excel_ignores_malformed_unselected_structured_mode(
+    tmp_path,
+    outputs,
+    broken_mode,
+    expected_sheet,
+):
+    file_path = tmp_path / f"ignore-{broken_mode}.xlsx"
+    valid_entries = {
+        "deviation": {"available": True, "x": [100.0], "y": [-1.0]},
+        "envelope": {"available": True, "x": [100.0], "y": [31.0]},
+    }
+    valid_entries[broken_mode] = {"available": True, "x": "broken", "y": []}
+    payload_result = {
+        GOLDEN_SAMPLE_CURVE_EXPORTS_KEY: {
+            "schema_version": 1,
+            "selected_modes": ["deviation", "envelope"],
+            "series": valid_entries,
+        }
+    }
+
+    result = export_analysis_to_excel(
+        {
+            "enabled": True,
+            "save_item_outputs": {"SPLF": outputs},
+            "lock_files": False,
+        },
+        file_path=str(file_path),
+        **_selected_export_args(payload_result),
+    )
+
+    assert result.ok is True
+    assert load_workbook(file_path).sheetnames == [expected_sheet]
+
+
+@pytest.mark.parametrize(
+    ("output", "mode"),
+    [("test_curve", "envelope"), ("deviation", "deviation")],
+)
+def test_direct_excel_rejects_malformed_selected_structured_mode(
+    tmp_path,
+    output,
+    mode,
+):
+    file_path = tmp_path / f"broken-{mode}.xlsx"
+    payload_result = {
+        "frequency_list": [100.0],
+        "spl_db_raw": [10.0],
+        GOLDEN_SAMPLE_CURVE_EXPORTS_KEY: {
+            "schema_version": 1,
+            "selected_modes": [mode],
+            "series": {mode: {"available": True, "x": [100.0], "y": []}},
+        },
+    }
+
+    result = export_analysis_to_excel(
+        {
+            "enabled": True,
+            "save_item_outputs": {"SPLF": [output]},
+            "lock_files": False,
+        },
+        file_path=str(file_path),
+        **_selected_export_args(payload_result),
+    )
+
+    assert result.ok is False
+    assert mode in result.message
+    assert not file_path.exists()
+
+
+def test_direct_excel_missing_selected_series_is_skipped(tmp_path):
+    file_path = tmp_path / "missing-series.xlsx"
+    payload_result = _golden_item_result(("envelope",), {"envelope": None})
+
+    result = export_analysis_to_excel(
+        {
+            "enabled": True,
+            "save_item_outputs": {"SPLF": ["test_curve"]},
+            "lock_files": False,
+        },
+        file_path=str(file_path),
+        **_selected_export_args(payload_result),
+    )
+
+    assert result.ok is True
+    assert load_workbook(file_path).sheetnames == ["Sheet"]
+
+
+@pytest.mark.parametrize("selected", [True, False])
+def test_direct_excel_gates_ai_main_result_on_test_curve(tmp_path, selected):
+    file_path = tmp_path / f"ai-{selected}.xlsx"
+    outputs = ["test_curve"] if selected else ["margin"]
+    result = export_analysis_to_excel(
+        {
+            "enabled": True,
+            "save_item_outputs": {"AI结果": outputs},
+            "lock_files": False,
+        },
+        sn="SN001",
+        date_text="2026-07-30 14:30:45",
+        analysis_items_data={"AI结果": {"type": "AI", "label": "OK"}},
+        analysis_config={
+            "AI结果": {
+                "limit_checked": True,
+                "limit_mode": "manual",
+                "manual_upper_enabled": True,
+                "manual_upper": 1.0,
+            }
+        },
+        analysis_result_dict={},
+        file_path=str(file_path),
+    )
+
+    assert result.ok is True
+    assert ("AI结果" in load_workbook(file_path).sheetnames) is selected
+
+
+def test_direct_excel_filters_stale_mapping_key_by_current_analysis_config(tmp_path):
+    file_path = tmp_path / "stale.xlsx"
+
+    result = export_analysis_to_excel(
+        {
+            "enabled": True,
+            "save_item_outputs": {"STALE": ["test_curve"]},
+            "lock_files": False,
+        },
+        sn="SN001",
+        date_text="2026-07-30 14:30:45",
+        analysis_items_data={
+            "STALE": {
+                "type": "SPLF",
+                "result": {"frequency_list": [100.0], "spl_db_raw": [10.0]},
+            }
+        },
+        analysis_config={"CURRENT": {}},
+        analysis_result_dict={"STALE": (True, 0.5)},
+        file_path=str(file_path),
+    )
+
+    assert result.ok is False
+    assert "未选择需要保存的分析项" in result.message
+    assert not file_path.exists()
+
+
+def test_session_supports_legacy_and_authoritative_successive_selections(tmp_path):
+    file_path = tmp_path / "session-selection.xlsx"
+    session = ExcelExportSession(file_path=str(file_path))
+    payload_result = _golden_item_result(
+        ("deviation", "envelope"),
+        {
+            "deviation": ([100.0], [-1.0]),
+            "envelope": ([100.0], [31.0]),
+        },
+    )
+    args = _selected_export_args(
+        payload_result,
+        analysis_result_dict={"SPLF": (True, 0.5)},
+    )
+
+    legacy = session.append(save_items=["SPLF"], max_points=2000, **args)
+    selected = session.append(
+        save_items=["SPLF"],
+        save_item_outputs={"SPLF": ["test_curve"]},
+        max_points=2000,
+        **args,
+    )
+    saved = session.save()
+
+    assert legacy.ok is True
+    assert selected.ok is True
+    assert saved.ok is True
+    workbook = load_workbook(file_path)
+    assert workbook["SPLF_测试曲线"].max_row == 3
+    assert workbook["SPLF_偏差曲线"].max_row == 2
+    assert workbook["SPLF margin"].max_row == 2
+
+
+def test_session_unselected_malformed_mode_does_not_poison_append(tmp_path):
+    file_path = tmp_path / "session-isolated.xlsx"
+    session = ExcelExportSession(file_path=str(file_path))
+    payload_result = {
+        GOLDEN_SAMPLE_CURVE_EXPORTS_KEY: {
+            "schema_version": 1,
+            "selected_modes": ["deviation", "envelope"],
+            "series": {
+                "deviation": {"available": True, "x": "broken", "y": []},
+                "envelope": {"available": True, "x": [100.0], "y": [31.0]},
+            },
+        }
+    }
+
+    appended = session.append(
+        save_items=["SPLF"],
+        save_item_outputs={"SPLF": ["test_curve"]},
+        max_points=2000,
+        **_selected_export_args(payload_result),
+    )
+    saved = session.save()
+
+    assert appended.ok is True
+    assert saved.ok is True
+    assert load_workbook(file_path).sheetnames == ["SPLF_测试曲线"]
+
+
+def test_session_filters_stale_selected_item(tmp_path):
+    file_path = tmp_path / "session-stale.xlsx"
+    session = ExcelExportSession(file_path=str(file_path))
+
+    appended = session.append(
+        save_items=["STALE"],
+        save_item_outputs={"STALE": ["test_curve"]},
+        max_points=2000,
+        sn="SN001",
+        date_text="2026-07-30 14:30:45",
+        analysis_items_data={
+            "STALE": {
+                "type": "SPLF",
+                "result": {"frequency_list": [100.0], "spl_db_raw": [10.0]},
+            }
+        },
+        analysis_config={"CURRENT": {}},
+        analysis_result_dict={},
+    )
+
+    assert appended.ok is False
+    assert "未选择需要保存的分析项" in appended.message
+    assert session._wb is None
 
 
 def test_direct_excel_exports_dual_named_curves_with_exact_values_and_one_margin(tmp_path):
@@ -228,6 +621,332 @@ def test_csv_spool_exports_envelope_only_and_no_auxiliary_curves(tmp_path):
     ]
 
 
+@pytest.mark.parametrize(
+    ("outputs", "expected_files"),
+    [
+        (["margin"], {"SPLF margin.csv"}),
+        (["deviation"], {"SPLF_偏差曲线.csv"}),
+        (["test_curve"], {"SPLF_测试曲线.csv"}),
+        (
+            ["test_curve", "margin", "deviation"],
+            {"SPLF margin.csv", "SPLF_偏差曲线.csv", "SPLF_测试曲线.csv"},
+        ),
+    ],
+)
+def test_csv_spool_selection_applies_independent_outputs(
+    tmp_path,
+    outputs,
+    expected_files,
+):
+    spool_dir = tmp_path / "spool"
+    payload_result = _golden_item_result(
+        ("deviation", "envelope"),
+        {
+            "deviation": ([100.0], [-1.0]),
+            "envelope": ([100.0], [31.0]),
+        },
+    )
+
+    result = export_analysis_to_csv_spool(
+        {
+            "enabled": True,
+            "save_items": ["SPLF"],
+            "save_item_outputs": {"SPLF": outputs},
+            "lock_files": False,
+        },
+        file_path=str(tmp_path / "result.xlsx"),
+        spool_dir=str(spool_dir),
+        **_selected_export_args(
+            payload_result,
+            analysis_result_dict={"SPLF": (True, 0.5)},
+        ),
+    )
+
+    assert result.ok is True
+    assert {path.name for path in spool_dir.iterdir()} == expected_files
+
+
+def test_csv_spool_selection_uses_generic_name_for_ordinary_test_curve(tmp_path):
+    spool_dir = tmp_path / "spool"
+
+    result = export_analysis_to_csv_spool(
+        {
+            "enabled": True,
+            "save_item_outputs": {"SPLF": ["test_curve"]},
+            "lock_files": False,
+        },
+        file_path=str(tmp_path / "result.xlsx"),
+        spool_dir=str(spool_dir),
+        **_selected_export_args(
+            {"frequency_list": [100.0], "spl_db_raw": [10.0]},
+        ),
+    )
+
+    assert result.ok is True
+    assert {path.name for path in spool_dir.iterdir()} == {"SPLF.csv"}
+
+
+@pytest.mark.parametrize("selected", [True, False])
+def test_csv_spool_selection_gates_ai_main_result_on_test_curve(tmp_path, selected):
+    spool_dir = tmp_path / "spool"
+    outputs = ["test_curve"] if selected else ["margin"]
+
+    result = export_analysis_to_csv_spool(
+        {
+            "enabled": True,
+            "save_item_outputs": {"AI结果": outputs},
+            "lock_files": False,
+        },
+        sn="SN001",
+        date_text="2026-07-30 14:30:45",
+        analysis_items_data={"AI结果": {"type": "AI", "label": "OK"}},
+        analysis_config=_fully_available_analysis_config("AI结果"),
+        analysis_result_dict={},
+        file_path=str(tmp_path / "result.xlsx"),
+        spool_dir=str(spool_dir),
+    )
+
+    assert result.ok is True
+    assert ((spool_dir / "AI结果.csv").exists()) is selected
+
+
+def test_csv_spool_selection_explicit_empty_mapping_creates_no_spool(tmp_path):
+    spool_dir = tmp_path / "spool"
+
+    result = export_analysis_to_csv_spool(
+        {
+            "enabled": True,
+            "save_items": ["SPLF"],
+            "save_item_outputs": {},
+            "lock_files": False,
+        },
+        file_path=str(tmp_path / "result.xlsx"),
+        spool_dir=str(spool_dir),
+        **_selected_export_args(
+            {"frequency_list": [100.0], "spl_db_raw": [10.0]},
+        ),
+    )
+
+    assert result.ok is False
+    assert "未选择需要保存的分析项" in result.message
+    assert not spool_dir.exists()
+
+
+@pytest.mark.parametrize(
+    ("outputs", "broken_mode", "expected_file"),
+    [
+        (["test_curve"], "deviation", "SPLF_测试曲线.csv"),
+        (["deviation"], "envelope", "SPLF_偏差曲线.csv"),
+    ],
+)
+def test_csv_spool_selected_output_ignores_malformed_unselected_mode(
+    tmp_path,
+    outputs,
+    broken_mode,
+    expected_file,
+):
+    spool_dir = tmp_path / "spool"
+    series = {
+        "deviation": {"available": True, "x": [100.0], "y": [-1.0]},
+        "envelope": {"available": True, "x": [100.0], "y": [31.0]},
+    }
+    series[broken_mode] = {"available": True, "x": "broken", "y": []}
+    payload_result = {
+        GOLDEN_SAMPLE_CURVE_EXPORTS_KEY: {
+            "schema_version": 1,
+            "selected_modes": ["deviation", "envelope"],
+            "series": series,
+        }
+    }
+
+    result = export_analysis_to_csv_spool(
+        {
+            "enabled": True,
+            "save_item_outputs": {"SPLF": outputs},
+            "lock_files": False,
+        },
+        file_path=str(tmp_path / "result.xlsx"),
+        spool_dir=str(spool_dir),
+        **_selected_export_args(payload_result),
+    )
+
+    assert result.ok is True
+    assert {path.name for path in spool_dir.iterdir()} == {expected_file}
+
+
+@pytest.mark.parametrize(
+    ("output", "mode"),
+    [("test_curve", "envelope"), ("deviation", "deviation")],
+)
+def test_csv_spool_selected_output_rejects_malformed_selected_mode(
+    tmp_path,
+    output,
+    mode,
+):
+    spool_dir = tmp_path / "spool"
+    payload_result = {
+        GOLDEN_SAMPLE_CURVE_EXPORTS_KEY: {
+            "schema_version": 1,
+            "selected_modes": [mode],
+            "series": {mode: {"available": True, "x": [100.0], "y": []}},
+        }
+    }
+
+    result = export_analysis_to_csv_spool(
+        {
+            "enabled": True,
+            "save_item_outputs": {"SPLF": [output]},
+            "lock_files": False,
+        },
+        file_path=str(tmp_path / "result.xlsx"),
+        spool_dir=str(spool_dir),
+        **_selected_export_args(payload_result),
+    )
+
+    assert result.ok is False
+    assert mode in result.message
+    assert not spool_dir.exists()
+
+
+def test_csv_spool_selected_test_curve_uses_raw_fallback_without_declared_envelope(tmp_path):
+    spool_dir = tmp_path / "spool"
+    payload_result = _golden_item_result(
+        ("deviation",),
+        {"deviation": ([100.0], [-1.0])},
+        frequency_list=[100.0],
+        spl_db_raw=[10.0],
+    )
+
+    result = export_analysis_to_csv_spool(
+        {
+            "enabled": True,
+            "save_item_outputs": {"SPLF": ["test_curve"]},
+            "lock_files": False,
+        },
+        file_path=str(tmp_path / "result.xlsx"),
+        spool_dir=str(spool_dir),
+        **_selected_export_args(payload_result),
+    )
+
+    assert result.ok is True
+    assert _read_csv_rows(spool_dir / "SPLF_测试曲线.csv") == [
+        ["SN", "time", "100.0"],
+        ["SN001", "2026-07-30 14:30:45", "10.0"],
+    ]
+
+
+def test_csv_spool_selection_filters_stale_mapping_key(tmp_path):
+    spool_dir = tmp_path / "spool"
+
+    result = export_analysis_to_csv_spool(
+        {
+            "enabled": True,
+            "save_item_outputs": {"STALE": ["test_curve"]},
+            "lock_files": False,
+        },
+        sn="SN001",
+        date_text="2026-07-30 14:30:45",
+        analysis_items_data={
+            "STALE": {
+                "type": "SPLF",
+                "result": {"frequency_list": [100.0], "spl_db_raw": [10.0]},
+            }
+        },
+        analysis_config={"CURRENT": {}},
+        analysis_result_dict={},
+        file_path=str(tmp_path / "result.xlsx"),
+        spool_dir=str(spool_dir),
+    )
+
+    assert result.ok is False
+    assert "未选择需要保存的分析项" in result.message
+    assert not spool_dir.exists()
+
+
+def test_csv_spool_historical_rebuild_keeps_existing_unselected_output(tmp_path):
+    spool_dir = tmp_path / "spool"
+    file_path = tmp_path / "result.xlsx"
+    payload_result = _golden_item_result(
+        ("envelope",),
+        {"envelope": ([100.0], [31.0])},
+    )
+    exported = export_analysis_to_csv_spool(
+        {
+            "enabled": True,
+            "save_item_outputs": {"SPLF": ["test_curve"]},
+            "lock_files": False,
+        },
+        file_path=str(file_path),
+        spool_dir=str(spool_dir),
+        **_selected_export_args(payload_result),
+    )
+
+    rebuilt = build_excel_from_csv_spool(
+        {
+            "enabled": True,
+            "save_item_outputs": {"SPLF": ["margin"]},
+            "lock_files": False,
+        },
+        file_path=str(file_path),
+        spool_dir=str(spool_dir),
+    )
+
+    assert exported.ok is True
+    assert rebuilt.ok is True
+    assert load_workbook(file_path).sheetnames == ["SPLF_测试曲线"]
+
+
+def test_csv_spool_selection_changes_only_later_appends_without_retroactive_deletion(tmp_path):
+    spool_dir = tmp_path / "spool"
+    payload_result = _golden_item_result(
+        ("deviation", "envelope"),
+        {
+            "deviation": ([100.0], [-1.0]),
+            "envelope": ([100.0], [31.0]),
+        },
+    )
+    first = export_analysis_to_csv_spool(
+        {
+            "enabled": True,
+            "save_item_outputs": {"SPLF": ["test_curve"]},
+            "lock_files": False,
+        },
+        file_path=str(tmp_path / "result.xlsx"),
+        spool_dir=str(spool_dir),
+        **_selected_export_args(payload_result),
+    )
+    second_args = _selected_export_args(
+        payload_result,
+        analysis_result_dict={"SPLF": (True, 0.5)},
+    )
+    second_args["sn"] = "SN002"
+    second = export_analysis_to_csv_spool(
+        {
+            "enabled": True,
+            "save_item_outputs": {"SPLF": ["margin"]},
+            "lock_files": False,
+        },
+        file_path=str(tmp_path / "result.xlsx"),
+        spool_dir=str(spool_dir),
+        **second_args,
+    )
+
+    assert first.ok is True
+    assert second.ok is True
+    assert {path.name for path in spool_dir.iterdir()} == {
+        "SPLF margin.csv",
+        "SPLF_测试曲线.csv",
+    }
+    assert [row[0] for row in _read_csv_rows(spool_dir / "SPLF_测试曲线.csv")] == [
+        "SN",
+        "SN001",
+    ]
+    assert [row[0] for row in _read_csv_rows(spool_dir / "SPLF margin.csv")] == [
+        "SN",
+        "SN002",
+    ]
+
+
 def test_explicitly_unavailable_current_series_is_skipped(tmp_path):
     file_path = tmp_path / "unavailable.xlsx"
     payload_result = _golden_item_result(
@@ -247,6 +966,7 @@ def test_explicitly_unavailable_current_series_is_skipped(tmp_path):
     workbook = load_workbook(file_path)
     assert "SPLF" not in workbook.sheetnames
     assert "SPLF_偏差曲线" not in workbook.sheetnames
+    assert "SPLF_测试曲线" in workbook.sheetnames
 
 
 def test_malformed_current_payload_fails_direct_excel_without_raw_fallback(tmp_path):

--- a/unit_test/base/test_golden_sample_export_payload.py
+++ b/unit_test/base/test_golden_sample_export_payload.py
@@ -5,6 +5,7 @@ from base.golden_sample_export_payload import (
     GoldenCurveSeries,
     build_golden_sample_curve_exports,
     parse_golden_sample_curve_exports,
+    parse_selected_golden_sample_curve_exports,
 )
 from consts.acoustic_analysis.common_consts import GOLDEN_SAMPLE_CURVE_EXPORTS_KEY
 
@@ -251,3 +252,103 @@ def test_parse_mixed_type_extra_series_keys_returns_error_without_raising():
         [],
         "series 包含未选择模式: ['1', \"'envelope'\"]",
     )
+
+
+def test_parse_selected_validates_only_requested_declared_modes():
+    result = _marked(
+        {
+            "schema_version": 1,
+            "selected_modes": ["deviation", "envelope"],
+            "series": {
+                "deviation": {"available": True, "x": "broken", "y": []},
+                "envelope": {
+                    "available": True,
+                    "x": [100.0, 200.0],
+                    "y": [31.0, 33.5],
+                },
+            },
+        }
+    )
+
+    assert parse_selected_golden_sample_curve_exports(result, ("envelope",)) == (
+        False,
+        [
+            GoldenCurveSeries(
+                mode="envelope",
+                available=True,
+                x=[100.0, 200.0],
+                y=[31.0, 33.5],
+            )
+        ],
+        None,
+    )
+    assert "deviation" in parse_golden_sample_curve_exports(result)[2]
+
+
+def test_parse_selected_returns_unavailable_for_requested_undeclared_mode():
+    result = _marked(
+        {
+            "schema_version": 1,
+            "selected_modes": ["deviation"],
+            "series": {"deviation": {"available": False}},
+        }
+    )
+
+    assert parse_selected_golden_sample_curve_exports(result, ("envelope",)) == (
+        False,
+        [GoldenCurveSeries(mode="envelope", available=False)],
+        None,
+    )
+
+
+@pytest.mark.parametrize(
+    ("payload", "diagnostic"),
+    [
+        (None, "对象"),
+        ({"schema_version": 2, "selected_modes": ["deviation"], "series": {}}, "schema_version"),
+        ({"schema_version": 1, "selected_modes": "deviation", "series": {}}, "selected_modes"),
+        ({"schema_version": 1, "selected_modes": ["deviation"], "series": []}, "series"),
+        (
+            {
+                "schema_version": 1,
+                "selected_modes": ["deviation"],
+                "series": {
+                    "deviation": {"available": False},
+                    "envelope": {"available": False},
+                },
+            },
+            "未选择",
+        ),
+    ],
+)
+def test_parse_selected_rejects_malformed_top_level_payload(payload, diagnostic):
+    is_legacy, parsed, error = parse_selected_golden_sample_curve_exports(
+        _marked(payload),
+        ("envelope",),
+    )
+
+    assert is_legacy is False
+    assert parsed == []
+    assert diagnostic in error
+
+
+def test_parse_selected_rejects_malformed_requested_declared_mode():
+    result = _marked(
+        {
+            "schema_version": 1,
+            "selected_modes": ["deviation", "envelope"],
+            "series": {
+                "deviation": {"available": False},
+                "envelope": {"available": True, "x": [100.0], "y": []},
+            },
+        }
+    )
+
+    is_legacy, parsed, error = parse_selected_golden_sample_curve_exports(
+        result,
+        ("envelope",),
+    )
+
+    assert is_legacy is False
+    assert parsed == []
+    assert "envelope" in error

--- a/unit_test/ui/test_analysis_config_dialog_migration.py
+++ b/unit_test/ui/test_analysis_config_dialog_migration.py
@@ -11,7 +11,7 @@ import numpy as np
 import pytest
 from PyQt5.QtCore import QItemSelection, QItemSelectionModel, Qt
 from PyQt5.QtGui import QStandardItemModel
-from PyQt5.QtWidgets import QApplication, QHeaderView, QLabel, QSizePolicy, QTableView, QTableWidgetItem
+from PyQt5.QtWidgets import QApplication, QHeaderView, QLabel, QSizePolicy, QTableView, QTableWidgetItem, QWidget
 
 from consts import error_code
 from consts.acoustic_analysis.curve_style_consts import DEFAULT_CURVE_COLORS
@@ -19,6 +19,7 @@ from consts.acoustic_analysis.specific_consts import spec_consts
 from consts.excel_export_consts import (
     EXCEL_OUTPUT_DEVIATION,
     EXCEL_OUTPUT_MARGIN,
+    EXCEL_OUTPUT_ORDER,
     EXCEL_OUTPUT_TEST_CURVE,
     SAVE_ITEM_OUTPUTS_KEY,
 )
@@ -27,6 +28,8 @@ from consts.harmonic_detection_consts import (
     HARMONIC_DETECTION_METHOD_KEY,
     HARMONIC_DETECTION_METHOD_SYNCHRONOUS,
 )
+from consts.ui_style_const import scale_size_px
+from ui.custom_ui_widget.widgets import TreeWidget
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -3258,6 +3261,11 @@ def _excel_output_config(*, excel_config):
             "lower_offset_db": -3.0,
             "golden_sample_checked": False,
         },
+        "Empty RSC": {
+            "type": "RSC",
+            "enable_threshold_judgment": False,
+            "golden_sample_checked": False,
+        },
         "SPLF": {
             "type": "SPLF",
             "limit_checked": True,
@@ -3270,7 +3278,65 @@ def _excel_output_config(*, excel_config):
     }
 
 
-def test_excel_output_table_structure_and_initial_state(qapp):
+def test_excel_output_tree_structure_filtering_and_initial_state(qapp):
+    from ui.ui_analysis_config.excel_config_dialog import ExcelConfigWindow
+
+    window = ExcelConfigWindow(
+        FakeConfigManager(
+            _excel_output_config(
+                excel_config={
+                    SAVE_ITEM_OUTPUTS_KEY: {
+                        "FR": ["test_curve"],
+                        "RSC": [],
+                        "SPLF": ["test_curve", "deviation"],
+                    }
+                }
+            )
+        ),
+        "Excel",
+    )
+
+    assert isinstance(window.output_tree, TreeWidget)
+    output_tree_font = QWidget.font(window.output_tree)
+    assert output_tree_font.family() == "SimSun"
+    assert output_tree_font.pixelSize() == scale_size_px(20)
+    assert window.output_tree.columnCount() == 1
+    assert window.output_tree.isHeaderHidden()
+    assert [
+        window.output_tree.topLevelItem(index).text(0)
+        for index in range(window.output_tree.topLevelItemCount())
+    ] == ["FR", "RSC", "SPLF"]
+
+    roots = window._output_root_by_name
+    children = window._output_child_by_name
+    assert "Empty RSC" not in roots
+    assert not roots["FR"].isExpanded()
+    assert not roots["RSC"].isExpanded()
+    assert not roots["SPLF"].isExpanded()
+    assert list(children["FR"]) == [EXCEL_OUTPUT_TEST_CURVE]
+    assert list(children["RSC"]) == [EXCEL_OUTPUT_MARGIN]
+    assert list(children["SPLF"]) == list(EXCEL_OUTPUT_ORDER)
+    assert [
+        children["SPLF"][output].text(0) for output in EXCEL_OUTPUT_ORDER
+    ] == ["测试曲线", "Margin", "偏差曲线"]
+    assert EXCEL_OUTPUT_TEST_CURVE not in children["RSC"]
+    assert EXCEL_OUTPUT_MARGIN not in children["FR"]
+    assert EXCEL_OUTPUT_DEVIATION not in children["FR"]
+
+    for root in roots.values():
+        assert bool(root.flags() & Qt.ItemIsUserCheckable)
+        for index in range(root.childCount()):
+            child = root.child(index)
+            assert bool(child.flags() & Qt.ItemIsUserCheckable)
+            assert bool(child.flags() & Qt.ItemIsEnabled)
+
+    assert roots["FR"].checkState(0) == Qt.Checked
+    assert roots["RSC"].checkState(0) == Qt.Unchecked
+    assert roots["SPLF"].checkState(0) == Qt.PartiallyChecked
+    window.close()
+
+
+def test_excel_output_tree_root_and_child_states_stay_synchronized(qapp):
     from ui.ui_analysis_config.excel_config_dialog import ExcelConfigWindow
 
     window = ExcelConfigWindow(
@@ -3279,46 +3345,25 @@ def test_excel_output_table_structure_and_initial_state(qapp):
         ),
         "Excel",
     )
+    root = window._output_root_by_name["SPLF"]
+    children = window._output_child_by_name["SPLF"]
 
-    assert [
-        window.output_table.horizontalHeaderItem(column).text()
-        for column in range(window.output_table.columnCount())
-    ] == ["分析项", "测试曲线", "Margin", "偏差曲线"]
-    assert window.output_table.rowCount() == 3
+    children[EXCEL_OUTPUT_TEST_CURVE].setCheckState(0, Qt.Checked)
+    assert root.checkState(0) == Qt.PartiallyChecked
+    for child in children.values():
+        child.setCheckState(0, Qt.Checked)
+    assert root.checkState(0) == Qt.Checked
+    children[EXCEL_OUTPUT_MARGIN].setCheckState(0, Qt.Unchecked)
+    assert root.checkState(0) == Qt.PartiallyChecked
 
-    row_by_name = {
-        window.output_table.item(row, 0).text(): row
-        for row in range(window.output_table.rowCount())
-    }
-    for row in row_by_name.values():
-        name_item = window.output_table.item(row, 0)
-        assert not bool(name_item.flags() & Qt.ItemIsUserCheckable)
-        assert not bool(name_item.flags() & Qt.ItemIsEditable)
-
-    checkboxes = window._output_checkbox_by_name
-    for name in ("FR", "SPLF"):
-        test_curve = checkboxes[name][EXCEL_OUTPUT_TEST_CURVE]
-        assert test_curve.isEnabled()
-        assert not test_curve.isChecked()
-
-    rsc_test_curve = checkboxes["RSC"][EXCEL_OUTPUT_TEST_CURVE]
-    assert not rsc_test_curve.isEnabled()
-    assert not rsc_test_curve.isChecked()
-
-    assert not checkboxes["FR"][EXCEL_OUTPUT_MARGIN].isEnabled()
-    assert not checkboxes["FR"][EXCEL_OUTPUT_MARGIN].isChecked()
-    assert not checkboxes["FR"][EXCEL_OUTPUT_DEVIATION].isEnabled()
-    assert not checkboxes["FR"][EXCEL_OUTPUT_DEVIATION].isChecked()
-
-    assert checkboxes["RSC"][EXCEL_OUTPUT_MARGIN].isEnabled()
-    assert not checkboxes["RSC"][EXCEL_OUTPUT_MARGIN].isChecked()
-    assert not checkboxes["RSC"][EXCEL_OUTPUT_DEVIATION].isEnabled()
-    assert not checkboxes["RSC"][EXCEL_OUTPUT_DEVIATION].isChecked()
-
-    assert checkboxes["SPLF"][EXCEL_OUTPUT_MARGIN].isEnabled()
-    assert not checkboxes["SPLF"][EXCEL_OUTPUT_MARGIN].isChecked()
-    assert checkboxes["SPLF"][EXCEL_OUTPUT_DEVIATION].isEnabled()
-    assert not checkboxes["SPLF"][EXCEL_OUTPUT_DEVIATION].isChecked()
+    root.setCheckState(0, Qt.Checked)
+    assert all(child.checkState(0) == Qt.Checked for child in children.values())
+    root.setCheckState(0, Qt.Unchecked)
+    assert all(child.checkState(0) == Qt.Unchecked for child in children.values())
+    root.setCheckState(0, Qt.PartiallyChecked)
+    root.setCheckState(0, Qt.Checked)
+    assert all(child.checkState(0) == Qt.Checked for child in children.values())
+    assert root.checkState(0) == Qt.Checked
     window.close()
 
 
@@ -3341,18 +3386,21 @@ def test_excel_output_bulk_actions_and_persistence(qapp):
         "Excel",
     )
 
-    checkboxes = window._output_checkbox_by_name
-    assert checkboxes["FR"][EXCEL_OUTPUT_TEST_CURVE].isChecked()
-    assert not checkboxes["FR"][EXCEL_OUTPUT_DEVIATION].isChecked()
-    assert not checkboxes["RSC"][EXCEL_OUTPUT_TEST_CURVE].isEnabled()
-    assert not checkboxes["RSC"][EXCEL_OUTPUT_TEST_CURVE].isChecked()
-    assert not checkboxes["SPLF"][EXCEL_OUTPUT_TEST_CURVE].isChecked()
+    children = window._output_child_by_name
+    roots = window._output_root_by_name
+    assert children["FR"][EXCEL_OUTPUT_TEST_CURVE].checkState(0) == Qt.Checked
+    assert EXCEL_OUTPUT_DEVIATION not in children["FR"]
+    assert EXCEL_OUTPUT_TEST_CURVE not in children["RSC"]
+    assert children["SPLF"][EXCEL_OUTPUT_TEST_CURVE].checkState(0) == Qt.Unchecked
 
     window.on_select_all()
-    for outputs in checkboxes.values():
-        for checkbox in outputs.values():
-            assert checkbox.isChecked() is checkbox.isEnabled()
-    assert not checkboxes["RSC"][EXCEL_OUTPUT_TEST_CURVE].isChecked()
+    assert all(
+        child.checkState(0) == Qt.Checked
+        for outputs in children.values()
+        for child in outputs.values()
+    )
+    assert all(root.checkState(0) == Qt.Checked for root in roots.values())
+    assert EXCEL_OUTPUT_TEST_CURVE not in children["RSC"]
 
     config = window.get_default_config()
     assert config[SAVE_ITEM_OUTPUTS_KEY] == {
@@ -3365,10 +3413,11 @@ def test_excel_output_bulk_actions_and_persistence(qapp):
 
     window.on_clear_all()
     assert all(
-        not checkbox.isChecked()
-        for outputs in checkboxes.values()
-        for checkbox in outputs.values()
+        child.checkState(0) == Qt.Unchecked
+        for outputs in children.values()
+        for child in outputs.values()
     )
+    assert all(root.checkState(0) == Qt.Unchecked for root in roots.values())
     assert window.get_default_config()[SAVE_ITEM_OUTPUTS_KEY] == {}
     assert window.get_default_config()["save_items"] == []
     window.close()
@@ -3391,17 +3440,20 @@ def test_excel_output_legacy_migration_and_restore(qapp):
         "save_items": ["SPLF"],
         SAVE_ITEM_OUTPUTS_KEY: {"RSC": ["margin"]},
     }
-    old_table = window.output_table
+    old_tree = window.output_tree
     window.on_restore_default_btn_clicked()
 
-    assert window.output_table is not old_table
+    assert window.output_tree is not old_tree
     assert window.get_default_config()[SAVE_ITEM_OUTPUTS_KEY] == {
         "RSC": ["margin"]
     }
     assert window.get_default_config()["save_items"] == ["RSC"]
-    assert not window._output_checkbox_by_name["SPLF"][
-        EXCEL_OUTPUT_TEST_CURVE
-    ].isChecked()
+    assert (
+        window._output_child_by_name["SPLF"][
+            EXCEL_OUTPUT_TEST_CURVE
+        ].checkState(0)
+        == Qt.Unchecked
+    )
     window.close()
 
 

--- a/unit_test/ui/test_analysis_config_dialog_migration.py
+++ b/unit_test/ui/test_analysis_config_dialog_migration.py
@@ -16,6 +16,12 @@ from PyQt5.QtWidgets import QApplication, QHeaderView, QLabel, QSizePolicy, QTab
 from consts import error_code
 from consts.acoustic_analysis.curve_style_consts import DEFAULT_CURVE_COLORS
 from consts.acoustic_analysis.specific_consts import spec_consts
+from consts.excel_export_consts import (
+    EXCEL_OUTPUT_DEVIATION,
+    EXCEL_OUTPUT_MARGIN,
+    EXCEL_OUTPUT_TEST_CURVE,
+    SAVE_ITEM_OUTPUTS_KEY,
+)
 from consts.harmonic_detection_consts import (
     HARMONIC_DETECTION_METHOD_FOURIER,
     HARMONIC_DETECTION_METHOD_KEY,
@@ -3227,10 +3233,176 @@ def test_excel_dialog_preserves_output_config_after_semantic_migration(qapp):
         "date_format": "%Y%m%d",
         "max_points": 500,
         "save_items": ["FBA", "SPL"],
+        "save_item_outputs": {
+            "FBA": ["test_curve"],
+            "SPL": ["test_curve"],
+        },
         "save_mes_enabled": True,
         "mes_file_base": "D:/dataMES",
         "mes_file_name": "MES_Result",
     }
+
+
+def _excel_output_config(*, excel_config):
+    return {
+        "Excel": excel_config,
+        "FR": {
+            "type": "FR",
+            "limit_checked": False,
+            "golden_sample_checked": False,
+        },
+        "RSC": {
+            "type": "RSC",
+            "enable_threshold_judgment": True,
+            "upper_offset_db": 3.0,
+            "lower_offset_db": -3.0,
+            "golden_sample_checked": False,
+        },
+        "SPLF": {
+            "type": "SPLF",
+            "limit_checked": True,
+            "limit_mode": "csv",
+            "limit_data": ([100.0], [80.0], [None]),
+            "golden_sample_checked": True,
+            "golden_sample_display_modes": ["deviation"],
+        },
+        "Spec": {"type": "Spec"},
+    }
+
+
+def test_excel_output_table_structure_and_initial_state(qapp):
+    from ui.ui_analysis_config.excel_config_dialog import ExcelConfigWindow
+
+    window = ExcelConfigWindow(
+        FakeConfigManager(
+            _excel_output_config(excel_config={SAVE_ITEM_OUTPUTS_KEY: {}})
+        ),
+        "Excel",
+    )
+
+    assert [
+        window.output_table.horizontalHeaderItem(column).text()
+        for column in range(window.output_table.columnCount())
+    ] == ["分析项", "测试曲线", "Margin", "偏差曲线"]
+    assert window.output_table.rowCount() == 3
+
+    row_by_name = {
+        window.output_table.item(row, 0).text(): row
+        for row in range(window.output_table.rowCount())
+    }
+    for row in row_by_name.values():
+        name_item = window.output_table.item(row, 0)
+        assert not bool(name_item.flags() & Qt.ItemIsUserCheckable)
+        assert not bool(name_item.flags() & Qt.ItemIsEditable)
+
+    checkboxes = window._output_checkbox_by_name
+    for name in ("FR", "SPLF"):
+        test_curve = checkboxes[name][EXCEL_OUTPUT_TEST_CURVE]
+        assert test_curve.isEnabled()
+        assert not test_curve.isChecked()
+
+    rsc_test_curve = checkboxes["RSC"][EXCEL_OUTPUT_TEST_CURVE]
+    assert not rsc_test_curve.isEnabled()
+    assert not rsc_test_curve.isChecked()
+
+    assert not checkboxes["FR"][EXCEL_OUTPUT_MARGIN].isEnabled()
+    assert not checkboxes["FR"][EXCEL_OUTPUT_MARGIN].isChecked()
+    assert not checkboxes["FR"][EXCEL_OUTPUT_DEVIATION].isEnabled()
+    assert not checkboxes["FR"][EXCEL_OUTPUT_DEVIATION].isChecked()
+
+    assert checkboxes["RSC"][EXCEL_OUTPUT_MARGIN].isEnabled()
+    assert not checkboxes["RSC"][EXCEL_OUTPUT_MARGIN].isChecked()
+    assert not checkboxes["RSC"][EXCEL_OUTPUT_DEVIATION].isEnabled()
+    assert not checkboxes["RSC"][EXCEL_OUTPUT_DEVIATION].isChecked()
+
+    assert checkboxes["SPLF"][EXCEL_OUTPUT_MARGIN].isEnabled()
+    assert not checkboxes["SPLF"][EXCEL_OUTPUT_MARGIN].isChecked()
+    assert checkboxes["SPLF"][EXCEL_OUTPUT_DEVIATION].isEnabled()
+    assert not checkboxes["SPLF"][EXCEL_OUTPUT_DEVIATION].isChecked()
+    window.close()
+
+
+def test_excel_output_bulk_actions_and_persistence(qapp):
+    from ui.ui_analysis_config.excel_config_dialog import ExcelConfigWindow
+
+    window = ExcelConfigWindow(
+        FakeConfigManager(
+            _excel_output_config(
+                excel_config={
+                    "save_items": ["FR", "stale"],
+                    SAVE_ITEM_OUTPUTS_KEY: {
+                        "FR": ["deviation", "test_curve", "unknown"],
+                        "RSC": ["test_curve"],
+                        "stale": ["margin"],
+                    },
+                }
+            )
+        ),
+        "Excel",
+    )
+
+    checkboxes = window._output_checkbox_by_name
+    assert checkboxes["FR"][EXCEL_OUTPUT_TEST_CURVE].isChecked()
+    assert not checkboxes["FR"][EXCEL_OUTPUT_DEVIATION].isChecked()
+    assert not checkboxes["RSC"][EXCEL_OUTPUT_TEST_CURVE].isEnabled()
+    assert not checkboxes["RSC"][EXCEL_OUTPUT_TEST_CURVE].isChecked()
+    assert not checkboxes["SPLF"][EXCEL_OUTPUT_TEST_CURVE].isChecked()
+
+    window.on_select_all()
+    for outputs in checkboxes.values():
+        for checkbox in outputs.values():
+            assert checkbox.isChecked() is checkbox.isEnabled()
+    assert not checkboxes["RSC"][EXCEL_OUTPUT_TEST_CURVE].isChecked()
+
+    config = window.get_default_config()
+    assert config[SAVE_ITEM_OUTPUTS_KEY] == {
+        "FR": ["test_curve"],
+        "RSC": ["margin"],
+        "SPLF": ["test_curve", "margin", "deviation"],
+    }
+    assert config["save_items"] == ["FR", "RSC", "SPLF"]
+    assert "stale" not in config[SAVE_ITEM_OUTPUTS_KEY]
+
+    window.on_clear_all()
+    assert all(
+        not checkbox.isChecked()
+        for outputs in checkboxes.values()
+        for checkbox in outputs.values()
+    )
+    assert window.get_default_config()[SAVE_ITEM_OUTPUTS_KEY] == {}
+    assert window.get_default_config()["save_items"] == []
+    window.close()
+
+
+def test_excel_output_legacy_migration_and_restore(qapp):
+    from ui.ui_analysis_config.excel_config_dialog import ExcelConfigWindow
+
+    config_manager = FakeConfigManager(
+        _excel_output_config(excel_config={"save_items": ["SPLF", "FR"]})
+    )
+    window = ExcelConfigWindow(config_manager, "Excel")
+
+    assert window.get_default_config()[SAVE_ITEM_OUTPUTS_KEY] == {
+        "FR": ["test_curve"],
+        "SPLF": ["test_curve", "margin", "deviation"],
+    }
+
+    config_manager.config["Excel"] = {
+        "save_items": ["SPLF"],
+        SAVE_ITEM_OUTPUTS_KEY: {"RSC": ["margin"]},
+    }
+    old_table = window.output_table
+    window.on_restore_default_btn_clicked()
+
+    assert window.output_table is not old_table
+    assert window.get_default_config()[SAVE_ITEM_OUTPUTS_KEY] == {
+        "RSC": ["margin"]
+    }
+    assert window.get_default_config()["save_items"] == ["RSC"]
+    assert not window._output_checkbox_by_name["SPLF"][
+        EXCEL_OUTPUT_TEST_CURVE
+    ].isChecked()
+    window.close()
 
 
 def test_pd_dialog_preserves_time_smoothing_keys_after_widget_migration(qapp):

--- a/unit_test/ui/test_custom_widgets.py
+++ b/unit_test/ui/test_custom_widgets.py
@@ -9,7 +9,8 @@ import pytest
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QApplication, QWidget
 
-from ui.custom_ui_widget.widgets import TableWidget
+from consts.ui_style_const import scale_size_px
+from ui.custom_ui_widget.widgets import TableWidget, TreeWidget
 
 
 @pytest.fixture(scope="module")
@@ -40,3 +41,21 @@ def test_table_widget_set_font_size_updates_headers(qapp):
 
     assert QWidget.font(table).pixelSize() == table.font_size
     assert_table_fonts_match(table)
+
+
+def test_tree_widget_applies_project_font_on_construction(qapp):
+    tree = TreeWidget()
+    font = QWidget.font(tree)
+
+    assert font.family() == "SimSun"
+    assert font.pixelSize() == scale_size_px(20)
+
+
+def test_tree_widget_set_font_size_updates_project_font(qapp):
+    tree = TreeWidget()
+    tree.set_font_size(37)
+    font = QWidget.font(tree)
+
+    assert tree.font_size == scale_size_px(37)
+    assert font.family() == "SimSun"
+    assert font.pixelSize() == scale_size_px(37)

--- a/unit_test/ui/test_operation_sequence_excel_selection_sync.py
+++ b/unit_test/ui/test_operation_sequence_excel_selection_sync.py
@@ -1,0 +1,75 @@
+from consts.excel_export_consts import SAVE_ITEM_OUTPUTS_KEY
+from ui.operation_sequence import (
+    _delete_excel_selection_item,
+    _rename_excel_selection_item,
+)
+
+
+def _analysis_list(mapping=...):
+    excel_config = {
+        "type": "Excel",
+        "save_items": ["SPLF 1", "FR 1"],
+    }
+    if mapping is not ...:
+        excel_config[SAVE_ITEM_OUTPUTS_KEY] = mapping
+    return {
+        "Excel": excel_config,
+        "SPLF 1": {"type": "SPLF"},
+        "FR 1": {"type": "FR"},
+    }
+
+
+def test_excel_selection_rename_preserves_output_list_exactly():
+    outputs = ["test_curve", "margin"]
+    analysis_list = _analysis_list(
+        {
+            "SPLF 1": outputs,
+            "FR 1": ["deviation"],
+        }
+    )
+
+    _rename_excel_selection_item(analysis_list, "SPLF 1", "SPLF renamed")
+
+    excel_config = analysis_list["Excel"]
+    assert excel_config["save_items"] == ["SPLF renamed", "FR 1"]
+    assert excel_config[SAVE_ITEM_OUTPUTS_KEY] == {
+        "SPLF renamed": outputs,
+        "FR 1": ["deviation"],
+    }
+    assert excel_config[SAVE_ITEM_OUTPUTS_KEY]["SPLF renamed"] is outputs
+
+
+def test_excel_selection_delete_removes_both_compatibility_structures():
+    analysis_list = _analysis_list(
+        {
+            "SPLF 1": ["test_curve", "margin"],
+            "FR 1": ["deviation"],
+        }
+    )
+
+    _delete_excel_selection_item(analysis_list, "FR 1")
+
+    excel_config = analysis_list["Excel"]
+    assert excel_config["save_items"] == ["SPLF 1"]
+    assert excel_config[SAVE_ITEM_OUTPUTS_KEY] == {
+        "SPLF 1": ["test_curve", "margin"]
+    }
+
+
+def test_excel_selection_sync_tolerates_absent_or_malformed_optional_mapping():
+    absent_mapping = _analysis_list()
+    malformed_mapping = _analysis_list(["not", "a", "mapping"])
+
+    _rename_excel_selection_item(absent_mapping, "SPLF 1", "renamed")
+    _delete_excel_selection_item(absent_mapping, "FR 1")
+    _rename_excel_selection_item(malformed_mapping, "SPLF 1", "renamed")
+    _delete_excel_selection_item(malformed_mapping, "FR 1")
+
+    assert absent_mapping["Excel"]["save_items"] == ["renamed"]
+    assert malformed_mapping["Excel"]["save_items"] == ["renamed"]
+    assert SAVE_ITEM_OUTPUTS_KEY not in absent_mapping["Excel"]
+    assert malformed_mapping["Excel"][SAVE_ITEM_OUTPUTS_KEY] == [
+        "not",
+        "a",
+        "mapping",
+    ]


### PR DESCRIPTION
## Summary
- Add per-analysis-item Excel export output selection for test curves, Margin results, and deviation curves.
- Migrate legacy `save_items` configuration and synchronize selections across rename/delete operations.
- Preserve direct, cached-session, and CSV spool export behavior with focused regression coverage.

## Test Plan
- `git diff --check`
- `$env:QT_QPA_PLATFORM='offscreen'; python -m pytest unit_test/base/test_excel_export_selection.py unit_test/base/test_excel_result_exporter.py unit_test/base/test_golden_sample_export_payload.py unit_test/ui/test_operation_sequence_excel_selection_sync.py unit_test/ui/test_analysis_config_dialog_migration.py -q --basetemp=C:\Users\Administrator\AppData\Local\Temp\codex-speaker-anomaly-20260805` — 267 passed, 18 warnings

Closes #804